### PR TITLE
chore: set `"type": "module"`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@hiogawa/vite-plugins-monorepo",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "pnpm -r build",
     "dev": "run-p dev:*",

--- a/packages/demo/misc/vercel/build.sh
+++ b/packages/demo/misc/vercel/build.sh
@@ -12,7 +12,7 @@ set -eu -o pipefail
 #     functions/
 #       index.func/
 #         .vc-config.json
-#         index.js         = dist/server/index.mjs (bundled)
+#         index.js         = bundled dist/server/index.js or mjs
 
 # clean
 rm -rf .vercel/output
@@ -27,5 +27,5 @@ cp -r dist/client/assets .vercel/output/static/assets
 
 # serverless
 mkdir -p .vercel/output/functions/index.func
-npx esbuild dist/server/index.mjs --outfile=.vercel/output/functions/index.func/index.js --bundle --minify --format=esm --platform=browser --metafile=dist/server/esbuild-metafile.json
+npx esbuild dist/server/index.js --outfile=.vercel/output/functions/index.func/index.js --bundle --minify --format=esm --platform=browser --metafile=dist/server/esbuild-metafile.json
 cp misc/vercel/.vc-config.json .vercel/output/functions/index.func/.vc-config.json

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -10,7 +10,7 @@
     "build:vite": "vite build && vite build --ssr",
     "build:vercel": "bash misc/vercel/build.sh",
     "build-preview": "SERVER_ENTRY=./src/server/adapter-preview.ts run-s build:vite",
-    "preview": "node ./dist/server/index.mjs",
+    "preview": "node ./dist/server/index.js",
     "test-e2e": "playwright test",
     "release": "vercel deploy --prebuilt .",
     "release-production": "vercel deploy --prebuilt . --prod"

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@hiogawa/vite-plugins-demo",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "run-p dev:*",
     "dev:vite": "vite",

--- a/packages/demo/playwright.config.ts
+++ b/packages/demo/playwright.config.ts
@@ -1,7 +1,7 @@
 import process from "node:process";
 import { defineConfig } from "@playwright/test";
 
-const PORT = Number(process.env["PORT"] ?? "4456");
+const PORT = Number((process.env.PORT ??= "4456"));
 const command = process.env["E2E_COMMAND"] ?? `pnpm dev:vite`;
 
 export default defineConfig({
@@ -26,10 +26,6 @@ export default defineConfig({
   webServer: {
     command: command + ` >> dev-e2e.log 2>&1`,
     port: PORT,
-    env: {
-      ...(process.env as any),
-      PORT,
-    },
     reuseExistingServer: true,
   },
   forbidOnly: Boolean(process.env["CI"]),


### PR DESCRIPTION
## todo

- [x] a few rename since vite emits `xxx.js` instead of `xxx.mjs`
- [x] test on staing