### PR TITLE
chore(demo): reduce server bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,10 @@
   },
   "volta": {
     "node": "18.16.0"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "@hattip/adapter-node@0.0.34": "patches/@hattip__adapter-node@0.0.34.patch"
+    }
   }
 }

--- a/packages/demo/misc/vercel/build.sh
+++ b/packages/demo/misc/vercel/build.sh
@@ -24,5 +24,7 @@ cp misc/vercel/config.json .vercel/output/config.json
 cp -r dist/client .vercel/output/static
 
 # serverless
-npx esbuild dist/server/index.mjs --outfile=.vercel/output/functions/index.func/index.js --bundle --platform=node --metafile=dist/server/esbuild-metafile.json
+npx esbuild dist/server/index.mjs --outfile=.vercel/output/functions/index.func/index.js --bundle --minify --platform=node \
+  '--external:*.development.js' \
+  --metafile=dist/server/esbuild-metafile.json
 cp misc/vercel/.vc-config.json .vercel/output/functions/index.func/.vc-config.json

--- a/packages/demo/misc/vercel/build.sh
+++ b/packages/demo/misc/vercel/build.sh
@@ -25,6 +25,6 @@ cp -r dist/client .vercel/output/static
 
 # serverless
 npx esbuild dist/server/index.mjs --outfile=.vercel/output/functions/index.func/index.js --bundle --minify --platform=node \
-  '--external:*.development.js' \
+  --external:'*.development.js' \
   --metafile=dist/server/esbuild-metafile.json
 cp misc/vercel/.vc-config.json .vercel/output/functions/index.func/.vc-config.json

--- a/packages/demo/misc/vercel/build.sh
+++ b/packages/demo/misc/vercel/build.sh
@@ -24,5 +24,5 @@ cp misc/vercel/config.json .vercel/output/config.json
 cp -r dist/client .vercel/output/static
 
 # serverless
-npx esbuild dist/server/index.mjs --outfile=.vercel/output/functions/index.func/index.js --bundle --platform=node
+npx esbuild dist/server/index.mjs --outfile=.vercel/output/functions/index.func/index.js --bundle --platform=node --metafile=dist/server/esbuild-metafile.json
 cp misc/vercel/.vc-config.json .vercel/output/functions/index.func/.vc-config.json

--- a/patches/@hattip__adapter-node@0.0.34.patch
+++ b/patches/@hattip__adapter-node@0.0.34.patch
@@ -1,0 +1,18 @@
+diff --git a/dist/index.js b/dist/index.js
+index 6f2d86baa67f9b8cf3346889d94ff77bba2d7dd1..6565efa1e7ed9a758255c396ac1f256b5dbb0877 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -4,10 +4,11 @@ import {
+ } from "./chunk-NY3T7LPC.js";
+ 
+ // src/index.ts
+-import installNodeFetch from "@hattip/polyfills/node-fetch";
++// (PATCH: remove heavy bundle of "node-fetch-native" (~300KB))
++// import installNodeFetch from "@hattip/polyfills/node-fetch";
+ import installGetSetCookie from "@hattip/polyfills/get-set-cookie";
+ import installCrypto from "@hattip/polyfills/crypto";
+-installNodeFetch();
++// installNodeFetch();
+ installGetSetCookie();
+ installCrypto();
+ export {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@hattip/adapter-node@0.0.34':
+    hash: 63rj2xdicuvvpcjbd4ybclgele
+    path: patches/@hattip__adapter-node@0.0.34.patch
+
 importers:
 
   .:
@@ -49,7 +54,7 @@ importers:
     devDependencies:
       '@hattip/adapter-node':
         specifier: ^0.0.34
-        version: 0.0.34
+        version: 0.0.34(patch_hash=63rj2xdicuvvpcjbd4ybclgele)
       '@hattip/compose':
         specifier: ^0.0.34
         version: 0.0.34
@@ -769,12 +774,13 @@ packages:
     dev: true
     optional: true
 
-  /@hattip/adapter-node@0.0.34:
+  /@hattip/adapter-node@0.0.34(patch_hash=63rj2xdicuvvpcjbd4ybclgele):
     resolution: {integrity: sha512-saEmf4Wh0KwXTm44sjvTcBOe8znPHBGtKhQOJVfafUgZ9OkXGTd9A8wdi6cO9b9HZFJm+JkQu/UVb4p0vccRmQ==}
     dependencies:
       '@hattip/core': 0.0.34
       '@hattip/polyfills': 0.0.34
     dev: true
+    patched: true
 
   /@hattip/compose@0.0.34:
     resolution: {integrity: sha512-faW5gIvyDmut3/lUWslHitH2+rrtkM9IQvBOmdTjS7r9vaADVh2t/M+MgitTzsSavfQUbP+uCbTPQ+ffrUhceA==}


### PR DESCRIPTION
I was surprised by 1.4 MB and it turned it includes "development", "legacy" etc... build from react.

## todo

- [x] minify?
- [x]  exclude `react` ~legacy~, development build?
- [x] `node-fetch-native` polyfill shouldn't be necessary?

<details>
<summary>esbuild metafile</summary>

Just loading it on https://esbuild.github.io/analyze/

- before

![image](https://github.com/hi-ogawa/vite-plugins/assets/4232207/074dde64-e96c-4e51-8517-c4812ad427be)

- after

![image](https://github.com/hi-ogawa/vite-plugins/assets/4232207/6f9281bd-aa1c-404a-93e8-562b43b990d5)

</details>
