### PR TITLE
feat(glob-routes): align with react-router API

### DIFF
--- a/packages/demo/e2e/basic.test.ts
+++ b/packages/demo/e2e/basic.test.ts
@@ -106,7 +106,7 @@ test.describe("server-redirect", () => {
   });
 });
 
-test.describe.only("ErrorBoundary", () => {
+test.describe("ErrorBoundary", () => {
   test("basic", async ({ page }) => {
     await page.goto("/error");
     await isPageReady(page);

--- a/packages/demo/e2e/basic.test.ts
+++ b/packages/demo/e2e/basic.test.ts
@@ -106,6 +106,21 @@ test.describe("server-redirect", () => {
   });
 });
 
+test.describe.only("ErrorBoundary", () => {
+  test("basic", async ({ page }) => {
+    await page.goto("/error");
+    await isPageReady(page);
+    await page.getByRole("heading", { name: "Page Component" }).click();
+    await page.getByRole("button", { name: "Throw" }).click();
+    await page
+      .getByRole("heading", { name: "ErrorBoundary Component" })
+      .click();
+    await page.getByText("Error: hey render eror! at onClick").click();
+    await page.getByRole("button", { name: "Reset" }).click();
+    await page.getByRole("heading", { name: "Page Component" }).click();
+  });
+});
+
 async function isPageReady(page: Page) {
   await page.getByTestId("hydrated").waitFor({ state: "attached" });
 }

--- a/packages/demo/misc/vercel/build.sh
+++ b/packages/demo/misc/vercel/build.sh
@@ -7,7 +7,8 @@ set -eu -o pipefail
 #   project.json
 #   output/
 #     config.json
-#     static/              = dist/client
+#     static/
+#       assets/            = dist/client/assets
 #     functions/
 #       index.func/
 #         .vc-config.json
@@ -15,13 +16,14 @@ set -eu -o pipefail
 
 # clean
 rm -rf .vercel/output
+mkdir -p .vercel/output/static
 mkdir -p .vercel/output/functions/index.func
 
 # config.json
 cp misc/vercel/config.json .vercel/output/config.json
 
 # static
-cp -r dist/client .vercel/output/static
+cp -r dist/client/assets .vercel/output/static/assets
 
 # serverless
 npx esbuild dist/server/index.mjs --outfile=.vercel/output/functions/index.func/index.js --bundle --minify --format=esm --platform=browser --metafile=dist/server/esbuild-metafile.json

--- a/packages/demo/misc/vercel/build.sh
+++ b/packages/demo/misc/vercel/build.sh
@@ -16,15 +16,16 @@ set -eu -o pipefail
 
 # clean
 rm -rf .vercel/output
-mkdir -p .vercel/output/static
-mkdir -p .vercel/output/functions/index.func
+mkdir -p .vercel/output
 
 # config.json
 cp misc/vercel/config.json .vercel/output/config.json
 
 # static
+mkdir -p .vercel/output/static
 cp -r dist/client/assets .vercel/output/static/assets
 
 # serverless
+mkdir -p .vercel/output/functions/index.func
 npx esbuild dist/server/index.mjs --outfile=.vercel/output/functions/index.func/index.js --bundle --minify --format=esm --platform=browser --metafile=dist/server/esbuild-metafile.json
 cp misc/vercel/.vc-config.json .vercel/output/functions/index.func/.vc-config.json

--- a/packages/demo/src/routes/error.page.tsx
+++ b/packages/demo/src/routes/error.page.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { useNavigate, useRouteError } from "react-router-dom";
+
+export function Component() {
+  const [error, setError] = React.useState<Error>();
+
+  if (error) {
+    throw error;
+  }
+
+  return (
+    <div className="flex flex-col items-center">
+      <div className="w-full p-6">
+        <div className="flex flex-col gap-2">
+          <h1>Page Component</h1>
+          <button
+            className="antd-btn antd-btn-default"
+            onClick={() => {
+              setError(new Error("hey render eror!"));
+            }}
+          >
+            Throw
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex flex-col items-center">
+      <div className="w-full p-6">
+        <div className="flex flex-col gap-2">
+          <h1>ErrorBoundary Component</h1>
+          <button
+            className="antd-btn antd-btn-default"
+            onClick={() => {
+              // trick to reset error
+              // https://github.com/remix-run/react-router/blob/bc2552840147206716544e5cdcdb54f649f9193f/packages/react-router/lib/hooks.tsx#L575-L583
+              navigate("", { replace: true });
+            }}
+          >
+            Reset
+          </button>
+          <pre className="text-sm overflow-auto border p-2 text-colorErrorText bg-colorErrorBg border-colorErrorBorder">
+            {error instanceof Error
+              ? error.stack ?? error.message
+              : JSON.stringify(error, null, 2)}
+          </pre>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/demo/src/routes/layout.tsx
+++ b/packages/demo/src/routes/layout.tsx
@@ -65,6 +65,7 @@ const ROUTES = [
   "/server-redirect",
   "/subdir",
   "/subdir/other",
+  "/error",
 ];
 
 declare let __themeSet: (theme: string) => void;

--- a/packages/demo/src/routes/layout.tsx
+++ b/packages/demo/src/routes/layout.tsx
@@ -1,6 +1,8 @@
 import { Toaster } from "react-hot-toast";
 import { NavLink, Outlet } from "react-router-dom";
 
+export const handle = "root-handle";
+
 export function Component() {
   return (
     <>

--- a/packages/demo/src/routes/subdir/layout.tsx
+++ b/packages/demo/src/routes/subdir/layout.tsx
@@ -1,0 +1,7 @@
+import { Outlet } from "react-router-dom";
+
+export const handle = "subdir-handle";
+
+export function Component() {
+  return <Outlet />;
+}

--- a/packages/demo/src/routes/subdir/other.page.tsx
+++ b/packages/demo/src/routes/subdir/other.page.tsx
@@ -1,7 +1,20 @@
+import { useMatches } from "react-router-dom";
+
+export const handle = "subdir-other-handle";
+
 export function Component() {
+  const matches = useMatches();
+
   return (
     <div className="flex flex-col items-center">
-      <div className="w-full p-6">Sub directory (other)</div>
+      <div className="w-full p-6">
+        <div className="flex flex-col gap-2">
+          Sub directory (other)
+          <pre className="text-sm border p-2">
+            useMatches() = {JSON.stringify(matches, null, 2)}
+          </pre>
+        </div>
+      </div>
     </div>
   );
 }

--- a/packages/vite-glob-routes/src/index.ts
+++ b/packages/vite-glob-routes/src/index.ts
@@ -53,9 +53,9 @@ export default function globRoutesPlugin(options: { root: string }): Plugin {
             const root = "${root}";
             const globPage = import.meta.glob("${root}/**/*.page.(js|jsx|ts|tsx)", { eager: true });
             const globLayout = import.meta.glob("${root}/**/layout.(js|jsx|ts|tsx)", { eager: true });
-            // TODO: same for layout?
             const globPageServer = import.meta.env.SSR ? import.meta.glob("${root}/**/*.page.server.(js|jsx|ts|tsx)", { eager: true }) : {};
-            export default { root, globPage, globPageServer, globLayout };
+            const globLayoutServer = import.meta.env.SSR ? import.meta.glob("${root}/**/layout.server.(js|jsx|ts|tsx)", { eager: true }) : {};
+            export default { root, globPage, globPageServer, globLayout, globLayoutServer };
           `;
       }
 

--- a/packages/vite-glob-routes/src/react-router-utils.test.ts
+++ b/packages/vite-glob-routes/src/react-router-utils.test.ts
@@ -8,6 +8,7 @@ import {
 describe(createGlobPageRoutes, () => {
   it("basic", () => {
     const Module: PageModule = { Component: () => null };
+    const Module2: PageModule = { loader: () => null };
     const tree = createGlobPageRoutes({
       root: "(root)",
       globPage: {
@@ -20,11 +21,14 @@ describe(createGlobPageRoutes, () => {
         "(root)/abc/[dynsub]/new.page.tsx": Module,
       },
       globPageServer: {
-        "(root)/other.page.server.jsx": { loader: () => null },
+        "(root)/other.page.server.jsx": Module2,
       },
       globLayout: {
         "(root)/layout.tsx": Module,
         "(root)/subdir/layout.jsx": Module,
+      },
+      globLayoutServer: {
+        "(root)/layout.server.tsx": Module2,
       },
     });
     expect(tree).toMatchInlineSnapshot(`
@@ -60,14 +64,12 @@ describe(createGlobPageRoutes, () => {
               "path": "subdir/",
             },
             {
-              "Component": null,
               "children": [
                 {
                   "Component": [Function],
                   "path": ":dynsub",
                 },
                 {
-                  "Component": null,
                   "children": [
                     {
                       "Component": [Function],
@@ -80,6 +82,7 @@ describe(createGlobPageRoutes, () => {
               "path": "abc/",
             },
           ],
+          "loader": [Function],
           "path": "/",
         },
       ]

--- a/packages/vite-glob-routes/src/react-router-utils.ts
+++ b/packages/vite-glob-routes/src/react-router-utils.ts
@@ -1,12 +1,20 @@
 import { mapRegExp, tinyassert } from "@hiogawa/utils";
-import type React from "react";
-import type { LoaderFunction, RouteObject } from "react-router";
+import type { RouteObject } from "react-router";
 import { mapKeys } from "./utils";
 
-// Pick<RouteObject, "Component" | "loader" | ...>
-export type PageModule = {
-  Component?: React.ComponentType;
-  loader?: LoaderFunction;
+// mirror everything from react-router
+export type PageModule = Omit<
+  RouteObject,
+  "index" | "path" | "children" | "lazy"
+>;
+
+// provided by plugin's virtual module based on glob import
+export type GlobPageRoutesInternal = {
+  root: string;
+  globPage: Record<string, PageModule>;
+  globPageServer: Record<string, PageModule>;
+  globLayout: Record<string, PageModule>;
+  globLayoutServer: Record<string, PageModule>;
 };
 
 export function createGlobPageRoutes({
@@ -14,12 +22,8 @@ export function createGlobPageRoutes({
   globPage,
   globPageServer,
   globLayout,
-}: {
-  root: string;
-  globPage: Record<string, PageModule>;
-  globPageServer: Record<string, PageModule>; // only for SSR
-  globLayout: Record<string, PageModule>;
-}): RouteObject[] {
+  globLayoutServer,
+}: GlobPageRoutesInternal): RouteObject[] {
   // TODO: warn invalid usage
   // - ensure `Component` export
   // - conflicting page/layout e.g. "/hello.page.tsx" and "/hello/layout.tsx"
@@ -35,9 +39,19 @@ export function createGlobPageRoutes({
     globPageServer,
     (k) => k.slice(root.length).match(/^(.*)\.page\.server\./)![1]!
   );
+  globLayoutServer = mapKeys(
+    globLayoutServer,
+    (k) => k.slice(root.length).match(/^(.*)layout\.server\./)![1]!
+  );
   for (const [k, v] of Object.entries(globPageServer)) {
-    tinyassert(globPage[k]);
-    globPage[k] = { ...globPage[k], ...v };
+    const v2 = globPage[k];
+    tinyassert(v2);
+    globPage[k] = { ...v2, ...v };
+  }
+  for (const [k, v] of Object.entries(globLayoutServer)) {
+    const v2 = globLayout[k];
+    tinyassert(v2);
+    globLayout[k] = { ...v2, ...v };
   }
   return createGlobPageRoutesInner({ ...globPage, ...globLayout });
 }
@@ -58,24 +72,22 @@ function createGlobPageRoutesInner(
   ): RouteObject[] {
     return Object.entries(children).map(([path, node]) => {
       const route: RouteObject = {
+        ...node.value,
         path: formatPath(path),
-        Component: node.value?.Component ?? null,
       };
       if (node.children) {
         route.children = recurse(node.children);
       }
-      if (node.value?.loader) {
-        route.loader = node.value?.loader;
-      }
       if (path === "index") {
-        // silence convoluted "index: true" typing
+        // silence tricky "index: true" typing
         route.index = true as false;
         delete route.path;
+        delete route.children;
       }
       return route;
     });
   }
-  return recurse(tree.children ?? {});
+  return tree.children ? recurse(tree.children) : [];
 }
 
 //

--- a/packages/vite-glob-routes/src/virtual.d.ts
+++ b/packages/vite-glob-routes/src/virtual.d.ts
@@ -1,10 +1,5 @@
 declare module "virtual:@hiogawa/vite-glob-routes/internal/page-routes" {
-  const value: {
-    root: string;
-    globPage: Record<string, any>;
-    globPageServer: Record<string, any>;
-    globLayout: Record<string, any>;
-  };
+  const value: import("./react-router-utils").GlobPageRoutesInternal;
   export default value;
 }
 


### PR DESCRIPTION
Simplifying route/page convention by adapting a whole `RouteObject` interface directly from react-router.
This allows using `ErrorBoundaray`, `handle` etc... already.