### PR TITLE
feat: create `vite-null-export` package

### DIFF
--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -43,6 +43,7 @@
     "@vavite/connect": "^1.8.1",
     "@vitejs/plugin-react": "^4.0.0",
     "cookie": "^0.5.0",
+    "es-module-lexer": "^1.3.1",
     "express": "^4.18.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -44,7 +44,6 @@
     "@vavite/connect": "^1.8.1",
     "@vitejs/plugin-react": "^4.0.0",
     "cookie": "^0.5.0",
-    "es-module-lexer": "^1.3.1",
     "express": "^4.18.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -31,6 +31,7 @@
     "@hiogawa/utils-hattip": "0.0.1-pre.1",
     "@hiogawa/vite-glob-routes": "workspace:*",
     "@hiogawa/vite-import-dev-server": "workspace:*",
+    "@hiogawa/vite-null-export": "workspace:*",
     "@iconify-json/ri": "^1.1.9",
     "@tanstack/react-query": "^4.29.14",
     "@tanstack/react-query-devtools": "^4.29.14",

--- a/packages/demo/src/routes/layout.tsx
+++ b/packages/demo/src/routes/layout.tsx
@@ -9,7 +9,6 @@ import {
   useNavigation,
   useRouteError,
 } from "react-router-dom";
-import { getRequestContext } from "../server/request-context";
 import { useEffectNoStrict } from "../utils/misc-react";
 import { ReactQueryWrapper } from "../utils/react-query-utils";
 
