### PR TITLE
feat: integrate react-router loader on SSR

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ miscellaneous plugins to experiment with Vite's SSR build ideas.
 
 ### `@hiogawa/vite-glob-routes`
 
-- employ [`rakkasjs`](https://github.com/rakkasjs/rakkasjs)-like file-system route convension
-- generate [`react-router`](https://github.com/remix-run/react-router) nested routes based on `**/*.page.tsx` and `**/layout.tsx`
+- file-system route conventioin inspired by [`rakkasjs`](https://github.com/rakkasjs/rakkasjs) and [`vite-plugin-ssr`](https://github.com/brillout/vite-plugin-ssr)
+- generate [`react-router`](https://github.com/remix-run/react-router) nested routes based on `**/*.page.tsx`, `**/*.page.server.tsx` and `**/layout.tsx`
 - generate [`hattip`](https://github.com/hattipjs/hattip) middleware based on `**/*.api.ts`
 
-### `@hiogawa/vite-index-html-middleware`
+### `@hiogawa/vite-expose-index-html`
 
-- generate `hattip` middleware to render `index.html` with the ability to inject code during runtime (e.g. server handing-off public configuration to client)
+- expose `index.html` for both development and production so that it can be used as a basic template of SSR
 
 ## development
 

--- a/packages/demo/e2e/basic.test.ts
+++ b/packages/demo/e2e/basic.test.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 test("basic", async ({ page }) => {
   await page.goto("/");
@@ -27,4 +27,38 @@ test("basic", async ({ page }) => {
   await page.goto("/some-dynamic-id");
   await page.waitForURL("/some-dynamic-id");
   await page.getByText('params = { "dynamic": "some-dynamic-id" }').click();
+});
+
+test.describe("server-data", () => {
+  test("server-side", async ({ page }) => {
+    await page.goto("/server-data");
+    await page.getByRole("img").click();
+    await page
+      .getByText(
+        '{ "types": [ { "slot": 1, "type": { "name": "electric", "url": "https://pokeapi.'
+      )
+      .click();
+  });
+
+  test("client-side-navigation", async ({ page }) => {
+    await page.goto("/");
+    await page.getByTestId("hydrated").waitFor({ state: "attached" });
+
+    await page.getByRole("link", { name: "/server-data", exact: true }).click();
+    await page.waitForURL("/server-data");
+    await page.getByRole("img").click();
+    await page
+      .getByText(
+        '{ "types": [ { "slot": 1, "type": { "name": "electric", "url": "https://pokeapi.'
+      )
+      .click();
+  });
+
+  test("ssr", async ({ request }) => {
+    const res = await request.get("/server-data");
+    const resText = await res.text();
+    expect(resText).toContain(
+      `src="https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/25.png"`
+    );
+  });
 });

--- a/packages/demo/src/routes/server-data-utils.ts
+++ b/packages/demo/src/routes/server-data-utils.ts
@@ -1,14 +1,21 @@
 import { tinyassert } from "@hiogawa/utils";
 import type { QueryObserverOptions } from "@tanstack/react-query";
+import { z } from "zod";
 
-interface PokemonOutput {
-  sprites?: { front_default?: string };
-}
+const Z_POKOMON_OUTPUT = z.object({
+  types: z.any().array(),
+  stats: z.any().array(),
+  sprites: z.object({
+    front_default: z.string(),
+  }),
+});
+
+type PokemonOutput = z.infer<typeof Z_POKOMON_OUTPUT>;
 
 async function fetchPokomonApi(): Promise<PokemonOutput> {
   const res = await fetch(`https://pokeapi.co/api/v2/pokemon/pikachu`);
   tinyassert(res.ok);
-  return res.json();
+  return Z_POKOMON_OUTPUT.parse(await res.json());
 }
 
 export function pokomenQueryOption() {

--- a/packages/demo/src/routes/server-data.page.server.tsx
+++ b/packages/demo/src/routes/server-data.page.server.tsx
@@ -2,7 +2,8 @@ import type { LoaderFunction } from "react-router-dom";
 import { pokomenQueryOptionSSR } from "./server-data-utils";
 
 // for the ease (i.e. no need) of tree-shake, employ explicit "page.server.ts" convention.
-// for the ease of integration, loader is used only during initial SSR.
+// for the ease of integration, loader is used only during initial SSR and "loader data" is not passed to client.
+// currently it only allowed to mutate `queryClient` to implicitly pass data during SSR and hydration.
 export const loader: LoaderFunction = async ({ context }) => {
   const { queryKey, queryFn } = pokomenQueryOptionSSR();
   await context.locals.queryClient.prefetchQuery(queryKey, queryFn);

--- a/packages/demo/src/routes/server-data.page.server.tsx
+++ b/packages/demo/src/routes/server-data.page.server.tsx
@@ -1,10 +1,10 @@
-import type { RequestContext } from "@hattip/compose";
+import type { LoaderFunction } from "react-router-dom";
 import { pokomenQueryOptionSSR } from "./server-data-utils";
 
-// TODO: server callback convention
-export async function onBeforeServerRender(ctx: RequestContext) {
-  if (ctx.url.pathname !== "/server-data") return;
-
+// for the ease (i.e. no need) of tree-shake, employ explicit "page.server.ts" convention.
+// for the ease of integration, loader is used only during initial SSR.
+export const loader: LoaderFunction = async ({ context }) => {
   const { queryKey, queryFn } = pokomenQueryOptionSSR();
-  await ctx.locals.queryClient.prefetchQuery(queryKey, queryFn);
-}
+  await context.locals.queryClient.prefetchQuery(queryKey, queryFn);
+  return null;
+};

--- a/packages/demo/src/routes/server-data.page.tsx
+++ b/packages/demo/src/routes/server-data.page.tsx
@@ -16,7 +16,7 @@ export function Page() {
                 src={query.data.sprites?.front_default}
               />
               <pre className="overflow-auto p-1 border text-sm">
-                {JSON.stringify(query.data.sprites, null, 2)}
+                {JSON.stringify(query.data, null, 2)}
               </pre>
             </>
           )}

--- a/packages/demo/src/server/index.ts
+++ b/packages/demo/src/server/index.ts
@@ -5,7 +5,6 @@ import { globApiRoutes } from "@hiogawa/vite-glob-routes/dist/hattip";
 import { globPageRoutes } from "@hiogawa/vite-glob-routes/dist/react-router";
 import type { Context, MiddlewareHandler } from "hono";
 import { logger } from "hono/logger";
-import { onBeforeServerRender } from "../routes/server-data.page.server";
 import {
   __QUERY_CLIENT_STATE,
   createQueryClient,
@@ -25,15 +24,12 @@ function globPageRoutesHandler(): RequestHandler {
   const routes = globPageRoutes();
 
   return async (ctx) => {
-    // initialize queryClient
+    // initialize queryClient in hattip/react-router context
     const queryClient = createQueryClient();
     ctx.locals.queryClient = queryClient;
 
-    // call per-page SSR hook for query prefetch etc... (TODO: server callback convention)
-    await onBeforeServerRender(ctx);
-
     // SSR
-    const res = await renderRoutes(ctx.request, routes, queryClient);
+    const res = await renderRoutes(ctx, routes, queryClient);
     if (res instanceof Response) {
       return res;
     }

--- a/packages/demo/src/server/render-routes.tsx
+++ b/packages/demo/src/server/render-routes.tsx
@@ -1,3 +1,4 @@
+import type { RequestContext } from "@hattip/compose";
 import type { QueryClient } from "@tanstack/react-query";
 import React from "react";
 import { renderToString } from "react-dom/server";
@@ -12,16 +13,15 @@ import { ReactQueryWrapper } from "../utils/react-query-utils";
 // cf. https://reactrouter.com/en/main/routers/static-router-provider
 
 export async function renderRoutes(
-  request: Request,
+  hattipContext: RequestContext,
   routes: RouteObject[],
   queryClient: QueryClient
 ): Promise<string | Response> {
   const handler = createStaticHandler(routes);
 
-  // since we don't have any loader side-effect, this context construction should be simple.
-  // still this probably handles "not found" error.
-  // https://github.com/remix-run/react-router/blob/bc2552840147206716544e5cdcdb54f649f9193f/packages/router/router.ts#L2608
-  const context = await handler.query(request);
+  const context = await handler.query(hattipContext.request, {
+    requestContext: hattipContext,
+  });
   if (context instanceof Response) {
     return context;
   }

--- a/packages/demo/src/server/render-routes.tsx
+++ b/packages/demo/src/server/render-routes.tsx
@@ -34,7 +34,9 @@ export async function renderRoutes(
         <StaticRouterProvider
           router={router}
           context={context}
-          // there should be no data for server to pass https://github.com/remix-run/react-router/blob/bc2552840147206716544e5cdcdb54f649f9193f/packages/react-router-dom/server.tsx#L114-L126
+          // currently "loader" is used only for `queryClient.prefetchQuery`, which allows passing data during SSR and hydration.
+          // thus, from react-router context point of view, there should be no data to pass.
+          // https://github.com/remix-run/react-router/blob/bc2552840147206716544e5cdcdb54f649f9193f/packages/react-router-dom/server.tsx#L114-L126
           hydrate={false}
         />
       </ReactQueryWrapper>

--- a/packages/demo/src/server/request-context.d.ts
+++ b/packages/demo/src/server/request-context.d.ts
@@ -1,8 +1,16 @@
 import "@hattip/compose";
+import "react-router-dom";
 
-// extend with custom context
+// provide access to QueryClient during request lifecycle
+
 declare module "@hattip/compose" {
   interface Locals {
     queryClient: import("@tanstack/react-query").QueryClient;
+  }
+}
+
+declare module "react-router-dom" {
+  interface LoaderFunctionArgs {
+    context: import("@hattip/compose").RequestContext;
   }
 }

--- a/packages/vite-glob-routes/src/index.ts
+++ b/packages/vite-glob-routes/src/index.ts
@@ -53,7 +53,9 @@ export default function globRoutesPlugin(options: { root: string }): Plugin {
             const root = "${root}";
             const globPage = import.meta.glob("${root}/**/*.page.(js|jsx|ts|tsx)", { eager: true });
             const globLayout = import.meta.glob("${root}/**/layout.(js|jsx|ts|tsx)", { eager: true });
-            export default { root, globPage, globLayout };
+            // TODO: same for layout?
+            const globPageServer = import.meta.env.SSR ? import.meta.glob("${root}/**/*.page.server.(js|jsx|ts|tsx)", { eager: true }) : {};
+            export default { root, globPage, globPageServer, globLayout };
           `;
       }
 

--- a/packages/vite-glob-routes/src/react-router-utils.test.ts
+++ b/packages/vite-glob-routes/src/react-router-utils.test.ts
@@ -5,9 +5,9 @@ describe(createGlobPageRoutes, () => {
   it("basic", () => {
     const Page = () => null;
     const Module = { Page };
-    const tree = createGlobPageRoutes(
-      "(root)",
-      {
+    const tree = createGlobPageRoutes({
+      root: "(root)",
+      globPage: {
         "(root)/index.page.js": Module,
         "(root)/other.page.jsx": Module,
         "(root)/[dynamic].page.ts": Module,
@@ -16,11 +16,14 @@ describe(createGlobPageRoutes, () => {
         "(root)/abc/[dynsub].page.tsx": Module,
         "(root)/abc/[dynsub]/new.page.tsx": Module,
       },
-      {
+      globPageServer: {
+        "(root)/other.page.server.jsx": { loader: () => null },
+      },
+      globLayout: {
         "(root)/layout.tsx": Module,
         "(root)/subdir/layout.jsx": Module,
-      }
-    );
+      },
+    });
     expect(tree).toMatchInlineSnapshot(`
       [
         {
@@ -32,12 +35,11 @@ describe(createGlobPageRoutes, () => {
             },
             {
               "Component": [Function],
-              "children": [],
+              "loader": [Function],
               "path": "other",
             },
             {
               "Component": [Function],
-              "children": [],
               "path": ":dynamic",
             },
             {
@@ -49,7 +51,6 @@ describe(createGlobPageRoutes, () => {
                 },
                 {
                   "Component": [Function],
-                  "children": [],
                   "path": "other",
                 },
               ],
@@ -60,7 +61,6 @@ describe(createGlobPageRoutes, () => {
               "children": [
                 {
                   "Component": [Function],
-                  "children": [],
                   "path": ":dynsub",
                 },
                 {
@@ -68,7 +68,6 @@ describe(createGlobPageRoutes, () => {
                   "children": [
                     {
                       "Component": [Function],
-                      "children": [],
                       "path": "new",
                     },
                   ],

--- a/packages/vite-glob-routes/src/react-router.ts
+++ b/packages/vite-glob-routes/src/react-router.ts
@@ -2,6 +2,5 @@ import internal from "virtual:@hiogawa/vite-glob-routes/internal/page-routes";
 import { createGlobPageRoutes } from "./react-router-utils";
 
 export function globPageRoutes() {
-  const { root, globPage, globLayout } = internal;
-  return createGlobPageRoutes(root, globPage, globLayout);
+  return createGlobPageRoutes(internal);
 }

--- a/packages/vite-glob-routes/src/virtual.d.ts
+++ b/packages/vite-glob-routes/src/virtual.d.ts
@@ -2,6 +2,7 @@ declare module "virtual:@hiogawa/vite-glob-routes/internal/page-routes" {
   const value: {
     root: string;
     globPage: Record<string, any>;
+    globPageServer: Record<string, any>;
     globLayout: Record<string, any>;
   };
   export default value;


### PR DESCRIPTION
- merge base https://github.com/hi-ogawa/vite-plugins/pull/17

## ideas

- employ vite-plugin-ssr like `*.page.server.tsx` for server code
- setup react-router `loader` only during SSR so that it could be used to mutate queryClient itself to provide data implicitly