### PR TITLE
feat: support server redirection

### DIFF
--- a/packages/demo/src/routes/client-redirect/[id].page.tsx
+++ b/packages/demo/src/routes/client-redirect/[id].page.tsx
@@ -1,0 +1,50 @@
+import { tinyassert } from "@hiogawa/utils";
+import { type QueryObserverOptions, useQuery } from "@tanstack/react-query";
+import React from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { sleep } from "../../utils/misc";
+
+export function Page() {
+  const params = useParams();
+
+  // check server and redirect on error
+  const checkQuery = useQuery(dummyClientCheckQueryOptions(params["id"]!));
+
+  const navigate = useNavigate();
+
+  React.useEffect(() => {
+    if (checkQuery.error) {
+      navigate("/client-redirect?error=client");
+    }
+  }, [checkQuery.error]);
+
+  if (checkQuery.isLoading) {
+    return <div className="mt-10 mx-auto antd-spin w-10 h-10"></div>;
+  }
+
+  return <PageInner data={checkQuery.data} />;
+}
+
+function dummyClientCheckQueryOptions(id: string) {
+  return {
+    queryKey: ["client-redirect-check", id],
+    queryFn: async () => {
+      await sleep(1000);
+      tinyassert(id === "good");
+      return { message: "success!" };
+    },
+  } satisfies QueryObserverOptions;
+}
+
+function PageInner(props: { data: unknown }) {
+  return (
+    <div className="flex flex-col items-center">
+      <div className="w-full p-6">
+        <div className="flex flex-col gap-4">
+          <h1>Client redirect</h1>
+          <pre>{JSON.stringify(props.data)}</pre>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/demo/src/routes/client-redirect/index.page.tsx
+++ b/packages/demo/src/routes/client-redirect/index.page.tsx
@@ -1,0 +1,27 @@
+import { Link } from "react-router-dom";
+
+export function Page() {
+  return (
+    <div className="flex flex-col items-center">
+      <div className="w-full p-6">
+        <div className="flex flex-col gap-4">
+          <h1>Client redirect</h1>
+          <div className="flex gap-2">
+            <Link
+              className="antd-btn antd-btn-default px-1"
+              to="/client-redirect/good"
+            >
+              good link
+            </Link>
+            <Link
+              className="antd-btn antd-btn-default px-1"
+              to="/client-redirect/forbidden"
+            >
+              forbidden link
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/demo/src/routes/layout.tsx
+++ b/packages/demo/src/routes/layout.tsx
@@ -17,11 +17,11 @@ function Header() {
   return (
     <header className="top-0 sticky antd-body flex items-center p-2 px-4 gap-3 shadow-md shadow-black/[0.05] dark:shadow-black/[0.7] z-1">
       <div>Example</div>
-      <ul className="flex gap-2 text-sm font-mono">
+      <ul className="flex gap-2 text-xs font-mono">
         {ROUTES.map((href) => (
           <li key={href} className="flex">
             <NavLink
-              className="border antd-menu-item aria-[current=page]:antd-menu-item-active px-2"
+              className="border antd-menu-item aria-[current=page]:antd-menu-item-active px-2 py-0.5"
               to={href}
               end
             >
@@ -46,6 +46,8 @@ const ROUTES = [
   "/other",
   "/some-dynamic-id",
   "/server-data",
+  "/server-redirect",
+  "/client-redirect",
   "/subdir",
   "/subdir/other",
 ];

--- a/packages/demo/src/routes/server-redirect/[id].page.server.tsx
+++ b/packages/demo/src/routes/server-redirect/[id].page.server.tsx
@@ -1,0 +1,27 @@
+import { tinyassert } from "@hiogawa/utils";
+import type { QueryObserverOptions } from "@tanstack/react-query";
+import { type LoaderFunction, redirect } from "react-router-dom";
+import { sleep } from "../../utils/misc";
+
+export const loader: LoaderFunction = async ({ params }) => {
+  const id = params["id"]!;
+  try {
+    await dummyCheck(id);
+    return null;
+  } catch {
+    throw redirect("/server-redirect?error=server");
+  }
+};
+
+async function dummyCheck(id: string) {
+  await sleep(1000);
+  tinyassert(id === "good");
+  return { message: "secret" };
+}
+
+export function dummyCheckQueryOptions(id: string) {
+  return {
+    queryKey: ["server-redirect-check", id],
+    queryFn: async () => dummyCheck(id),
+  } satisfies QueryObserverOptions;
+}

--- a/packages/demo/src/routes/server-redirect/[id].page.tsx
+++ b/packages/demo/src/routes/server-redirect/[id].page.tsx
@@ -1,0 +1,38 @@
+import { useQuery } from "@tanstack/react-query";
+import React from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { dummyCheckQueryOptions } from "./[id].page.server";
+
+export function Page() {
+  const params = useParams();
+
+  // check server and redirect on error
+  const checkQuery = useQuery(dummyCheckQueryOptions(params["id"]!));
+
+  const navigate = useNavigate();
+
+  React.useEffect(() => {
+    if (checkQuery.error) {
+      navigate("/server-redirect?error=client");
+    }
+  }, [checkQuery.error]);
+
+  if (checkQuery.isLoading) {
+    return <div className="mt-10 mx-auto antd-spin w-10 h-10"></div>;
+  }
+
+  return <PageInner data={checkQuery.data} />;
+}
+
+function PageInner(props: { data: unknown }) {
+  return (
+    <div className="flex flex-col items-center">
+      <div className="w-full p-6">
+        <div className="flex flex-col gap-4">
+          <h1>Server redirect</h1>
+          <pre>{JSON.stringify(props.data)}</pre>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/demo/src/routes/server-redirect/index.page.tsx
+++ b/packages/demo/src/routes/server-redirect/index.page.tsx
@@ -1,0 +1,27 @@
+import { Link } from "react-router-dom";
+
+export function Page() {
+  return (
+    <div className="flex flex-col items-center">
+      <div className="w-full p-6">
+        <div className="flex flex-col gap-4">
+          <h1>Server redirect</h1>
+          <div className="flex gap-2">
+            <Link
+              className="antd-btn antd-btn-default px-1"
+              to="/server-redirect/good"
+            >
+              good link
+            </Link>
+            <Link
+              className="antd-btn antd-btn-default px-1"
+              to="/server-redirect/forbidden"
+            >
+              forbidden link
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/demo/src/utils/misc.ts
+++ b/packages/demo/src/utils/misc.ts
@@ -1,3 +1,7 @@
 export function cls(...args: unknown[]): string {
   return args.filter(Boolean).join(" ");
 }
+
+export function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(() => resolve(null), ms));
+}


### PR DESCRIPTION
- merge base https://github.com/hi-ogawa/vite-plugins/pull/17
- part 3 of https://github.com/hi-ogawa/vite-plugins/issues/10

we can throw "redirection response" in react-router's loader, so the bare minimum form of server side redirection is already possible.