@@ -17,9 +16,6 @@ export const handle = "root-handle";
 
 export function Component() {
   useTopProgressBar();
-
-  // test viteNullExportPlugin
-  import.meta.env.SSR && console.log(getRequestContext().url);
 
   return (
     <ReactQueryWrapper>

--- a/packages/demo/src/routes/layout.tsx
+++ b/packages/demo/src/routes/layout.tsx
@@ -9,6 +9,7 @@ import {
   useNavigation,
   useRouteError,
 } from "react-router-dom";
+import { getRequestContext } from "../server/request-context";
 import { useEffectNoStrict } from "../utils/misc-react";
 import { ReactQueryWrapper } from "../utils/react-query-utils";
 
@@ -16,6 +17,9 @@ export const handle = "root-handle";
 
 export function Component() {
   useTopProgressBar();
+
+  // test viteNullExportPlugin
+  import.meta.env.SSR && console.log(getRequestContext().url);
 
   return (
     <ReactQueryWrapper>

--- a/packages/demo/vite.config.ts
+++ b/packages/demo/vite.config.ts
@@ -4,7 +4,7 @@ import { importDevServerPlugin } from "@hiogawa/vite-import-dev-server";
 import vaviteConnect from "@vavite/connect";
 import react from "@vitejs/plugin-react";
 import unocss from "unocss/vite";
-import { defineConfig } from "vite";
+import { FilterPattern, type Plugin, createFilter, defineConfig } from "vite";
 
 export default defineConfig((ctx) => ({
   plugins: [
@@ -18,6 +18,7 @@ export default defineConfig((ctx) => ({
       handlerEntry:
         process.env["SERVER_ENTRY"] ?? "./src/server/adapter-connect.ts",
     }),
+    viteEmptifyModulePlugin(),
   ],
   build: {
     outDir: ctx.ssrBuild ? "dist/server" : "dist/client",
@@ -32,3 +33,38 @@ export default defineConfig((ctx) => ({
     : undefined,
   clearScreen: false,
 }));
+
+// similar to https://github.com/remix-run/remix/blob/80c6842f547b7e83b58f1963894b07ad18c2dfe2/packages/remix-dev/compiler/plugins/emptyModules.ts#L10
+// but for vite, we needs to fake esm exports so we use es-module-lexer to extract export names.
+function viteEmptifyModulePlugin(pluginOptions?: {
+  clientOnly?: FilterPattern;
+  serverOnly?: FilterPattern;
+  exclude?: FilterPattern;
+}): Plugin {
+  const exclude = pluginOptions?.exclude ?? ["**/node_modules/**"];
+  const serverOnly = createFilter(
+    pluginOptions?.serverOnly ?? ["**/server/**", "**/*.server.*"],
+    exclude
+  );
+  const clientOnly = createFilter(
+    pluginOptions?.clientOnly ?? ["**/client/**", "**/*.client.*"],
+    exclude
+  );
+  return {
+    name: viteEmptifyModulePlugin.name,
+    enforce: "pre",
+    async transform(code, id, options) {
+      if (options?.ssr ? clientOnly(id) : serverOnly(id)) {
+        const lib = await import("es-module-lexer");
+        await lib.init;
+        const [_import, exports] = lib.parse(code);
+        return exports
+          .map((e) =>
+            e.n === "default" ? `export default {}` : `export var ${e.n} = {}`
+          )
+          .join("\n");
+      }
+      return undefined;
+    },
+  };
+}

--- a/packages/demo/vite.config.ts
+++ b/packages/demo/vite.config.ts
@@ -19,7 +19,7 @@ export default defineConfig((ctx) => ({
       handlerEntry:
         process.env["SERVER_ENTRY"] ?? "./src/server/adapter-connect.ts",
     }),
-    viteNullExportPlugin(),
+    viteNullExportPlugin({ debug: true }),
   ],
   build: {
     outDir: ctx.ssrBuild ? "dist/server" : "dist/client",

--- a/packages/demo/vite.config.ts
+++ b/packages/demo/vite.config.ts
@@ -1,10 +1,11 @@
 import process from "node:process";
 import globRoutesPlugin from "@hiogawa/vite-glob-routes";
 import { importDevServerPlugin } from "@hiogawa/vite-import-dev-server";
+import { viteNullExportPlugin } from "@hiogawa/vite-null-export";
 import vaviteConnect from "@vavite/connect";
 import react from "@vitejs/plugin-react";
 import unocss from "unocss/vite";
-import { FilterPattern, type Plugin, createFilter, defineConfig } from "vite";
+import { defineConfig } from "vite";
 
 export default defineConfig((ctx) => ({
   plugins: [
@@ -18,7 +19,7 @@ export default defineConfig((ctx) => ({
       handlerEntry:
         process.env["SERVER_ENTRY"] ?? "./src/server/adapter-connect.ts",
     }),
-    viteEmptifyModulePlugin(),
+    viteNullExportPlugin(),
   ],
   build: {
     outDir: ctx.ssrBuild ? "dist/server" : "dist/client",
@@ -33,38 +34,3 @@ export default defineConfig((ctx) => ({
     : undefined,
   clearScreen: false,
 }));
-
-// similar to https://github.com/remix-run/remix/blob/80c6842f547b7e83b58f1963894b07ad18c2dfe2/packages/remix-dev/compiler/plugins/emptyModules.ts#L10
-// but for vite, we needs to fake esm exports so we use es-module-lexer to extract export names.
-function viteEmptifyModulePlugin(pluginOptions?: {
-  clientOnly?: FilterPattern;
-  serverOnly?: FilterPattern;
-  exclude?: FilterPattern;
-}): Plugin {
-  const exclude = pluginOptions?.exclude ?? ["**/node_modules/**"];
-  const serverOnly = createFilter(
-    pluginOptions?.serverOnly ?? ["**/server/**", "**/*.server.*"],
-    exclude
-  );
-  const clientOnly = createFilter(
-    pluginOptions?.clientOnly ?? ["**/client/**", "**/*.client.*"],
-    exclude
-  );
-  return {
-    name: viteEmptifyModulePlugin.name,
-    enforce: "pre",
-    async transform(code, id, options) {
-      if (options?.ssr ? clientOnly(id) : serverOnly(id)) {
-        const lib = await import("es-module-lexer");
-        await lib.init;
-        const [_import, exports] = lib.parse(code);
-        return exports
-          .map((e) =>
-            e.n === "default" ? `export default {}` : `export var ${e.n} = {}`
-          )
-          .join("\n");
-      }
-      return undefined;
-    },
-  };
-}

--- a/packages/demo/vite.config.ts
+++ b/packages/demo/vite.config.ts
@@ -19,7 +19,10 @@ export default defineConfig((ctx) => ({
       handlerEntry:
         process.env["SERVER_ENTRY"] ?? "./src/server/adapter-connect.ts",
     }),
-    viteNullExportPlugin({ debug: true }),
+    viteNullExportPlugin({
+      serverOnly: "**/server/**",
+      debug: true,
+    }),
   ],
   build: {
     outDir: ctx.ssrBuild ? "dist/server" : "dist/client",

--- a/packages/vite-null-export/README.md
+++ b/packages/vite-null-export/README.md
@@ -1,0 +1,8 @@
+# vite-null-export
+
+Vite port of remix's server/client-only file convention plugin https://github.com/remix-run/remix/blob/80c6842f547b7e83b58f1963894b07ad18c2dfe2/packages/remix-dev/compiler/plugins/emptyModules.ts#L10
+
+```sh
+pnpm build
+pnpm release
+```

--- a/packages/vite-null-export/README.md
+++ b/packages/vite-null-export/README.md
@@ -1,6 +1,29 @@
 # vite-null-export
 
-Vite port of remix's server/client-only file convention plugin https://github.com/remix-run/remix/blob/80c6842f547b7e83b58f1963894b07ad18c2dfe2/packages/remix-dev/compiler/plugins/emptyModules.ts#L10
+Vite port of remix's server-only file convention
+
+- https://remix.run/docs/en/main/file-conventions/-server
+- https://remix.run/docs/en/main/guides/gotchas#server-code-in-client-bundles
+- https://github.com/remix-run/remix/blob/80c6842f547b7e83b58f1963894b07ad18c2dfe2/packages/remix-dev/compiler/plugins/emptyModules.ts#L10
+
+## example
+
+```tsx
+// vite.config.ts
+
+import { defineConfig } from "vite";
+import { viteNullExportPlugin } from "@hiogawa/vite-null-export";
+
+export default defineConfig({
+  plugins: [
+    viteNullExportPlugin({
+      serverOnly: ["**/server/**", "**/*.server.*"],
+    }),
+  ],
+});
+```
+
+## development
 
 ```sh
 pnpm build

--- a/packages/vite-null-export/package.json
+++ b/packages/vite-null-export/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@hiogawa/vite-null-export",
+  "version": "0.0.0",
+  "homepage": "https://github.com/hi-ogawa/vite-plugins/tree/main/packages/vite-null-export",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hi-ogawa/vite-plugins",
+    "directory": "packages/vite-null-export"
+  },
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "release": "pnpm publish --no-git-checks --access public"
+  },
+  "dependencies": {
+    "es-module-lexer": "^1.3.1"
+  },
+  "devDependencies": {
+    "vite": "^4.4.4"
+  },
+  "peerDependencies": {
+    "vite": "*"
+  }
+}

--- a/packages/vite-null-export/src/index.ts
+++ b/packages/vite-null-export/src/index.ts
@@ -1,0 +1,43 @@
+import * as esModuleLexer from "es-module-lexer";
+import { type FilterPattern, type Plugin, createFilter } from "vite";
+import { name as packageName } from "../package.json";
+
+// similar to remix's https://github.com/remix-run/remix/blob/80c6842f547b7e83b58f1963894b07ad18c2dfe2/packages/remix-dev/compiler/plugins/emptyModules.ts#L10
+// but for vite, we needs to fake esm exports so we use es-module-lexer to extract export names.
+
+export function viteNullExportPlugin(pluginOptions?: {
+  clientOnly?: FilterPattern;
+  serverOnly?: FilterPattern;
+  exclude?: FilterPattern;
+}): Plugin {
+  const exclude = pluginOptions?.exclude ?? ["**/node_modules/**"];
+  const serverOnly = createFilter(
+    pluginOptions?.serverOnly ?? ["**/server/**", "**/*.server.*"],
+    exclude
+  );
+  const clientOnly = createFilter(
+    pluginOptions?.clientOnly ?? ["**/client/**", "**/*.client.*"],
+    exclude
+  );
+  return {
+    name: packageName,
+
+    // we don't enforce "pre" since es-module-lexer cannot reliably parse typescript file.
+    // so we rely on vite's default typescript transpilation.
+
+    async transform(code, id, options) {
+      if (options?.ssr ? clientOnly(id) : serverOnly(id)) {
+        await esModuleLexer.init;
+        const [_import, exports] = esModuleLexer.parse(code);
+        return exports
+          .map((e) =>
+            e.n === "default"
+              ? `export default null;\n`
+              : `export var ${e.n} = null;\n`
+          )
+          .join("");
+      }
+      return undefined;
+    },
+  };
+}

--- a/packages/vite-null-export/tsconfig.json
+++ b/packages/vite-null-export/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"]
+}

--- a/packages/vite-null-export/tsup.config.ts
+++ b/packages/vite-null-export/tsup.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,6 +185,9 @@ importers:
       '@hiogawa/vite-import-dev-server':
         specifier: workspace:*
         version: link:../vite-import-dev-server
+      '@hiogawa/vite-null-export':
+        specifier: workspace:*
+        version: link:../vite-null-export
       '@iconify-json/ri':
         specifier: ^1.1.9
         version: 1.1.9
@@ -265,6 +268,16 @@ importers:
         version: 4.4.4(@types/node@18.16.18)
 
   packages/vite-import-dev-server:
+    devDependencies:
+      vite:
+        specifier: ^4.4.4
+        version: 4.4.4(@types/node@18.16.18)
+
+  packages/vite-null-export:
+    dependencies:
+      es-module-lexer:
+        specifier: ^1.3.1
+        version: 1.3.1
     devDependencies:
       vite:
         specifier: ^4.4.4
@@ -2664,7 +2677,6 @@ packages:
 
   /es-module-lexer@1.3.1:
     resolution: {integrity: sha512-JUFAyicQV9mXc3YRxPnDlrfBKpqt6hUYzz9/boprUJHs4e4KVr3XwOF70doO6gwXUor6EWZJAyWAfKki84t20Q==}
-    dev: true
 
   /es-set-tostringtag@2.0.1:
     resolution: {integrity: sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,9 +224,6 @@ importers:
       cookie:
         specifier: ^0.5.0
         version: 0.5.0
-      es-module-lexer:
-        specifier: ^1.3.1
-        version: 1.3.1
       express:
         specifier: ^4.18.2
         version: 4.18.2
@@ -2677,6 +2674,7 @@ packages:
 
   /es-module-lexer@1.3.1:
     resolution: {integrity: sha512-JUFAyicQV9mXc3YRxPnDlrfBKpqt6hUYzz9/boprUJHs4e4KVr3XwOF70doO6gwXUor6EWZJAyWAfKki84t20Q==}
+    dev: false
 
   /es-set-tostringtag@2.0.1:
     resolution: {integrity: sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,6 +221,9 @@ importers:
       cookie:
         specifier: ^0.5.0
         version: 0.5.0
+      es-module-lexer:
+        specifier: ^1.3.1
+        version: 1.3.1
       express:
         specifier: ^4.18.2
         version: 4.18.2
@@ -2657,6 +2660,10 @@ packages:
       typed-array-length: 1.0.4
       unbox-primitive: 1.0.2
       which-typed-array: 1.1.9
+    dev: true
+
+  /es-module-lexer@1.3.1:
+    resolution: {integrity: sha512-JUFAyicQV9mXc3YRxPnDlrfBKpqt6hUYzz9/boprUJHs4e4KVr3XwOF70doO6gwXUor6EWZJAyWAfKki84t20Q==}
     dev: true
 
   /es-set-tostringtag@2.0.1:


### PR DESCRIPTION
Making a dedicated package for
- https://github.com/hi-ogawa/cloudflare-workers-example/blob/98558796ac9330d38df86b234ca5f1971ad563d4/vite.config.ts#L39

## todo

- [x] package naming?
  - emptify, nullify, fake
  - module, exports
- [ ] find similar packages?
  - https://github.com/vikejs/vike/issues/744
    - similar but this is to guard against unintended usage
  - https://github.com/remix-run/remix/pull/7590
    - probably their vite plugin would require similar thing?