### PR TITLE
feat(demo): two pass render to trigger ErrorBoundary on SSR error

### DIFF
--- a/packages/demo/e2e/basic.test.ts
+++ b/packages/demo/e2e/basic.test.ts
@@ -185,8 +185,7 @@ test.describe("ErrorBoundary", () => {
       const res = await page.goto("/error?id=exception-render");
       tinyassert(res);
       expect(res.status()).toBe(500);
-      // TODO: no error boundary?
-      await page.getByText("Internal Server Error").click();
+      await page.getByText("render boom!", { exact: true }).click();
     });
   });
 });

--- a/packages/demo/src/routes/error.page.tsx
+++ b/packages/demo/src/routes/error.page.tsx
@@ -11,7 +11,6 @@ export function Component() {
   const loaderData = useLoaderData();
   const [searchParams] = useSearchParams();
 
-  // TODO: ErrorBoundary doesn't catch it during SSR?
   if (searchParams.get("id") === "exception-render") {
     throw new Error("render boom!");
   }

--- a/packages/demo/src/server/index.tsx
+++ b/packages/demo/src/server/index.tsx
@@ -47,7 +47,7 @@ function ssrHandler(): RequestHandler {
       );
     } catch (e) {
       // cf. https://github.com/remix-run/react-router/blob/4e12473040de76abf26e1374c23a19d29d78efc0/packages/router/router.ts#L3021-L3034
-      const newContext = {
+      routerResult.context = {
         ...routerResult.context,
         statusCode: 500,
         errors: {
@@ -56,13 +56,17 @@ function ssrHandler(): RequestHandler {
         },
       };
       // router also needs to be re-created
-      const newRouter = createStaticRouter(
+      routerResult.router = createStaticRouter(
         routerResult.router.routes,
-        newContext
+        routerResult.context
       );
+      routerResult.statusCode = routerResult.context.statusCode;
       ssrHtml = renderToString(
         <React.StrictMode>
-          <StaticRouterProvider router={newRouter} context={newContext} />
+          <StaticRouterProvider
+            router={routerResult.router}
+            context={routerResult.context}
+          />
         </React.StrictMode>
       );
     }

--- a/packages/vite-glob-routes/src/react-router-helper-server.ts
+++ b/packages/vite-glob-routes/src/react-router-helper-server.ts
@@ -19,14 +19,17 @@ import {
 } from "./react-router-helper-shared";
 import type { GlobPageRoutesResult } from "./react-router-utils";
 
-// this type not exposed?
+// typings from "@remix-run/router"
+// for now just derive it from "react-router" exports
 type RemixRouter = ReturnType<typeof createStaticRouter>;
+type RemixStaticHandler = ReturnType<typeof createStaticHandler>;
 
 type ServerRouterResult =
   | {
       type: "render";
+      handler: RemixStaticHandler;
       context: StaticHandlerContext;
-      router: RemixRouter;
+      router: RemixRouter; // TODO: remove in favor of `context.statusCode`
       statusCode: number;
       injectToHtml: string;
     }
@@ -91,6 +94,7 @@ export async function handleReactRouterServer({
 
   return {
     type: "render",
+    handler,
     context,
     router: createStaticRouter(handler.dataRoutes, context),
     statusCode: getResponseStatusCode(context),

--- a/packages/vite-glob-routes/src/react-router-helper-server.ts
+++ b/packages/vite-glob-routes/src/react-router-helper-server.ts
@@ -1,5 +1,4 @@
-import { typedBoolean, wrapErrorAsync } from "@hiogawa/utils";
-import { isRouteErrorResponse } from "react-router";
+import { wrapErrorAsync } from "@hiogawa/utils";
 import {
   type StaticHandlerContext,
   createStaticHandler,
@@ -29,8 +28,7 @@ type ServerRouterResult =
       type: "render";
       handler: RemixStaticHandler;
       context: StaticHandlerContext;
-      router: RemixRouter; // TODO: remove in favor of `context.statusCode`
-      statusCode: number;
+      router: RemixRouter;
       injectToHtml: string;
     }
   | {
@@ -97,7 +95,6 @@ export async function handleReactRouterServer({
     handler,
     context,
     router: createStaticRouter(handler.dataRoutes, context),
-    statusCode: getResponseStatusCode(context),
     injectToHtml: [
       assetPaths.map((f) => getPreloadLink(f)),
       // TOOD: support nonce for CSP? https://github.com/remix-run/react-router/blob/4e12473040de76abf26e1374c23a19d29d78efc0/packages/react-router-dom/server.tsx#L148
@@ -106,18 +103,4 @@ export async function handleReactRouterServer({
       .flat()
       .join("\n"),
   };
-}
-
-// probe context for error status (e.g. 404)
-function getResponseStatusCode(context: StaticHandlerContext): number {
-  if (context.errors) {
-    const errorResponses = Object.values(context.errors)
-      .map((e) => isRouteErrorResponse(e) && e)
-      .filter(typedBoolean);
-    if (errorResponses.length) {
-      return Math.max(...errorResponses.map((e) => e.status));
-    }
-    return 500;
-  }
-  return 200;
 }

--- a/packages/vite-glob-routes/src/react-router-helper-server.ts
+++ b/packages/vite-glob-routes/src/react-router-helper-server.ts
@@ -96,6 +96,7 @@ export async function handleReactRouterServer({
     statusCode: getResponseStatusCode(context),
     injectToHtml: [
       assetPaths.map((f) => getPreloadLink(f)),
+      // TOOD: support nonce for CSP? https://github.com/remix-run/react-router/blob/4e12473040de76abf26e1374c23a19d29d78efc0/packages/react-router-dom/server.tsx#L148
       createGlobalScript(KEY_extraRouterInfo, extraRouterInfo),
     ]
       .flat()

--- a/packages/vite-glob-routes/src/react-router-helper-server.ts
+++ b/packages/vite-glob-routes/src/react-router-helper-server.ts
@@ -23,7 +23,7 @@ import type { GlobPageRoutesResult } from "./react-router-utils";
 type RemixRouter = ReturnType<typeof createStaticRouter>;
 type RemixStaticHandler = ReturnType<typeof createStaticHandler>;
 
-type ServerRouterResult =
+export type ServerRouterResult =
   | {
       type: "render";
       handler: RemixStaticHandler;

--- a/packages/vite-glob-routes/src/react-router.ts
+++ b/packages/vite-glob-routes/src/react-router.ts
@@ -27,5 +27,9 @@ export { type GlobPageRoutesResult, walkArrayTree } from "./react-router-utils";
 // provide helpers for standard SSR setup (depends on "react-router-dom")
 //
 
-export { handleReactRouterServer } from "./react-router-helper-server";
+export {
+  handleReactRouterServer,
+  type ServerRouterResult,
+} from "./react-router-helper-server";
+
 export { initializeClientRoutes } from "./react-router-helper-client";


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/vite-plugins/issues/58
- supersedes https://github.com/hi-ogawa/vite-plugins/pull/56

~It can be implemented in the app-side, but hopefully there's a way to abstract this logic to glob-routes plugin?~
It's only a matter of modifying `StaticContextHandler.statusCode/errors` so it looks fine without too much abstraction.