### PR TITLE
(poc) chore: implement jws

### DIFF
--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -23,7 +23,6 @@
     "@hiogawa/query-proxy": "0.1.1-pre.3",
     "@hiogawa/tiny-rpc": "^0.2.2",
     "@hiogawa/unocss-preset-antd": "2.2.1-pre.3",
-    "@hiogawa/utils": "1.4.2-pre.12",
     "@hiogawa/utils-experimental": "^0.1.0",
     "@hiogawa/vite-glob-routes": "workspace:*",
     "@hiogawa/vite-import-index-html": "workspace:*",

--- a/packages/demo/src/rpc/server.ts
+++ b/packages/demo/src/rpc/server.ts
@@ -11,14 +11,14 @@ export const rpcRoutes = {
     const ctx = getRequestContext();
     tinyassert(!ctx.session.user, "already logged in");
     ctx.session.user = { name: input.name };
-    ctx.commitSession();
+    await ctx.commitSession();
   }),
 
   logout: async () => {
     const ctx = getRequestContext();
     tinyassert(ctx.session.user, "not logged in");
     ctx.session = {};
-    ctx.commitSession();
+    await ctx.commitSession();
   },
 
   me: async () => {

--- a/packages/demo/src/server/session.ts
+++ b/packages/demo/src/server/session.ts
@@ -1,7 +1,8 @@
 import type { RequestHandler } from "@hattip/compose";
-import { tinyassert, wrapError } from "@hiogawa/utils";
+import { tinyassert, wrapErrorAsync } from "@hiogawa/utils";
 import * as cookieLib from "cookie";
 import { z } from "zod";
+import { jwsSign, jwsVerify } from "../utils/jws";
 
 // session api exposed via request context
 
@@ -20,7 +21,7 @@ type SessionData = z.infer<typeof Z_SESSION_DATA>;
 declare module "@hattip/compose" {
   interface RequestContextExtensions {
     session: SessionData;
-    commitSession: () => void;
+    commitSession: () => Promise<void>;
   }
 }
 
@@ -30,13 +31,13 @@ declare module "@hattip/compose" {
 
 export function sessionHandler(): RequestHandler {
   return async (ctx) => {
-    ctx.session = readCookieSession(
+    ctx.session = await readCookieSession(
       ctx.request.headers.get("cookie") ?? undefined
     );
 
     let setCookie: string | undefined;
-    ctx.commitSession = () => {
-      setCookie = writeCookieSession(ctx.session);
+    ctx.commitSession = async () => {
+      setCookie = await writeCookieSession(ctx.session);
     };
 
     // TODO: check status?
@@ -49,15 +50,21 @@ export function sessionHandler(): RequestHandler {
 }
 
 const COOKIE_SESSION_KEY = "__session";
+const JWS_SECRET = "__secret";
 
-function readCookieSession(cookie?: string): SessionData {
+async function readCookieSession(cookie?: string): Promise<SessionData> {
   if (cookie) {
     const cookieRecord = cookieLib.parse(cookie);
     const value = cookieRecord[COOKIE_SESSION_KEY];
     if (value) {
-      const parsed = wrapError(() =>
-        Z_SESSION_DATA.parse(JSON.parse(decodeURIComponent(value)))
-      );
+      const parsed = await wrapErrorAsync(async () => {
+        const verified = await jwsVerify({
+          token: value,
+          algorithms: ["HS256"],
+          secret: JWS_SECRET,
+        });
+        return Z_SESSION_DATA.parse(verified.payload);
+      });
       if (parsed.ok) {
         return parsed.value;
       }
@@ -66,17 +73,18 @@ function readCookieSession(cookie?: string): SessionData {
   return SESSION_DATA_DEFAULT;
 }
 
-function writeCookieSession(session: SessionData): string {
-  const cookie = cookieLib.serialize(
-    COOKIE_SESSION_KEY,
-    encodeURIComponent(JSON.stringify(session)),
-    {
-      httpOnly: true,
-      secure: true,
-      sameSite: "lax",
-      path: "/",
-    }
-  );
+async function writeCookieSession(session: SessionData): Promise<string> {
+  const token = await jwsSign({
+    header: { alg: "HS256" },
+    payload: session,
+    secret: JWS_SECRET,
+  });
+  const cookie = cookieLib.serialize(COOKIE_SESSION_KEY, token, {
+    httpOnly: true,
+    secure: true,
+    sameSite: "lax",
+    path: "/",
+  });
   tinyassert(cookie.length < 2 ** 12, "too large cookie session");
   return cookie;
 }

--- a/packages/demo/src/utils/jws.test.ts
+++ b/packages/demo/src/utils/jws.test.ts
@@ -5,6 +5,7 @@ describe("jws", () => {
   it("basic", async () => {
     const secret = "asdfjkl;asdfjkl;asdfjkl;";
     const token = await jwsSign({
+      header: { alg: "HS256" },
       payload: { hello: "world", utf: "콘솔🐈" },
       secret,
     });
@@ -12,7 +13,7 @@ describe("jws", () => {
       '"eyJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwidXRmIjoi7L2Y7IaU8J-QiCJ9.1PVKyDo4Ew2zzdR9yUfGic2J8yddS5KJHUrBpYcjtao"'
     );
 
-    const verified = await jwsVerify({ token, secret });
+    const verified = await jwsVerify({ token, secret, algorithms: ["HS256"] });
     expect(verified).toMatchInlineSnapshot(`
       {
         "payload": {

--- a/packages/demo/src/utils/jws.test.ts
+++ b/packages/demo/src/utils/jws.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { jwsSign, jwsVerify } from "./jws";
+
+describe("jws", () => {
+  it("basic", async () => {
+    const secret = "asdfjkl;asdfjkl;asdfjkl;";
+    const token = await jwsSign({
+      payload: { hello: "world", utf: "콘솔🐈" },
+      secret,
+    });
+    expect(token).toMatchInlineSnapshot(
+      '"eyJhbGciOiJIUzI1NiJ9.eyJoZWxsbyI6IndvcmxkIiwidXRmIjoi7L2Y7IaU8J-QiCJ9.1PVKyDo4Ew2zzdR9yUfGic2J8yddS5KJHUrBpYcjtao"'
+    );
+
+    const verified = await jwsVerify({ token, secret });
+    expect(verified).toMatchInlineSnapshot(`
+      {
+        "payload": {
+          "hello": "world",
+          "utf": "콘솔🐈",
+        },
+      }
+    `);
+  });
+});

--- a/packages/demo/src/utils/jws.test.ts
+++ b/packages/demo/src/utils/jws.test.ts
@@ -16,6 +16,9 @@ describe("jws", () => {
     const verified = await jwsVerify({ token, secret, algorithms: ["HS256"] });
     expect(verified).toMatchInlineSnapshot(`
       {
+        "header": {
+          "alg": "HS256",
+        },
         "payload": {
           "hello": "world",
           "utf": "콘솔🐈",

--- a/packages/demo/src/utils/jws.ts
+++ b/packages/demo/src/utils/jws.ts
@@ -53,27 +53,32 @@ export async function jwsVerify({
 }) {
   // parse components
   const components = token.split(".");
-  tinyassert(components.length === 3);
+  tinyassert(components.length === 3, "invalid token components");
   const [headerB64, payloadB64, signatureB64] = components;
-  tinyassert(headerB64 && payloadB64 && signatureB64);
+  tinyassert(
+    headerB64 && payloadB64 && signatureB64,
+    "invalid token components (2)"
+  );
 
   // parse header and payload
   const headerResult = jsonFromB64(headerB64);
   const payloadResult = jsonFromB64(payloadB64);
-  tinyassert(headerResult.ok && payloadResult.ok);
+  tinyassert(headerResult.ok, "invalid header");
+  tinyassert(payloadResult.ok, "invalid payload");
   const header = headerResult.data;
   const payload = payloadResult.data;
   tinyassert(
     header &&
       typeof header === "object" &&
       "alg" in header &&
-      typeof header.alg === "string"
+      typeof header.alg === "string",
+    "invalid header 'alg'"
   );
 
   // check algorihtm
   const algorithm = CRYPTO_ALGORITHM_MAP.get(header.alg);
-  tinyassert(algorithm);
-  tinyassert(algorithms.includes(header.alg));
+  tinyassert(algorithm, "unsupported 'alg'");
+  tinyassert(algorithms.includes(header.alg), "disallowed 'alg'");
 
   // verify signature
   const dataB64 = headerB64 + "." + payloadB64;

--- a/packages/demo/src/utils/jws.ts
+++ b/packages/demo/src/utils/jws.ts
@@ -50,7 +50,7 @@ export async function jwsVerify({
   token: string;
   secret: string;
   algorithms: string[];
-}): Promise<{ payload: unknown }> {
+}) {
   // parse components
   const components = token.split(".");
   tinyassert(components.length === 3);
@@ -58,20 +58,22 @@ export async function jwsVerify({
   tinyassert(headerB64 && payloadB64 && signatureB64);
 
   // parse header and payload
-  const header = jsonFromB64(headerB64);
-  const payload = jsonFromB64(payloadB64);
-  tinyassert(header.ok && payload.ok);
+  const headerResult = jsonFromB64(headerB64);
+  const payloadResult = jsonFromB64(payloadB64);
+  tinyassert(headerResult.ok && payloadResult.ok);
+  const header = headerResult.data;
+  const payload = payloadResult.data;
   tinyassert(
-    header.data &&
-      typeof header.data === "object" &&
-      "alg" in header.data &&
-      typeof header.data.alg === "string"
+    header &&
+      typeof header === "object" &&
+      "alg" in header &&
+      typeof header.alg === "string"
   );
 
   // check algorihtm
-  const algorithm = CRYPTO_ALGORITHM_MAP.get(header.data.alg);
+  const algorithm = CRYPTO_ALGORITHM_MAP.get(header.alg);
   tinyassert(algorithm);
-  tinyassert(algorithms.includes(header.data.alg));
+  tinyassert(algorithms.includes(header.alg));
 
   // verify signature
   const dataB64 = headerB64 + "." + payloadB64;
@@ -83,7 +85,7 @@ export async function jwsVerify({
   });
   tinyassert(isValid, "invalid signature");
 
-  return { payload: payload.data };
+  return { header, payload };
 }
 
 //

--- a/packages/demo/src/utils/jws.ts
+++ b/packages/demo/src/utils/jws.ts
@@ -1,0 +1,152 @@
+import crypto from "node:crypto";
+import { tinyassert } from "@hiogawa/utils";
+
+//
+// quick and dirty JWS based on crypto.subtle and atob/btoa
+//
+// cf.
+// https://github.com/remix-run/remix/blob/100ecd3ea686eeec14f17fa908116b74aebdb91c/packages/remix-cloudflare/crypto.ts#L14-L21
+// https://github.com/auth0/node-jws/blob/b9fb8d30e9c009ade6379f308590f1b0703eefc3/lib/sign-stream.js
+// https://github.com/panva/jose/blob/e2836e6aaaddecde053018884abb040908f186fd/src/runtime/browser/sign.ts
+//
+
+// hard-code algorithm
+const JWS_ALGORITHM = "HS256";
+const CRYPTO_SUBTLE_ALGORITHM = { name: "HMAC", hash: "SHA-256" };
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+export async function jwsSign({
+  payload,
+  secret,
+}: {
+  payload: unknown;
+  secret: string;
+}): Promise<string> {
+  const header = { alg: JWS_ALGORITHM };
+  const dataB64 = jsonToB64(header) + "." + jsonToB64(payload);
+  const signature = await cryptoSign({
+    data: textEncoder.encode(dataB64),
+    secret: textEncoder.encode(secret),
+  });
+  const signatureB64 = toB64(new Uint8Array(signature));
+  const token = dataB64 + "." + signatureB64;
+  return token;
+}
+
+export async function jwsVerify({
+  token,
+  secret,
+}: {
+  token: string;
+  secret: string;
+}): Promise<{ payload: unknown }> {
+  // parse components
+  const components = token.split(".");
+  tinyassert(components.length === 3);
+  const [headerB64, payloadB64, signatureB64] = components;
+  tinyassert(headerB64 && payloadB64 && signatureB64);
+
+  // parse header and payload
+  const header = jsonFromB64(headerB64);
+  const payload = jsonFromB64(payloadB64);
+  tinyassert(header.ok && payload.ok);
+  tinyassert(
+    header.data &&
+      typeof header.data === "object" &&
+      "alg" in header.data &&
+      header.data.alg === JWS_ALGORITHM
+  );
+
+  // verify signature
+  const dataB64 = headerB64 + "." + payloadB64;
+  const isValid = await cryptoVerify({
+    data: textEncoder.encode(dataB64),
+    secret: textEncoder.encode(secret),
+    signature: fromB64(signatureB64),
+  });
+  tinyassert(isValid, "invalid signature");
+
+  return { payload: payload.data };
+}
+
+//
+// base64url
+//
+// cf. https://developer.mozilla.org/en-US/docs/Glossary/Base64#the_unicode_problem
+//
+
+function toB64(bin: Uint8Array): string {
+  const strBin = Array.from(bin, (c) => String.fromCharCode(c)).join("");
+  const base64 = btoa(strBin);
+  const base64url = base64
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+  return base64url;
+}
+
+function fromB64(base64url: string): Uint8Array {
+  const base64 = base64url.replace(/-/g, "+").replace(/_/g, "/");
+  const strBin = atob(base64);
+  const bin = Uint8Array.from(strBin, (c) => c.codePointAt(0) ?? 0);
+  return bin;
+}
+
+function jsonToB64(value: unknown): string {
+  return toB64(textEncoder.encode(JSON.stringify(value)));
+}
+
+function jsonFromB64(encoded: string): { ok: boolean; data: unknown } {
+  const jsonString = textDecoder.decode(fromB64(encoded));
+  try {
+    return { ok: true, data: JSON.parse(jsonString) };
+  } catch (e) {
+    return { ok: false, data: e };
+  }
+}
+
+//
+// crypto.subtle wrapper
+//
+
+async function cryptoSign({
+  data,
+  secret,
+}: {
+  data: BufferSource;
+  secret: BufferSource;
+}): Promise<ArrayBuffer> {
+  const key = await cryptoImportKey({ secret, usage: "sign" });
+  return await crypto.subtle.sign(key.algorithm.name, key, data);
+}
+
+async function cryptoVerify({
+  data,
+  signature,
+  secret,
+}: {
+  data: BufferSource;
+  signature: BufferSource;
+  secret: BufferSource;
+}): Promise<boolean> {
+  const key = await cryptoImportKey({ secret, usage: "verify" });
+  return await crypto.subtle.verify(key.algorithm.name, key, signature, data);
+}
+
+async function cryptoImportKey({
+  secret,
+  usage,
+}: {
+  secret: BufferSource;
+  usage: "sign" | "verify";
+}) {
+  return crypto.subtle.importKey(
+    "raw",
+    secret,
+    CRYPTO_SUBTLE_ALGORITHM,
+    false,
+    [usage]
+  );
+}

--- a/packages/demo/src/utils/jws.ts
+++ b/packages/demo/src/utils/jws.ts
@@ -37,7 +37,7 @@ export async function jwsSign({
     secret: textEncoder.encode(secret),
     algorithm,
   });
-  const signatureB64 = toB64(new Uint8Array(signature));
+  const signatureB64 = toB64(signature);
   const token = dataB64 + "." + signatureB64;
   return token;
 }
@@ -131,14 +131,15 @@ async function cryptoSign({
   secret,
   algorithm,
 }: {
-  data: BufferSource;
-  secret: BufferSource;
+  data: Uint8Array;
+  secret: Uint8Array;
   algorithm: HmacImportParams;
-}): Promise<ArrayBuffer> {
+}): Promise<Uint8Array> {
   const key = await crypto.subtle.importKey("raw", secret, algorithm, false, [
     "sign",
   ]);
-  return await crypto.subtle.sign(key.algorithm.name, key, data);
+  const signature = await crypto.subtle.sign(key.algorithm.name, key, data);
+  return new Uint8Array(signature);
 }
 
 async function cryptoVerify({
@@ -147,9 +148,9 @@ async function cryptoVerify({
   secret,
   algorithm,
 }: {
-  data: BufferSource;
-  signature: BufferSource;
-  secret: BufferSource;
+  data: Uint8Array;
+  signature: Uint8Array;
+  secret: Uint8Array;
   algorithm: HmacImportParams;
 }): Promise<boolean> {
   const key = await crypto.subtle.importKey("raw", secret, algorithm, false, [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,9 +77,6 @@ importers:
       '@hiogawa/unocss-preset-antd':
         specifier: 2.2.1-pre.3
         version: 2.2.1-pre.3(@unocss/preset-uno@0.53.5)(unocss@0.53.1)
-      '@hiogawa/utils':
-        specifier: 1.4.2-pre.12
-        version: 1.4.2-pre.12
       '@hiogawa/utils-experimental':
         specifier: ^0.1.0
         version: 0.1.0
@@ -1083,10 +1080,6 @@ packages:
 
   /@hiogawa/utils-experimental@0.1.0:
     resolution: {integrity: sha512-/iXmtdJlhBGfNK+bt4gNipdRPaHGkHeXbW+yY9RLB4dC2kOWoEpKY2aZjFugFRXEGtz3luEYVeLpV4VWEuq5kA==}
-    dev: true
-
-  /@hiogawa/utils@1.4.2-pre.12:
-    resolution: {integrity: sha512-YkNSrK+h1/iFeshHC+9YAhux1kUO0JJ+hjZdlcT5gJR8hW9GJpOK8xwOpAE1fVjRE+QWupKwPx33tJUXCGPoPA==}
     dev: true
 
   /@hiogawa/utils@1.4.2-pre.15:


### PR DESCRIPTION
- base https://github.com/hi-ogawa/vite-plugins/pull/75

Just wondering what it takes to make own jws since existing library (the ones from auth0 or https://github.com/panva/jose) feels a bit bloated (not the api but the implementation).
Also to get familiar with `crypto.subtle` (aka webcrypto) api.

Maybe I'll move it to https://github.com/hi-ogawa/js-utils as usual...?