### PR TITLE
fix(vite-node-miniflare): fix `pathToFileURL` for virtual module

### DIFF
--- a/packages/vite-node-miniflare/src/client/polyfills/node-url.ts
+++ b/packages/vite-node-miniflare/src/client/polyfills/node-url.ts
@@ -1,12 +1,20 @@
 import type url from "node:url";
-import { tinyassert } from "@hiogawa/utils";
 
 export const fileURLToPath: typeof url.fileURLToPath = (url) => {
   const s = url.toString();
-  tinyassert(s.startsWith("file://"));
+  if (!s.startsWith("file://")) {
+    throw new Error(
+      `[vite-node-miniflare] fileURLToPath - Unexpected url '${url}'`
+    );
+  }
   return s.slice("file://".length);
 };
 
 export const pathToFileURL: typeof url.pathToFileURL = (path) => {
+  // since virtual module comes here as relative path (e.g. "\0virtual:xxx"),
+  // we force absolute path format since Workerd throws when `new URL(file://relative)`.
+  if (!path.startsWith("/")) {
+    path = "/" + path;
+  }
   return new URL("file://" + path);
 };

--- a/packages/vite-node-miniflare/src/server/vite-node.ts
+++ b/packages/vite-node-miniflare/src/server/vite-node.ts
@@ -69,6 +69,8 @@ export function setupViteNodeServerRpc(viteNodeServer: ViteNodeServer) {
         },
       ],
       modulesRoot: "/",
+      // reasonable default? (ReadableStream etc...)
+      compatibilityDate: "2023-08-01",
       // expose to runtime
       unsafeEvalBinding: "__UNSAFE_EVAL",
       bindings: {


### PR DESCRIPTION
After investigation in https://github.com/hi-ogawa/vite-plugins/pull/134, it turned out Workerd throws when `new URL(file://something-relative)` depending on `compatibilityDate`.
Probably it should be fixed on `vite-node-miniflare` side.
