### PR TITLE
feat: support page prefetching

### DIFF
--- a/packages/demo/src/routes/layout.tsx
+++ b/packages/demo/src/routes/layout.tsx
@@ -1,9 +1,17 @@
 import BarOfProgress from "@badrap/bar-of-progress";
+import { tinyassert } from "@hiogawa/utils";
+import {
+  getExtraRouteInfo,
+  resolveAssetPathsByRouteId,
+} from "@hiogawa/vite-glob-routes/dist/react-router";
 import React from "react";
 import { Toaster } from "react-hot-toast";
 import {
+  type DataRouteObject,
   NavLink,
   Outlet,
+  UNSAFE_DataRouterContext,
+  matchRoutes,
   useLocation,
   useNavigation,
   useRouteError,
@@ -70,6 +78,8 @@ function PageInner() {
 }
 
 function Header() {
+  const injectPrefetch = useInjectPagePrefetchLinks();
+
   return (
     <header className="top-0 sticky antd-body flex items-center p-2 px-4 gap-3 shadow-md shadow-black/[0.05] dark:shadow-black/[0.7] z-1">
       <div>Example</div>
@@ -80,6 +90,7 @@ function Header() {
               className="border antd-menu-item aria-[current=page]:antd-menu-item-active px-2 py-0.5"
               to={href}
               end
+              onMouseEnter={() => injectPrefetch(href)}
             >
               {href}
             </NavLink>
@@ -110,6 +121,45 @@ const ROUTES = [
   "/subdir/other",
   "/error",
 ];
+
+//
+// link prefetching
+//
+
+// cf. https://github.com/remix-run/remix/blob/9ae3cee0e81ccb7259d6103df490b019e8c2fd94/packages/remix-react/components.tsx#L479
+function useInjectPagePrefetchLinks() {
+  const dataRouteContext = React.useContext(UNSAFE_DataRouterContext);
+  tinyassert(dataRouteContext);
+  const routes = dataRouteContext.router.routes;
+
+  function inject(page: string) {
+    const hrefs = resolveAssetPathsByPage(routes, page);
+    for (const href of hrefs) {
+      // TODO: escape
+      const found = document.body.querySelector(`link[href="${href}"]`);
+      if (!found) {
+        const el = document.createElement("link");
+        el.setAttribute("rel", "modulepreload");
+        el.setAttribute("href", href);
+        document.body.appendChild(el);
+      }
+    }
+  }
+
+  return inject;
+}
+
+function resolveAssetPathsByPage(
+  routes: DataRouteObject[],
+  page: string
+): string[] {
+  const matches = matchRoutes(routes, page) ?? [];
+  const extraRouterInfo = getExtraRouteInfo();
+  const assetPaths = matches.flatMap((m) =>
+    resolveAssetPathsByRouteId(m.route.id, extraRouterInfo)
+  );
+  return assetPaths;
+}
 
 //
 // ThemeSelect

--- a/packages/demo/src/routes/layout.tsx
+++ b/packages/demo/src/routes/layout.tsx
@@ -1,17 +1,10 @@
 import BarOfProgress from "@badrap/bar-of-progress";
-import { tinyassert } from "@hiogawa/utils";
-import {
-  getExtraRouteInfo,
-  resolveAssetPathsByRouteId,
-} from "@hiogawa/vite-glob-routes/dist/react-router";
+import { getPagePrefetchLinks } from "@hiogawa/vite-glob-routes/dist/react-router";
 import React from "react";
 import { Toaster } from "react-hot-toast";
 import {
-  type DataRouteObject,
   NavLink,
   Outlet,
-  UNSAFE_DataRouterContext,
-  matchRoutes,
   useLocation,
   useNavigation,
   useRouteError,
@@ -78,7 +71,18 @@ function PageInner() {
 }
 
 function Header() {
-  const injectPrefetch = useInjectPagePrefetchLinks();
+  // TODO: global hook to monitor events on "data-prefetch" anchor element?
+  useEffectNoStrict(() => {
+    // TODO: not sure perf impact of global "mouseover" handler etc...
+    document.addEventListener("mouseover", (e) => {
+      if (e.target instanceof HTMLAnchorElement) {
+        const dataPrefetch = e.target.getAttribute("data-prefetch");
+        if (dataPrefetch !== null) {
+          console.log(e.target.href);
+        }
+      }
+    });
+  }, []);
 
   return (
     <header className="top-0 sticky antd-body flex items-center p-2 px-4 gap-3 shadow-md shadow-black/[0.05] dark:shadow-black/[0.7] z-1">
@@ -90,8 +94,9 @@ function Header() {
               className="border antd-menu-item aria-[current=page]:antd-menu-item-active px-2 py-0.5"
               to={href}
               end
-              onMouseOver={() => injectPrefetch(href)}
-              onTouchStart={() => injectPrefetch(href)}
+              onMouseOver={() => injectPagePrefetchLinks(href)}
+              onTouchStart={() => injectPagePrefetchLinks(href)}
+              data-prefetch
             >
               {href}
             </NavLink>
@@ -128,37 +133,18 @@ const ROUTES = [
 //
 
 // cf. https://github.com/remix-run/remix/blob/9ae3cee0e81ccb7259d6103df490b019e8c2fd94/packages/remix-react/components.tsx#L479
-function useInjectPagePrefetchLinks() {
-  const dataRouteContext = React.useContext(UNSAFE_DataRouterContext);
-  tinyassert(dataRouteContext, "forgot to render 'RouterProvider'?");
-  const routes = dataRouteContext.router.routes;
-
-  function inject(page: string) {
-    const hrefs = resolveAssetPathsByPage(routes, page);
-    for (const href of hrefs) {
-      // TODO: escape
-      const found = document.body.querySelector(`link[href="${href}"]`);
-      if (!found) {
-        const el = document.createElement("link");
-        el.setAttribute("rel", "modulepreload");
-        el.setAttribute("href", href);
-        document.body.appendChild(el);
-      }
+function injectPagePrefetchLinks(page: string) {
+  const prefetchLinks = getPagePrefetchLinks(page);
+  for (const href of prefetchLinks.modules) {
+    // TODO: escapeHtml
+    const found = document.body.querySelector(`link[href="${href}"]`);
+    if (!found) {
+      const el = document.createElement("link");
+      el.setAttribute("rel", "modulepreload");
+      el.setAttribute("href", href);
+      document.body.appendChild(el);
     }
   }
-  return inject;
-}
-
-function resolveAssetPathsByPage(
-  routes: DataRouteObject[],
-  page: string
-): string[] {
-  const matches = matchRoutes(routes, page) ?? [];
-  const extraRouterInfo = getExtraRouteInfo();
-  const assetPaths = matches.flatMap((m) =>
-    resolveAssetPathsByRouteId(m.route.id, extraRouterInfo)
-  );
-  return assetPaths;
 }
 
 //

--- a/packages/demo/src/routes/layout.tsx
+++ b/packages/demo/src/routes/layout.tsx
@@ -90,7 +90,8 @@ function Header() {
               className="border antd-menu-item aria-[current=page]:antd-menu-item-active px-2 py-0.5"
               to={href}
               end
-              onMouseEnter={() => injectPrefetch(href)}
+              onMouseOver={() => injectPrefetch(href)}
+              onTouchStart={() => injectPrefetch(href)}
             >
               {href}
             </NavLink>
@@ -129,7 +130,7 @@ const ROUTES = [
 // cf. https://github.com/remix-run/remix/blob/9ae3cee0e81ccb7259d6103df490b019e8c2fd94/packages/remix-react/components.tsx#L479
 function useInjectPagePrefetchLinks() {
   const dataRouteContext = React.useContext(UNSAFE_DataRouterContext);
-  tinyassert(dataRouteContext);
+  tinyassert(dataRouteContext, "forgot to render 'RouterProvider'?");
   const routes = dataRouteContext.router.routes;
 
   function inject(page: string) {
@@ -145,7 +146,6 @@ function useInjectPagePrefetchLinks() {
       }
     }
   }
-
   return inject;
 }
 

--- a/packages/vite-glob-routes/src/react-router-helper-client.ts
+++ b/packages/vite-glob-routes/src/react-router-helper-client.ts
@@ -63,7 +63,7 @@ export async function initializeClientRoutes({
   }
 }
 
-// TODO: avoid global (but would wish to avoid react context either?)
+// TODO: re-think about global
 export function getExtraRouteInfo() {
   const extraRouterInfo = getGlobalScriptData(
     KEY_extraRouterInfo

--- a/packages/vite-glob-routes/src/react-router-helper-client.ts
+++ b/packages/vite-glob-routes/src/react-router-helper-client.ts
@@ -15,17 +15,12 @@ import { walkArrayTree } from "./react-router-utils";
 
 export async function initializeClientRoutes({
   routes,
-  extraRouterInfo,
   noAutoProxyServerLoader,
 }: {
   routes: DataRouteObject[]; // mutated
-  extraRouterInfo?: ExtraRouterInfo; // user can pass directly without relying on global script
   noAutoProxyServerLoader?: boolean;
 }) {
-  if (!extraRouterInfo) {
-    extraRouterInfo = getGlobalScriptData(KEY_extraRouterInfo) as any;
-    tinyassert(extraRouterInfo);
-  }
+  const extraRouterInfo = getExtraRouteInfo();
 
   //
   // Resolve "lazy" route for current matching routes. otherwise it will leads to hydration mismatch and redundant initial client loader call.
@@ -66,6 +61,18 @@ export async function initializeClientRoutes({
       }
     }
   }
+}
+
+// TODO: avoid global (but would wish to avoid react context either?)
+export function getExtraRouteInfo() {
+  const extraRouterInfo = getGlobalScriptData(
+    KEY_extraRouterInfo
+  ) as ExtraRouterInfo;
+  tinyassert(
+    extraRouterInfo,
+    "did you forget to inject 'extraRouterInfo' global?"
+  );
+  return extraRouterInfo;
 }
 
 async function resolveLazyRouteObject(

--- a/packages/vite-glob-routes/src/react-router-helper-client.ts
+++ b/packages/vite-glob-routes/src/react-router-helper-client.ts
@@ -136,6 +136,7 @@ export function getClientGlobal() {
 //
 
 // TOOD: css? loader data?
+// TODO: rename resolvePageDependencies?
 // cf. https://github.com/remix-run/remix/blob/9ae3cee0e81ccb7259d6103df490b019e8c2fd94/packages/remix-react/components.tsx#L479
 export function getPagePrefetchLinks(page: string) {
   const { client, server } = getClientGlobal();

--- a/packages/vite-glob-routes/src/react-router-helper-shared.ts
+++ b/packages/vite-glob-routes/src/react-router-helper-shared.ts
@@ -235,6 +235,7 @@ export function resolveAssetPathsByRouteId(
 }
 
 // general vite manifest utility to map production asset
+// TODO: differentiate asset types? (e.g. css, js, etc..)
 function resolveManifestAssets(files: string[], manifest: Manifest) {
   const entryKeys = new Set<string>();
 

--- a/packages/vite-glob-routes/src/react-router-helper-shared.ts
+++ b/packages/vite-glob-routes/src/react-router-helper-shared.ts
@@ -235,7 +235,6 @@ export function resolveAssetPathsByRouteId(
 }
 
 // general vite manifest utility to map production asset
-// TODO: differentiate asset types? (e.g. css, js, etc..)
 function resolveManifestAssets(files: string[], manifest: Manifest) {
   const entryKeys = new Set<string>();
 
@@ -247,6 +246,8 @@ function resolveManifestAssets(files: string[], manifest: Manifest) {
       for (const nextKey of e.imports ?? []) {
         collectEnryKeysRecursive(nextKey);
       }
+      // TODO: css?
+      e.css;
     }
   }
 

--- a/packages/vite-glob-routes/src/react-router.ts
+++ b/packages/vite-glob-routes/src/react-router.ts
@@ -5,6 +5,8 @@ import { createGlobPageRoutes } from "./react-router-utils";
 
 // TODO: proper peer-dependency version range
 
+// TODO: separate files for client and server? (currently all exported from "@hiogawa/vite-glob-routes/dist/react-router")
+
 //
 // provide "react-router" RouterObject tree (only type dependency)
 //
@@ -34,7 +36,9 @@ export {
 
 export {
   initializeClientRoutes,
-  getExtraRouteInfo,
+  getClientGlobal,
+  getPagePrefetchLinks,
+  type ClientGlobal,
 } from "./react-router-helper-client";
 
 export {

--- a/packages/vite-glob-routes/src/react-router.ts
+++ b/packages/vite-glob-routes/src/react-router.ts
@@ -32,4 +32,12 @@ export {
   type ServerRouterResult,
 } from "./react-router-helper-server";
 
-export { initializeClientRoutes } from "./react-router-helper-client";
+export {
+  initializeClientRoutes,
+  getExtraRouteInfo,
+} from "./react-router-helper-client";
+
+export {
+  type ExtraRouterInfo,
+  resolveAssetPathsByRouteId,
+} from "./react-router-helper-shared";


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/vite-plugins/issues/40

~Idea is something like this, but the boundary of plugin/app is becoming messy.
Somehow I'm resisting again introducing helper component/hook in the plugin (e.g. context, hook).
Especially we need a clean way to deal with `ExtraRouterInfo` global.~

Ended up introducing honest `ClinetGlobal`, which makes it easy to add more client helpers.