### PR TITLE
build(demo): fix edge deployment

### DIFF
--- a/packages/demo/misc/vercel/.vc-config.json
+++ b/packages/demo/misc/vercel/.vc-config.json
@@ -1,7 +1,4 @@
 {
-  "runtime": "nodejs18.x",
-  "handler": "index.js",
-  "launcherType": "Nodejs",
-  "supportsResponseStreaming": true,
-  "regions": ["hnd1"]
+  "runtime": "edge",
+  "entrypoint": "index.js"
 }

--- a/packages/demo/misc/vercel/build.sh
+++ b/packages/demo/misc/vercel/build.sh
@@ -24,5 +24,5 @@ cp misc/vercel/config.json .vercel/output/config.json
 cp -r dist/client .vercel/output/static
 
 # serverless
-npx esbuild dist/server/index.mjs --outfile=.vercel/output/functions/index.func/index.js --bundle --minify --platform=browser --metafile=dist/server/esbuild-metafile.json
+npx esbuild dist/server/index.mjs --outfile=.vercel/output/functions/index.func/index.js --bundle --minify --format=esm --platform=browser --metafile=dist/server/esbuild-metafile.json
 cp misc/vercel/.vc-config.json .vercel/output/functions/index.func/.vc-config.json

--- a/packages/demo/misc/vercel/build.sh
+++ b/packages/demo/misc/vercel/build.sh
@@ -24,5 +24,5 @@ cp misc/vercel/config.json .vercel/output/config.json
 cp -r dist/client .vercel/output/static
 
 # serverless
-npx esbuild dist/server/index.mjs --outfile=.vercel/output/functions/index.func/index.js --bundle --platform=node
+npx esbuild dist/server/index.mjs --outfile=.vercel/output/functions/index.func/index.js --bundle --platform=neutral
 cp misc/vercel/.vc-config.json .vercel/output/functions/index.func/.vc-config.json

--- a/packages/demo/misc/vercel/build.sh
+++ b/packages/demo/misc/vercel/build.sh
@@ -24,5 +24,5 @@ cp misc/vercel/config.json .vercel/output/config.json
 cp -r dist/client .vercel/output/static
 
 # serverless
-npx esbuild dist/server/index.mjs --outfile=.vercel/output/functions/index.func/index.js --bundle --platform=neutral
+npx esbuild dist/server/index.mjs --outfile=.vercel/output/functions/index.func/index.js --bundle --minify --platform=browser --metafile=dist/server/esbuild-metafile.json
 cp misc/vercel/.vc-config.json .vercel/output/functions/index.func/.vc-config.json

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -3,7 +3,7 @@
     "dev": "run-p dev:*",
     "dev:vite": "vite",
     "dev:tsc": "tsc -b --watch --preserveWatchOutput",
-    "build": "run-s build:*",
+    "build": "SERVER_ENTRY=./src/server/adapter-vercel-edge.ts run-s build:*",
     "build:vite": "vite build && vite build --ssr",
     "build:vercel": "bash misc/vercel/build.sh",
     "build-preview": "SERVER_ENTRY=./src/server/adapter-preview.ts run-s build:vite",
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "@hattip/adapter-node": "^0.0.34",
+    "@hattip/adapter-vercel-edge": "^0.0.34",
     "@hattip/compose": "^0.0.34",
     "@hiogawa/isort-ts": "1.0.2-pre.1",
     "@hiogawa/unocss-preset-antd": "2.2.1-pre.3",

--- a/packages/demo/src/server/adapter-vercel-edge.ts
+++ b/packages/demo/src/server/adapter-vercel-edge.ts
@@ -1,0 +1,4 @@
+import adapterVercelEdge from "@hattip/adapter-vercel-edge";
+import { createHattipApp } from ".";
+
+export default adapterVercelEdge(createHattipApp());

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       '@hattip/adapter-node':
         specifier: ^0.0.34
         version: 0.0.34
+      '@hattip/adapter-vercel-edge':
+        specifier: ^0.0.34
+        version: 0.0.34
       '@hattip/compose':
         specifier: ^0.0.34
         version: 0.0.34
@@ -774,6 +777,12 @@ packages:
     dependencies:
       '@hattip/core': 0.0.34
       '@hattip/polyfills': 0.0.34
+    dev: true
+
+  /@hattip/adapter-vercel-edge@0.0.34:
+    resolution: {integrity: sha512-c50G3Jq4TCmu5MjcQU/hoOCZGOMSDPE4+pm+/2Mn7lbqHEy2hxP852fpGGHOdBYSNh3ZfGuR9c4K99GxX8FwEA==}
+    dependencies:
+      '@hattip/core': 0.0.34
     dev: true
 
   /@hattip/compose@0.0.34:


### PR DESCRIPTION
Edge deployment was temporary gave up in
- https://github.com/hi-ogawa/vite-plugins/pull/11

It turns out esbuild just needed `--format=esm --platform=browser`.