### PR TITLE
feat(vite-node-miniflare) enable nodejs compat

### DIFF
--- a/packages/vite-node-miniflare/src/client/polyfills/node-path.ts
+++ b/packages/vite-node-miniflare/src/client/polyfills/node-path.ts
@@ -1,4 +1,0 @@
-import { createUsageChecker } from "./usage-checker";
-
-export { dirname } from "pathe";
-export default createUsageChecker("node:path");

--- a/packages/vite-node-miniflare/src/server/vite-node.ts
+++ b/packages/vite-node-miniflare/src/server/vite-node.ts
@@ -69,6 +69,7 @@ export function setupViteNodeServerRpc(viteNodeServer: ViteNodeServer) {
         },
       ],
       modulesRoot: "/",
+      compatibilityFlags: ["nodejs_compat"],
       // expose to runtime
       unsafeEvalBinding: "__UNSAFE_EVAL",
       bindings: {

--- a/packages/vite-node-miniflare/tsup.config.ts
+++ b/packages/vite-node-miniflare/tsup.config.ts
@@ -13,7 +13,8 @@ export default [
     platform: "browser",
     dts: true,
     splitting: false,
-    noExternal: [/.*/],
+    noExternal: ["vite-node/client"],
+    external: ["node:path"],
     esbuildOptions: (options) => {
       // patch to run "vite-node/client" on workerd
       options.define = {
@@ -23,7 +24,7 @@ export default [
       options.alias = {
         debug: "./src/client/polyfills/debug.ts",
       };
-      for (const mod of ["fs", "module", "path", "url", "vm"]) {
+      for (const mod of ["fs", "module", "url", "vm"]) {
         options.alias[`node:${mod}`] = `./src/client/polyfills/node-${mod}.ts`;
       }
     },


### PR DESCRIPTION
For example this will allow removing `node:path` polyfill, but I feel this decision shouldn't be done automatically to align with wrangler config for example.