### PR TITLE
feat(glob-routes): loader data preload

### DIFF
--- a/packages/demo/src/client/index.tsx
+++ b/packages/demo/src/client/index.tsx
@@ -30,6 +30,7 @@ async function main() {
     routes,
     routesMeta,
     manifest: serverHandoff.__viteManifest,
+    serverLoaderRouteIds: serverHandoff.__serverLoaderRouteIds,
   });
   setupGlobalPreloadHandler();
 

--- a/packages/vite-glob-routes/src/react-router/features/preload/client.ts
+++ b/packages/vite-glob-routes/src/react-router/features/preload/client.ts
@@ -98,15 +98,21 @@ function injectPreloadLinks(url: URL) {
   }
 
   for (const href of deps.css) {
-    // TODO
-    href;
+    const found = document.querySelector(`link[href="${href}"]`);
+    if (!found) {
+      const el = document.createElement("link");
+      el.setAttribute("rel", "preload");
+      el.setAttribute("as", "style");
+      el.setAttribute("href", href);
+      document.body.appendChild(el);
+    }
   }
 
   for (const href of deps.data ?? []) {
     const found = document.querySelector(`link[href="${href}"]`);
     if (!found) {
       const el = document.createElement("link");
-      el.setAttribute("rel", "prefetch");
+      el.setAttribute("rel", "preload");
       el.setAttribute("as", "fetch");
       el.setAttribute("href", href);
       document.body.appendChild(el);

--- a/packages/vite-glob-routes/src/react-router/features/preload/client.ts
+++ b/packages/vite-glob-routes/src/react-router/features/preload/client.ts
@@ -114,6 +114,9 @@ function injectPreloadLinks(url: URL) {
       const el = document.createElement("link");
       el.setAttribute("rel", "preload");
       el.setAttribute("as", "fetch");
+      // https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/preload#cors-enabled_fetches
+      // > even when the fetch is not cross-origin.
+      el.setAttribute("crossorigin", "true");
       el.setAttribute("href", href);
       document.body.appendChild(el);
     }

--- a/packages/vite-glob-routes/src/react-router/features/preload/shared.ts
+++ b/packages/vite-glob-routes/src/react-router/features/preload/shared.ts
@@ -5,7 +5,7 @@ import type { RoutesMeta } from "../../route-utils";
 export type RouteDependencies = {
   js: string[];
   css: string[]; // TODO: not tested yet
-  // data?: string[]; // TODO: data request too?
+  data?: string[];
 };
 
 function mergeRouteDependencies(ls: RouteDependencies[]): RouteDependencies {


### PR DESCRIPTION
- follow up https://github.com/hi-ogawa/vite-plugins/pull/96
- closes https://github.com/hi-ogawa/vite-plugins/issues/101

For server loader data request, it suffices to just add prefetch link, but for client loader (like in `examples/spa`), it might requires hacking some react-router internal.

--- 

Or maybe it's trickier than I thought?

<details>

![image](https://github.com/hi-ogawa/vite-plugins/assets/4232207/1777d165-3de0-4dbf-905b-f6ee17853d19)

</details>