### PR TITLE
refactor(glob-routes): renaming exports

### DIFF
--- a/packages/demo/src/client/index.tsx
+++ b/packages/demo/src/client/index.tsx
@@ -1,7 +1,7 @@
 import "virtual:uno.css";
 import { tinyassert } from "@hiogawa/utils";
 import {
-  globPageRoutesLazy,
+  globPageRoutesClientLazy,
   initializeClientRoutes,
 } from "@hiogawa/vite-glob-routes/dist/react-router";
 import React from "react";
@@ -12,7 +12,7 @@ async function main() {
   const el = document.getElementById("root");
   tinyassert(el);
 
-  const { routes } = globPageRoutesLazy();
+  const { routes } = globPageRoutesClientLazy();
   await initializeClientRoutes({ routes });
 
   const router = createBrowserRouter(routes);

--- a/packages/demo/src/server/index.tsx
+++ b/packages/demo/src/server/index.tsx
@@ -5,7 +5,7 @@ import THEME_SCRIPT from "@hiogawa/utils-experimental/dist/theme-script.global.j
 import { globApiRoutes } from "@hiogawa/vite-glob-routes/dist/hattip";
 import {
   type ServerRouterResult,
-  globPageRoutes,
+  globPageRoutesServer,
   handleReactRouterServer,
 } from "@hiogawa/vite-glob-routes/dist/react-router";
 import { importIndexHtml } from "@hiogawa/vite-import-index-html/dist/runtime";
@@ -22,7 +22,7 @@ export function createHattipApp() {
 }
 
 function ssrHandler(): RequestHandler {
-  const { routes, routesMeta } = globPageRoutes();
+  const { routes, routesMeta } = globPageRoutesServer();
 
   return async (ctx) => {
     const routerResult = await handleReactRouterServer({

--- a/packages/vite-glob-routes/src/hattip.ts
+++ b/packages/vite-glob-routes/src/hattip.ts
@@ -1,4 +1,4 @@
-import internal from "virtual:@hiogawa/vite-glob-routes/internal/api-routes";
+import internal from "virtual:@hiogawa/vite-glob-routes/internal/apiRoutes";
 import type { RequestHandler } from "@hattip/compose";
 import { tinyassert } from "@hiogawa/utils";
 import { mapKeys } from "./utils";

--- a/packages/vite-glob-routes/src/react-router.ts
+++ b/packages/vite-glob-routes/src/react-router.ts
@@ -1,5 +1,6 @@
-import internalEager from "virtual:@hiogawa/vite-glob-routes/internal/page-routes";
-import internalLazy from "virtual:@hiogawa/vite-glob-routes/internal/page-routes/lazy";
+import virtualPageRoutesClient from "virtual:@hiogawa/vite-glob-routes/internal/pageRoutesClient";
+import vurtialPageRoutesClientLazy from "virtual:@hiogawa/vite-glob-routes/internal/pageRoutesClientLazy";
+import virtualPageRoutesServer from "virtual:@hiogawa/vite-glob-routes/internal/pageRoutesServer";
 import { createGlobPageRoutes } from "./react-router-utils";
 
 // TODO: proper peer-dependency version range
@@ -8,17 +9,16 @@ import { createGlobPageRoutes } from "./react-router-utils";
 // provide "react-router" RouterObject tree (only type dependency)
 //
 
-// TODO: create separate exports for
-// globPageRoutesClient
-// globPageRoutesClientLazy
-// globPageRoutesServer
-
-export function globPageRoutes() {
-  return createGlobPageRoutes(internalEager);
+export function globPageRoutesServer() {
+  return createGlobPageRoutes(virtualPageRoutesServer);
 }
 
-export function globPageRoutesLazy() {
-  return createGlobPageRoutes(internalLazy);
+export function globPageRoutesClient() {
+  return createGlobPageRoutes(virtualPageRoutesClient);
+}
+
+export function globPageRoutesClientLazy() {
+  return createGlobPageRoutes(vurtialPageRoutesClientLazy);
 }
 
 export { type GlobPageRoutesResult, walkArrayTree } from "./react-router-utils";

--- a/packages/vite-glob-routes/src/virtual.d.ts
+++ b/packages/vite-glob-routes/src/virtual.d.ts
@@ -1,14 +1,19 @@
-declare module "virtual:@hiogawa/vite-glob-routes/internal/page-routes" {
+declare module "virtual:@hiogawa/vite-glob-routes/internal/pageRoutesServer" {
   const value: import("./react-router-utils").GlobPageRoutesInternal;
   export default value;
 }
 
-declare module "virtual:@hiogawa/vite-glob-routes/internal/page-routes/lazy" {
+declare module "virtual:@hiogawa/vite-glob-routes/internal/pageRoutesClient" {
   const value: import("./react-router-utils").GlobPageRoutesInternal;
   export default value;
 }
 
-declare module "virtual:@hiogawa/vite-glob-routes/internal/api-routes" {
+declare module "virtual:@hiogawa/vite-glob-routes/internal/pageRoutesClientLazy" {
+  const value: import("./react-router-utils").GlobPageRoutesInternal;
+  export default value;
+}
+
+declare module "virtual:@hiogawa/vite-glob-routes/internal/apiRoutes" {
   const value: {
     root: string;
     globApi: Record<string, any>;

--- a/packages/vite-glob-routes/tsup.config.ts
+++ b/packages/vite-glob-routes/tsup.config.ts
@@ -7,8 +7,9 @@ export default defineConfig({
   format: ["esm", "cjs"],
   dts: true,
   external: [
-    "virtual:@hiogawa/vite-glob-routes/internal/page-routes",
-    "virtual:@hiogawa/vite-glob-routes/internal/page-routes/lazy",
-    "virtual:@hiogawa/vite-glob-routes/internal/api-routes",
+    "virtual:@hiogawa/vite-glob-routes/internal/pageRoutesServer",
+    "virtual:@hiogawa/vite-glob-routes/internal/pageRoutesClient",
+    "virtual:@hiogawa/vite-glob-routes/internal/pageRoutesClientLazy",
+    "virtual:@hiogawa/vite-glob-routes/internal/apiRoutes",
   ],
 });


### PR DESCRIPTION
For clarity, renaming exports to be

```
globPageRoutesClient
globPageRoutesClientLazy
globPageRoutesServer
```