### PR TITLE
feat(vite-node-miniflare): support error stack sourcemap

### DIFF
--- a/.changeset/nasty-llamas-glow.md
+++ b/.changeset/nasty-llamas-glow.md
@@ -1,0 +1,5 @@
+---
+"@hiogawa/vite-node-miniflare": patch
+---
+
+feat: improve error stack with sourcemap

--- a/packages/vite-node-miniflare/examples/basic/src/app.tsx
+++ b/packages/vite-node-miniflare/examples/basic/src/app.tsx
@@ -1,13 +1,10 @@
 import { useState } from "@hiogawa/tiny-react";
 import { TestComponent } from "./component";
+import { CrashSsr } from "./crash";
 
 export function App(props: { url: string }) {
   const [input, setInput] = useState("");
   const [counter, setCounter] = useState(0);
-
-  if (import.meta.env.SSR && props.url.includes("crash-ssr")) {
-    throw new Error("crash ssr");
-  }
 
   return (
     <div style="display: flex; flex-direction: column; gap: 0.5rem; max-width: 300px">
@@ -27,6 +24,7 @@ export function App(props: { url: string }) {
         <button onclick={() => setCounter(counter + 1)}>+1</button>
       </div>
       <TestComponent />
+      <CrashSsr url={props.url} />
     </div>
   );
 }

--- a/packages/vite-node-miniflare/examples/basic/src/crash-dep.ts
+++ b/packages/vite-node-miniflare/examples/basic/src/crash-dep.ts
@@ -1,0 +1,4 @@
+// test stack trace follows multiple files correctly
+export function crash(message: string): never {
+  throw new Error(message);
+}

--- a/packages/vite-node-miniflare/examples/basic/src/crash.tsx
+++ b/packages/vite-node-miniflare/examples/basic/src/crash.tsx
@@ -1,0 +1,8 @@
+import { crash } from "./crash-dep";
+
+export function CrashSsr(props: { url: string }) {
+  if (import.meta.env.SSR && props.url.includes("crash-ssr")) {
+    crash("crash ssr");
+  }
+  return <div>Hello</div>;
+}

--- a/packages/vite-node-miniflare/package.json
+++ b/packages/vite-node-miniflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/vite-node-miniflare",
-  "version": "0.0.0-pre.11",
+  "version": "0.0.0-pre.12",
   "homepage": "https://github.com/hi-ogawa/vite-plugins/tree/main/packages/vite-node-miniflare",
   "repository": {
     "type": "git",

--- a/packages/vite-node-miniflare/src/client/polyfills/node-path.ts
+++ b/packages/vite-node-miniflare/src/client/polyfills/node-path.ts
@@ -1,7 +1,6 @@
-import { createUsageChecker } from "./usage-checker";
+import * as pathe from "pathe";
 
-// TODO don't have to polyfill?
-// https://developers.cloudflare.com/workers/runtime-apis/nodejs/path/
-
-export { dirname } from "pathe";
-export default createUsageChecker("node:path");
+// used for source map path manipulation?
+// https://github.com/vitest-dev/vitest/blob/8dabef860a3f51f5a4c4debc10faa1837fdcdd71/packages/vite-node/src/source-map-handler.ts#L81
+export const dirname = pathe.dirname;
+export default pathe;

--- a/packages/vite-node-miniflare/src/client/polyfills/node-vm.ts
+++ b/packages/vite-node-miniflare/src/client/polyfills/node-vm.ts
@@ -6,8 +6,13 @@ export function __setUnsafeEval(v: any) {
   __unsafeEval = v;
 }
 
-const runInThisContext: typeof vm.runInThisContext = (code) => {
-  return __unsafeEval.eval(code);
+// Workerd's unsafe eval supports 2nd argument for stacktrace filename
+// https://github.com/cloudflare/workerd/blob/5e2544fd2948b53e68831a9b219dc1e9970cf96f/src/workerd/api/unsafe.c%2B%2B#L18-L23
+// https://github.com/cloudflare/workerd/pull/1338
+// https://github.com/vitest-dev/vitest/blob/8dabef860a3f51f5a4c4debc10faa1837fdcdd71/packages/vite-node/src/client.ts#L414
+// https://nodejs.org/docs/latest/api/vm.html#vmrunincontextcode-contextifiedobject-options
+const runInThisContext: typeof vm.runInThisContext = (code, options) => {
+  return __unsafeEval.eval(code, (options as any).filename);
 };
 
 export default {


### PR DESCRIPTION
Part of https://github.com/hi-ogawa/vite-plugins/issues/127

It turns out Workerd's `eval` already supports `name` option for stacktrace!
- https://github.com/cloudflare/workerd/pull/1338