### PR TITLE
fea: integrate react-router ssr

### DIFF
--- a/packages/demo/e2e/basic.test.ts
+++ b/packages/demo/e2e/basic.test.ts
@@ -2,6 +2,7 @@ import { test } from "@playwright/test";
 
 test("basic", async ({ page }) => {
   await page.goto("/");
+  await page.getByTestId("hydrated").waitFor({ state: "attached" });
 
   await page.getByRole("button", { name: "Fetch API" }).click();
   await page.getByText('{ "env": ').click();

--- a/packages/demo/index.html
+++ b/packages/demo/index.html
@@ -22,7 +22,7 @@
     </style>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root"><!--@INJECT_SSR@--></div>
     <script src="/src/client/index.tsx" type="module"></script>
   </body>
 </html>

--- a/packages/demo/misc/vercel/.vc-config.json
+++ b/packages/demo/misc/vercel/.vc-config.json
@@ -1,4 +1,7 @@
 {
-  "runtime": "edge",
-  "entrypoint": "index.js"
+  "runtime": "nodejs18.x",
+  "handler": "index.js",
+  "launcherType": "Nodejs",
+  "supportsResponseStreaming": true,
+  "regions": ["hnd1"]
 }

--- a/packages/demo/misc/vercel/build.sh
+++ b/packages/demo/misc/vercel/build.sh
@@ -11,7 +11,7 @@ set -eu -o pipefail
 #     functions/
 #       index.func/
 #         .vc-config.json
-#         index.js         = dist/server/index.js (bundled)
+#         index.js         = dist/server/index.mjs (bundled)
 
 # clean
 rm -rf .vercel/output

--- a/packages/demo/misc/vercel/build.sh
+++ b/packages/demo/misc/vercel/build.sh
@@ -24,5 +24,5 @@ cp misc/vercel/config.json .vercel/output/config.json
 cp -r dist/client .vercel/output/static
 
 # serverless
-npx esbuild dist/server/index.mjs --outfile=.vercel/output/functions/index.func/index.js --bundle --platform=neutral
+npx esbuild dist/server/index.mjs --outfile=.vercel/output/functions/index.func/index.js --bundle --platform=node
 cp misc/vercel/.vc-config.json .vercel/output/functions/index.func/.vc-config.json

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -3,7 +3,7 @@
     "dev": "run-p dev:*",
     "dev:vite": "vite",
     "dev:tsc": "tsc -b --watch --preserveWatchOutput",
-    "build": "SERVER_ENTRY=./src/server/adapter-vercel-edge.ts run-s build:*",
+    "build": "run-s build:*",
     "build:vite": "vite build && vite build --ssr",
     "build:vercel": "bash misc/vercel/build.sh",
     "build-preview": "SERVER_ENTRY=./src/server/adapter-preview.ts run-s build:vite",
@@ -14,7 +14,6 @@
   },
   "devDependencies": {
     "@hattip/adapter-node": "^0.0.34",
-    "@hattip/adapter-vercel-edge": "^0.0.34",
     "@hattip/compose": "^0.0.34",
     "@hiogawa/isort-ts": "1.0.2-pre.1",
     "@hiogawa/unocss-preset-antd": "2.2.1-pre.3",

--- a/packages/demo/src/client/index.tsx
+++ b/packages/demo/src/client/index.tsx
@@ -2,23 +2,21 @@ import "virtual:uno.css";
 import { tinyassert } from "@hiogawa/utils";
 import { globPageRoutes } from "@hiogawa/vite-glob-routes/dist/react-router";
 import React from "react";
-import { createRoot } from "react-dom/client";
+import { hydrateRoot } from "react-dom/client";
 import { RouterProvider, createBrowserRouter } from "react-router-dom";
 
 function main() {
   const el = document.getElementById("root");
   tinyassert(el);
-  const reactRoot = createRoot(el);
-  reactRoot.render(<Root />);
-}
 
-function Root() {
-  const [router] = React.useState(() => createBrowserRouter(globPageRoutes()));
-  return (
+  const router = createBrowserRouter(globPageRoutes());
+  const root = (
     <React.StrictMode>
       <RouterProvider router={router} />
     </React.StrictMode>
   );
+  hydrateRoot(el, root);
+  el.dataset["testid"] = "hydrated"; // for e2e
 }
 
 main();

--- a/packages/demo/src/server/adapter-connect.ts
+++ b/packages/demo/src/server/adapter-connect.ts
@@ -1,4 +1,4 @@
 import { createMiddleware } from "@hattip/adapter-node";
 import { createHattipApp } from ".";
 
-export default createMiddleware(createHattipApp());
+export default createMiddleware(createHattipApp(), { trustProxy: true });

--- a/packages/demo/src/server/adapter-vercel-edge.ts
+++ b/packages/demo/src/server/adapter-vercel-edge.ts
@@ -1,4 +1,0 @@
-import adapterVercelEdge from "@hattip/adapter-vercel-edge";
-import { createHattipApp } from ".";
-
-export default adapterVercelEdge(createHattipApp());

--- a/packages/demo/src/server/render-routes.tsx
+++ b/packages/demo/src/server/render-routes.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { renderToString } from "react-dom/server";
+import type { RouteObject } from "react-router-dom";
+import {
+  StaticRouterProvider,
+  createStaticHandler,
+  createStaticRouter,
+} from "react-router-dom/server";
+
+// cf. https://reactrouter.com/en/main/routers/static-router-provider
+
+export async function renderRoutes(
+  request: Request,
+  routes: RouteObject[]
+): Promise<string | Response> {
+  const handler = createStaticHandler(routes);
+
+  // since we don't have any loader side-effect, this context construction should be simple.
+  // still this probably handles "not found" error.
+  // https://github.com/remix-run/react-router/blob/bc2552840147206716544e5cdcdb54f649f9193f/packages/router/router.ts#L2608
+  const context = await handler.query(request);
+  if (context instanceof Response) {
+    return context;
+  }
+
+  const router = createStaticRouter(handler.dataRoutes, context);
+
+  const root = (
+    <React.StrictMode>
+      {/* there should be no data for server to pass https://github.com/remix-run/react-router/blob/bc2552840147206716544e5cdcdb54f649f9193f/packages/react-router-dom/server.tsx#L114-L126 */}
+      <StaticRouterProvider router={router} context={context} hydrate={false} />
+    </React.StrictMode>
+  );
+
+  // TODO: streaming
+  const result = renderToString(root);
+  return result;
+}

--- a/packages/demo/vite.config.ts
+++ b/packages/demo/vite.config.ts
@@ -8,8 +8,8 @@ import { defineConfig } from "vite";
 
 export default defineConfig((ctx) => ({
   plugins: [
-    unocss(),
     react(),
+    unocss(),
     globRoutesPlugin({ root: "/src/routes" }),
     indexHtmlMiddlewarePlugin(),
     vaviteConnect({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,9 +50,6 @@ importers:
       '@hattip/adapter-node':
         specifier: ^0.0.34
         version: 0.0.34
-      '@hattip/adapter-vercel-edge':
-        specifier: ^0.0.34
-        version: 0.0.34
       '@hattip/compose':
         specifier: ^0.0.34
         version: 0.0.34
@@ -781,12 +778,6 @@ packages:
     dependencies:
       '@hattip/core': 0.0.34
       '@hattip/polyfills': 0.0.34
-    dev: true
-
-  /@hattip/adapter-vercel-edge@0.0.34:
-    resolution: {integrity: sha512-c50G3Jq4TCmu5MjcQU/hoOCZGOMSDPE4+pm+/2Mn7lbqHEy2hxP852fpGGHOdBYSNh3ZfGuR9c4K99GxX8FwEA==}
-    dependencies:
-      '@hattip/core': 0.0.34
     dev: true
 
   /@hattip/compose@0.0.34:


### PR DESCRIPTION
- a part of https://github.com/hi-ogawa/vite-plugins/issues/10

## todo

- [x] render react-router ssr
- [x] inject ssr render to html
- [x] client hydration
- [x] fix infinite `[vite] hot updated: /__uno.css` ?
  - https://github.com/unocss/unocss/issues/1961
  - very oddly this happens on initial render and it stops, for example, when triggering legitimate HMR by modifying some component.
  - https://github.com/hi-ogawa/vite-plugins/pull/12
  - fixed in https://github.com/hi-ogawa/vite-plugins/pull/11/commits/02a20c59ea9047f25219de084b3750a45f66dc7c
- [x] react-router(-dom) doesn't build for edge runtime (esbuild neutral)?
  - fine to give up edge and just use nodejs serverless. maybe move code to `demo-ssr`?
  - remix runs on edge so there has to be a way to do it though?
  - well bundle size already got to 1.3mb so cannot push it to cloudflare anyway...
  - fixed in https://github.com/hi-ogawa/vite-plugins/pull/11/commits/3897fbeb8b0a3a5c60b823d79829db308075f64e
- [ ] generalize `indexHtmlMiddleware` plugin for non middleware use case