### PR TITLE
chore: add react jsx runtime in tsconfig

### DIFF
--- a/examples/spa/src/routes/layout.tsx
+++ b/examples/spa/src/routes/layout.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { NavLink, Outlet } from "react-router-dom";
 
 export function Component() {

--- a/examples/spa/src/routes/pokemon/layout.tsx
+++ b/examples/spa/src/routes/pokemon/layout.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { NavLink, Outlet, useNavigate, useNavigation } from "react-router-dom";
 
 export function Component() {

--- a/examples/spa/tsconfig.json
+++ b/examples/spa/tsconfig.json
@@ -3,6 +3,6 @@
   "include": ["src", "e2e"],
   "compilerOptions": {
     "types": ["vite/client"],
-    "jsx": "preserve"
+    "jsx": "react-jsx"
   }
 }

--- a/examples/ssr/src/routes/layout.tsx
+++ b/examples/ssr/src/routes/layout.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Link, Outlet } from "react-router-dom";
 
 export function Component() {

--- a/examples/ssr/tsconfig.json
+++ b/examples/ssr/tsconfig.json
@@ -3,6 +3,6 @@
   "include": ["src", "e2e"],
   "compilerOptions": {
     "types": ["vite/client"],
-    "jsx": "preserve"
+    "jsx": "react-jsx"
   }
 }

--- a/packages/demo/src/routes/error.page.tsx
+++ b/packages/demo/src/routes/error.page.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import {
   Link,
   useLoaderData,

--- a/packages/demo/src/routes/server-redirect/[id].page.tsx
+++ b/packages/demo/src/routes/server-redirect/[id].page.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useLoaderData } from "react-router-dom";
 
 export function Component() {

--- a/packages/demo/tsconfig.json
+++ b/packages/demo/tsconfig.json
@@ -3,6 +3,6 @@
   "include": ["src", "e2e"],
   "compilerOptions": {
     "types": ["vite/client"],
-    "jsx": "preserve"
+    "jsx": "react-jsx"
   }
 }


### PR DESCRIPTION
Technically `@vitejs/plugin-react` shouldn't be necessary since vite/esbuild can transpile tsx out-of-the-box as long as tsconfig is setup properly.