### PR TITLE
refactor(glob-routes)!: separate non-lazy client routes

### DIFF
--- a/.changeset/rich-lamps-turn.md
+++ b/.changeset/rich-lamps-turn.md
@@ -1,0 +1,5 @@
+---
+"@hiogawa/vite-glob-routes": major
+---
+
+refactor!: split non-lazy client routes entry

--- a/examples/spa/src/client/index.tsx
+++ b/examples/spa/src/client/index.tsx
@@ -1,5 +1,5 @@
 import { tinyassert } from "@hiogawa/utils";
-import { globPageRoutesClientLazy } from "@hiogawa/vite-glob-routes/dist/react-router/client";
+import { globPageRoutesClient } from "@hiogawa/vite-glob-routes/dist/react-router/client";
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider, createBrowserRouter } from "react-router-dom";
@@ -8,7 +8,7 @@ async function main() {
   const el = document.getElementById("root");
   tinyassert(el);
 
-  const { routes } = globPageRoutesClientLazy();
+  const { routes } = globPageRoutesClient();
   const router = createBrowserRouter(routes);
   const root = (
     <React.StrictMode>

--- a/examples/ssr/src/client/index.tsx
+++ b/examples/ssr/src/client/index.tsx
@@ -1,6 +1,6 @@
 import { tinyassert } from "@hiogawa/utils";
 import {
-  globPageRoutesClientLazy,
+  globPageRoutesClient,
   initializeClientRoutes,
 } from "@hiogawa/vite-glob-routes/dist/react-router/client";
 import React from "react";
@@ -11,7 +11,7 @@ async function main() {
   const el = document.getElementById("root");
   tinyassert(el);
 
-  const { routes } = globPageRoutesClientLazy();
+  const { routes } = globPageRoutesClient();
   await initializeClientRoutes({ routes });
 
   const router = createBrowserRouter(routes);

--- a/packages/demo/playwright.config.ts
+++ b/packages/demo/playwright.config.ts
@@ -6,8 +6,10 @@ const command = process.env["E2E_COMMAND"] ?? `pnpm dev:vite`;
 
 export default defineConfig({
   testDir: "e2e",
+  retries: process.env.CI ? 1 : 0,
   use: {
     baseURL: `http://localhost:${PORT}`,
+    trace: "on-first-retry",
   },
   projects: [
     {

--- a/packages/demo/src/client/index.tsx
+++ b/packages/demo/src/client/index.tsx
@@ -1,7 +1,7 @@
 import "virtual:uno.css";
 import { tinyassert } from "@hiogawa/utils";
 import {
-  globPageRoutesClientLazy,
+  globPageRoutesClient,
   initializeClientRoutes,
 } from "@hiogawa/vite-glob-routes/dist/react-router/client";
 import React from "react";
@@ -12,7 +12,7 @@ async function main() {
   const el = document.getElementById("root");
   tinyassert(el);
 
-  const { routes } = globPageRoutesClientLazy();
+  const { routes } = globPageRoutesClient();
   await initializeClientRoutes({ routes });
 
   const router = createBrowserRouter(routes);

--- a/packages/vite-glob-routes/package.json
+++ b/packages/vite-glob-routes/package.json
@@ -15,6 +15,10 @@
       "import": "./dist/react-router/client.js",
       "types": "./dist/react-router/client.d.ts"
     },
+    "./dist/react-router/client-eager": {
+      "import": "./dist/react-router/client-eager.js",
+      "types": "./dist/react-router/client-eager.d.ts"
+    },
     "./dist/react-router/server": {
       "import": "./dist/react-router/server.js",
       "types": "./dist/react-router/server.d.ts"

--- a/packages/vite-glob-routes/package.json
+++ b/packages/vite-glob-routes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/vite-glob-routes",
-  "version": "0.6.0",
+  "version": "0.6.1-pre.0",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/vite-glob-routes/src/react-router/client-eager.ts
+++ b/packages/vite-glob-routes/src/react-router/client-eager.ts
@@ -1,0 +1,6 @@
+import virtualPageRoutesClient from "virtual:@hiogawa/vite-glob-routes/internal/pageRoutesClient";
+import { createGlobPageRoutes } from "./route-utils";
+
+export function globPageRoutesClientEager() {
+  return createGlobPageRoutes(virtualPageRoutesClient);
+}

--- a/packages/vite-glob-routes/src/react-router/client.ts
+++ b/packages/vite-glob-routes/src/react-router/client.ts
@@ -1,12 +1,7 @@
-import virtualPageRoutesClient from "virtual:@hiogawa/vite-glob-routes/internal/pageRoutesClient";
 import vurtialPageRoutesClientLazy from "virtual:@hiogawa/vite-glob-routes/internal/pageRoutesClientLazy";
 import { createGlobPageRoutes } from "./route-utils";
 
 export function globPageRoutesClient() {
-  return createGlobPageRoutes(virtualPageRoutesClient);
-}
-
-export function globPageRoutesClientLazy() {
   return createGlobPageRoutes(vurtialPageRoutesClientLazy);
 }
 

--- a/packages/vite-glob-routes/src/react-router/client.ts
+++ b/packages/vite-glob-routes/src/react-router/client.ts
@@ -1,8 +1,8 @@
-import vurtialPageRoutesClientLazy from "virtual:@hiogawa/vite-glob-routes/internal/pageRoutesClientLazy";
+import virtualPageRoutesClientLazy from "virtual:@hiogawa/vite-glob-routes/internal/pageRoutesClientLazy";
 import { createGlobPageRoutes } from "./route-utils";
 
 export function globPageRoutesClient() {
-  return createGlobPageRoutes(vurtialPageRoutesClientLazy);
+  return createGlobPageRoutes(virtualPageRoutesClientLazy);
 }
 
 export {

--- a/packages/vite-glob-routes/tsup.config.ts
+++ b/packages/vite-glob-routes/tsup.config.ts
@@ -9,6 +9,7 @@ export default defineConfig([
   {
     entry: [
       "src/react-router/client.ts",
+      "src/react-router/client-eager.ts",
       "src/react-router/server.ts",
       "src/hattip.ts",
     ],


### PR DESCRIPTION
Having both eager/lazy glob imports in one file was tricky to debug sometime, so let's just split it for explicit-ness:

https://github.com/hi-ogawa/vite-plugins/blob/60eb4903177c4fab942ebe6609c51d32df4cd216/packages/vite-glob-routes/src/react-router/client.ts#L1-L2
