### PR TITLE
fix(glob-routes): tree shake server code from client

### DIFF
--- a/packages/demo/src/routes/server-redirect/[id].page.server.tsx
+++ b/packages/demo/src/routes/server-redirect/[id].page.server.tsx
@@ -1,9 +1,7 @@
-import crypto from "node:crypto";
 import { type LoaderFunction } from "react-router-dom";
 import { serverRedirectCheckQueryOptions } from "./check.api";
 
 export const loader: LoaderFunction = async ({ params, context }) => {
-  console.log(crypto.randomBytes(8).toString("hex"));
   const id = params["id"] ?? "";
   // note that we don't use `prefetchQuery` since it would swallow "throw redirect inside `queryFn`.
   await context.queryClient.fetchQuery(serverRedirectCheckQueryOptions(id));

--- a/packages/demo/src/routes/server-redirect/[id].page.server.tsx
+++ b/packages/demo/src/routes/server-redirect/[id].page.server.tsx
@@ -1,6 +1,6 @@
+import crypto from "node:crypto";
 import { type LoaderFunction } from "react-router-dom";
 import { serverRedirectCheckQueryOptions } from "./check.api";
-import crypto from "node:crypto";
 
 export const loader: LoaderFunction = async ({ params, context }) => {
   console.log(crypto.randomBytes(8).toString("hex"));

--- a/packages/demo/src/routes/server-redirect/[id].page.server.tsx
+++ b/packages/demo/src/routes/server-redirect/[id].page.server.tsx
@@ -1,7 +1,9 @@
 import { type LoaderFunction } from "react-router-dom";
 import { serverRedirectCheckQueryOptions } from "./check.api";
+import crypto from "node:crypto";
 
 export const loader: LoaderFunction = async ({ params, context }) => {
+  console.log(crypto.randomBytes(8).toString("hex"));
   const id = params["id"] ?? "";
   // note that we don't use `prefetchQuery` since it would swallow "throw redirect inside `queryFn`.
   await context.queryClient.fetchQuery(serverRedirectCheckQueryOptions(id));

--- a/packages/vite-glob-routes/src/react-router.ts
+++ b/packages/vite-glob-routes/src/react-router.ts
@@ -1,7 +1,7 @@
 import internal from "virtual:@hiogawa/vite-glob-routes/internal/page-routes";
 import { createGlobPageRoutes } from "./react-router-utils";
 
-// TODO: proepr peer-dependency version range
+// TODO: proper peer-dependency version range
 
 // provide "react-router" RouterObject (only type dependency)
 export function globPageRoutes() {


### PR DESCRIPTION
It seems client build is still seeing `*.page.server.tsx` code even when we guard glob import by `import.meta.env.SSR`:

https://github.com/hi-ogawa/vite-plugins/blob/eab55ae4f5e6fad50c6bfd95e4862e383e43160b/packages/vite-glob-routes/src/index.ts#L52-L59

```
$ pnpm build
...
vite v4.3.9 building for production...
transforming (25) ../vite-glob-routes/dist/chunk-YXB3VE22.js[plugin:vite:resolve] Module "node:crypto" has been externalized for browser compatibility, imported by "/home/hiroshi/code/personal/vite-plugins/packages/demo/src/routes/server-redirect/[id].page.server.tsx". See http://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
✓ 129 modules transformed.
dist/client/index.html                   2.06 kB │ gzip:  1.22 kB
dist/client/assets/index-ec8fd62b.css   34.56 kB │ gzip:  8.22 kB
dist/client/assets/index-c0aad7d3.js   307.38 kB │ gzip: 93.71 kB │ map: 1,115.90 kB
✓ built in 1.75s
```

---

It seems this is because "glob import" is actually hoisted like below.
If we switch to non-eager import in https://github.com/hi-ogawa/vite-plugins/pull/32, then it'll probably fine, but probably it makes sense to split virtual modules itself and not rely on `import.meta.env.SSR` switch.

<details><summary>virtual module</summary>

Checking the source code from browser dev tool:

```js
import.meta.env = {
    "BASE_URL": "/",
    "MODE": "development",
    "DEV": true,
    "PROD": false,
    "SSR": false
};
import*as __vite_glob_0_0 from "/src/routes/dynamic/[id].page.tsx";
import*as __vite_glob_0_1 from "/src/routes/error.page.tsx";
import*as __vite_glob_0_2 from "/src/routes/index.page.tsx";
import*as __vite_glob_0_3 from "/src/routes/other.page.tsx";
import*as __vite_glob_0_4 from "/src/routes/server-data.page.tsx";
import*as __vite_glob_0_5 from "/src/routes/server-redirect/[id].page.tsx";
import*as __vite_glob_0_6 from "/src/routes/server-redirect/index.page.tsx";
import*as __vite_glob_0_7 from "/src/routes/subdir/index.page.tsx";
import*as __vite_glob_0_8 from "/src/routes/subdir/other.page.tsx";
import*as __vite_glob_1_0 from "/src/routes/layout.tsx";
import*as __vite_glob_1_1 from "/src/routes/subdir/layout.tsx";
import*as __vite_glob_2_0 from "/src/routes/server-data.page.server.tsx";
import*as __vite_glob_2_1 from "/src/routes/server-redirect/[id].page.server.tsx";
const root = "/src/routes";
const globPage = /* #__PURE__ */
Object.assign({
    "/src/routes/dynamic/[id].page.tsx": __vite_glob_0_0,
    "/src/routes/error.page.tsx": __vite_glob_0_1,
    "/src/routes/index.page.tsx": __vite_glob_0_2,
    "/src/routes/other.page.tsx": __vite_glob_0_3,
    "/src/routes/server-data.page.tsx": __vite_glob_0_4,
    "/src/routes/server-redirect/[id].page.tsx": __vite_glob_0_5,
    "/src/routes/server-redirect/index.page.tsx": __vite_glob_0_6,
    "/src/routes/subdir/index.page.tsx": __vite_glob_0_7,
    "/src/routes/subdir/other.page.tsx": __vite_glob_0_8
});
const globLayout = /* #__PURE__ */
Object.assign({
    "/src/routes/layout.tsx": __vite_glob_1_0,
    "/src/routes/subdir/layout.tsx": __vite_glob_1_1
});
const globPageServer = import.meta.env.SSR ? /* #__PURE__ */
Object.assign({
    "/src/routes/server-data.page.server.tsx": __vite_glob_2_0,
    "/src/routes/server-redirect/[id].page.server.tsx": __vite_glob_2_1
}) : {};
const globLayoutServer = import.meta.env.SSR ? /* #__PURE__ */
Object.assign({}) : {};
export default {
    root,
    globPage,
    globPageServer,
    globLayout,
    globLayoutServer
};
```

</details>