### PR TITLE
fix(demo): set `optimizeDeps` to avoid late discovery

### DIFF
--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -48,6 +48,7 @@
     "express": "^4.18.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router": "6.13.0",
     "react-router-dom": "^6.13.0",
     "unocss": "^0.57.7",
     "zod": "^3.21.4"

--- a/packages/demo/playwright.config.ts
+++ b/packages/demo/playwright.config.ts
@@ -6,7 +6,7 @@ const command = process.env["E2E_COMMAND"] ?? `pnpm dev:vite`;
 
 export default defineConfig({
   testDir: "e2e",
-  retries: process.env.CI ? 2 : 0,
+  retries: process.env.CI ? 1 : 0,
   use: {
     baseURL: `http://localhost:${PORT}`,
     trace: "on-first-retry",

--- a/packages/demo/vite.config.ts
+++ b/packages/demo/vite.config.ts
@@ -30,6 +30,13 @@ export default defineConfig((ctx) => ({
     manifest: ".vite/manifest.json", // explicit manifest path for v4/v5 compat
     sourcemap: true,
   },
+  optimizeDeps: {
+    // avoid pre-bundling late discovery which forces browser full reload
+    // debug it by:
+    //   DEBUG=vite:deps pnpm -C packages/demo dev:vite --force
+    entries: ["./src/client/index.tsx", "./src/routes/**/*"],
+    include: ["react-router"], // TODO: probably vite-glob-routes should add it automatically
+  },
   server: process.env["PORT"]
     ? {
         port: Number(process.env["PORT"]),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,6 +236,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
+      react-router:
+        specifier: 6.13.0
+        version: 6.13.0(react@18.2.0)
       react-router-dom:
         specifier: ^6.13.0
         version: 6.13.0(react-dom@18.2.0)(react@18.2.0)


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/vite-plugins/issues/99

Looks good?

## before

https://github.com/hi-ogawa/vite-plugins/actions/runs/7327401800/job/19954230973#step:11:11

```
Running 24 tests using 2 workers
···×××±·±··················

  Slow test file: [chromium] › basic.test.ts (44.5s)
  Slow test file: [chromium] › session.test.ts (36.9s)
  Consider splitting slow test files to speed up parallel execution
  2 flaky
    [chromium] › basic.test.ts:5:1 › basic ─────────────────────────────────────────────────────────
    [chromium] › session.test.ts:5:3 › session › basic ─────────────────────────────────────────────
  22 passed (48.5s)
```

## after

No retry!

https://github.com/hi-ogawa/vite-plugins/actions/runs/7334364661/job/19970952135#step:11:11

```
Running 24 tests using 2 workers
························
  24 passed (15.1s)
```