### PR TITLE
refactor: implement client-side per-route asset preloading via Vite's automatic preload

### DIFF
--- a/examples/spa/src/client/index.tsx
+++ b/examples/spa/src/client/index.tsx
@@ -1,24 +1,18 @@
 import { tinyassert } from "@hiogawa/utils";
 import {
   globPageRoutesClient,
-  setPreloadContext,
-  setupGlobalPreloadHandler,
+  setupPreload,
 } from "@hiogawa/vite-glob-routes/dist/react-router/client";
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider, createBrowserRouter } from "react-router-dom";
-import type { Manifest } from "vite";
-
-// see examples/spa/misc/inject-global-script.js
-const __viteManifest: Manifest | undefined = (window as any).__viteManifest;
 
 async function main() {
   const el = document.getElementById("root");
   tinyassert(el);
 
-  const { routes, routesMeta } = globPageRoutesClient();
-  setPreloadContext({ routes, routesMeta, manifest: __viteManifest });
-  setupGlobalPreloadHandler();
+  const { routes } = globPageRoutesClient();
+  setupPreload({ routes });
 
   const router = createBrowserRouter(routes);
   const root = (

--- a/examples/spa/vite-plugin-inject-manifest.ts
+++ b/examples/spa/vite-plugin-inject-manifest.ts
@@ -4,6 +4,7 @@ import { tinyassert } from "@hiogawa/utils";
 import { type Plugin } from "vite";
 
 // directly expose vite's manifest.json on client for page assets prefetching
+// (TODO: it turns out this is not necessary for client navigation prefetch...)
 
 export function vitePluginInjectManifest(): Plugin {
   return {

--- a/examples/spa/vite.config.ts
+++ b/examples/spa/vite.config.ts
@@ -2,12 +2,10 @@ import process from "node:process";
 import globRoutesPlugin from "@hiogawa/vite-glob-routes";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
-import { vitePluginInjectManifest } from "./vite-plugin-inject-manifest";
 import { vitePluginSkipRefreshPlugin } from "./vite-plugin-skip-refresh";
 
 export default defineConfig({
   plugins: [
-    vitePluginInjectManifest(),
     vitePluginSkipRefreshPlugin({ include: ["**/src/routes/**/*.tsx"] }),
     react(),
     globRoutesPlugin({ root: "/src/routes" }),

--- a/packages/demo/e2e/preload.test.ts
+++ b/packages/demo/e2e/preload.test.ts
@@ -1,22 +1,32 @@
 import process from "node:process";
 import { tinyassert } from "@hiogawa/utils";
-import { test } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import { isPageReady } from "./helper";
 
 // TODO: test production build
 const isPreview = Boolean(process.env["E2E_COMMAND"]?.includes("preview"));
 
-test("modulepreload", async ({ page }) => {
+test("ssr", async ({ request }) => {
+  test.skip(isPreview);
+
+  const res = await request.get("/loader-data");
+  tinyassert(res.ok);
+
+  const resText = await res.text();
+  const links = [
+    ...resText.matchAll(/<link rel="modulepreload" href="(.*?)" \/\>/g),
+  ].map((m) => m[0]);
+  expect(links).toEqual([
+    '<link rel="modulepreload" href="/src/routes/layout.tsx" />',
+    '<link rel="modulepreload" href="/src/routes/loader-data.page.tsx" />',
+  ]);
+});
+
+test("client", async ({ page }) => {
   test.skip(isPreview);
 
   await page.goto("/loader-data");
   await isPageReady(page);
-
-  // server rendered preload for matching initial routes
-  tinyassert(await findPreloadLink("/src/routes/layout.tsx"));
-  tinyassert(await findPreloadLink("/src/routes/loader-data.page.tsx"));
-  tinyassert(!(await findPreloadLink("/src/routes/subdir/layout.tsx")));
-  tinyassert(!(await findPreloadLink("/src/routes/subdir/other.page.tsx")));
 
   // preload after mouseover
   const preloadRequests = Promise.all([
@@ -27,11 +37,4 @@ test("modulepreload", async ({ page }) => {
     .getByRole("link", { name: "/subdir/other" })
     .dispatchEvent("mouseover");
   await preloadRequests;
-
-  function findPreloadLink(href: string) {
-    return page.evaluate(
-      (href) => Boolean(document.querySelector(`link[href="${href}"]`)),
-      href
-    );
-  }
 });

--- a/packages/demo/e2e/preload.test.ts
+++ b/packages/demo/e2e/preload.test.ts
@@ -3,6 +3,7 @@ import { tinyassert } from "@hiogawa/utils";
 import { test } from "@playwright/test";
 import { isPageReady } from "./helper";
 
+// TODO: test production build
 const isPreview = Boolean(process.env["E2E_COMMAND"]?.includes("preview"));
 
 test("modulepreload", async ({ page }) => {
@@ -18,11 +19,14 @@ test("modulepreload", async ({ page }) => {
   tinyassert(!(await findPreloadLink("/src/routes/subdir/other.page.tsx")));
 
   // preload after mouseover
+  const preloadRequests = Promise.all([
+    page.waitForRequest("/src/routes/subdir/layout.tsx"),
+    page.waitForRequest("/src/routes/subdir/other.page.tsx"),
+  ]);
   await page
     .getByRole("link", { name: "/subdir/other" })
     .dispatchEvent("mouseover");
-  tinyassert(await findPreloadLink("/src/routes/subdir/layout.tsx"));
-  tinyassert(await findPreloadLink("/src/routes/subdir/other.page.tsx"));
+  await preloadRequests;
 
   function findPreloadLink(href: string) {
     return page.evaluate(

--- a/packages/demo/src/client/index.tsx
+++ b/packages/demo/src/client/index.tsx
@@ -4,17 +4,14 @@ import {
   globPageRoutesClient,
   injectDataRequestLoaders,
   resolveLazyRoutes,
-  setPreloadContext,
-  setupGlobalPreloadHandler,
+  setupPreload,
 } from "@hiogawa/vite-glob-routes/dist/react-router/client";
 import React from "react";
 import { hydrateRoot } from "react-dom/client";
 import { RouterProvider, createBrowserRouter } from "react-router-dom";
-import type { Manifest } from "vite";
 
 // cf. packages/demo/src/server/ssr.tsx
 const serverHandoff = window as any as {
-  __viteManifest?: Manifest;
   __serverLoaderRouteIds: string[];
   __initialMatchRouteIds: string[];
 };
@@ -23,15 +20,10 @@ async function main() {
   const el = document.getElementById("root");
   tinyassert(el);
 
-  const { routes, routesMeta } = globPageRoutesClient();
+  const { routes } = globPageRoutesClient();
   await resolveLazyRoutes(routes, serverHandoff.__initialMatchRouteIds);
   injectDataRequestLoaders(routes, serverHandoff.__serverLoaderRouteIds);
-  setPreloadContext({
-    routes,
-    routesMeta,
-    manifest: serverHandoff.__viteManifest,
-  });
-  setupGlobalPreloadHandler();
+  setupPreload({ routes });
 
   const router = createBrowserRouter(routes);
   const root = (

--- a/packages/demo/src/server/ssr.tsx
+++ b/packages/demo/src/server/ssr.tsx
@@ -91,7 +91,6 @@ export function ssrHandler(): RequestHandler {
         // so other data could be hard-coded somewhere after build?
         matchRouteDeps.js.map((href) => `<link rel="modulepreload" href="${href}" />`),
         `<script>
-          window.__viteManifest = ${JSON.stringify(manifest)};
           window.__serverLoaderRouteIds = ${JSON.stringify(serverLoaderRouteIds)};
           window.__initialMatchRouteIds = ${JSON.stringify(matchRouteIds)};
         </script>`,

--- a/packages/demo/src/server/ssr.tsx
+++ b/packages/demo/src/server/ssr.tsx
@@ -66,6 +66,7 @@ export function ssrHandler(): RequestHandler {
 
     // for initial prefetch link + client side lazy resolution
     const matchRouteIds = routerResult.context.matches.map((m) => m.route.id);
+    // TODO: use ssr-manifest.json?
     const matchRouteDeps = resolveRouteDependenciesByIds(
       matchRouteIds,
       routesMeta,

--- a/packages/demo/vite.config.ts
+++ b/packages/demo/vite.config.ts
@@ -28,6 +28,7 @@ export default defineConfig((ctx) => ({
   build: {
     outDir: ctx.isSsrBuild ? "dist/server" : "dist/client",
     manifest: ".vite/manifest.json", // explicit manifest path for v4/v5 compat
+    ssrManifest: ".vite/ssr-manifest.json",
   },
   optimizeDeps: {
     // avoid pre-bundling late discovery which forces browser full reload

--- a/packages/demo/vite.config.ts
+++ b/packages/demo/vite.config.ts
@@ -28,9 +28,6 @@ export default defineConfig((ctx) => ({
   build: {
     outDir: ctx.isSsrBuild ? "dist/server" : "dist/client",
     manifest: ".vite/manifest.json", // explicit manifest path for v4/v5 compat
-    ssrManifest: true,
-    sourcemap: true,
-    minify: false,
   },
   optimizeDeps: {
     // avoid pre-bundling late discovery which forces browser full reload

--- a/packages/demo/vite.config.ts
+++ b/packages/demo/vite.config.ts
@@ -28,7 +28,9 @@ export default defineConfig((ctx) => ({
   build: {
     outDir: ctx.isSsrBuild ? "dist/server" : "dist/client",
     manifest: ".vite/manifest.json", // explicit manifest path for v4/v5 compat
+    ssrManifest: true,
     sourcemap: true,
+    minify: false,
   },
   optimizeDeps: {
     // avoid pre-bundling late discovery which forces browser full reload

--- a/packages/vite-glob-routes/src/react-router/features/preload/client.ts
+++ b/packages/vite-glob-routes/src/react-router/features/preload/client.ts
@@ -37,6 +37,14 @@ function getRouteDependencies(page: string): RouteDependencies {
   );
 }
 
+// Vite's production build will wrap each dynamic import with `__vitePreload`,
+// which will inject preload links for asset dependencies when such dynamic import is invoked.
+async function preloadPageAssets(page: string) {
+  const { routes } = getPreloadContext();
+  const matches = matchRoutes(routes, page) ?? [];
+  await Promise.all(matches.map(m => m.route.lazy?.()));
+}
+
 //
 // helper to globally setup preload handler for <a href="..." date-preload />
 //
@@ -72,6 +80,11 @@ function injectPreloadLinks(href: string) {
 
   // TODO: prefetch external links?
   if (url.host !== window.location.host) {
+    return;
+  }
+
+  preloadPageAssets(url.pathname);
+  if (1) {
     return;
   }
 

--- a/packages/vite-glob-routes/src/react-router/features/preload/client.ts
+++ b/packages/vite-glob-routes/src/react-router/features/preload/client.ts
@@ -1,47 +1,13 @@
-import { tinyassert } from "@hiogawa/utils";
 import { type DataRouteObject, matchRoutes } from "react-router";
-import type { Manifest } from "vite";
-import type { RoutesMeta } from "../../route-utils";
-import {
-  type RouteDependencies,
-  resolveRouteDependenciesByIds,
-} from "./shared";
-
-// simple global system on our own convention
-// instead of using React.Context
 
 interface PreloadContext {
   routes: DataRouteObject[];
-  routesMeta: RoutesMeta;
-  manifest?: Manifest;
-}
-
-let __preloadContext: PreloadContext | undefined;
-
-export function setPreloadContext(v: PreloadContext) {
-  __preloadContext = v;
-}
-
-function getPreloadContext() {
-  tinyassert(__preloadContext, "forgot 'setPreloadContext'?");
-  return __preloadContext;
-}
-
-function getRouteDependencies(page: string): RouteDependencies {
-  const { routes, routesMeta, manifest } = getPreloadContext();
-  const matches = matchRoutes(routes, page) ?? [];
-  return resolveRouteDependenciesByIds(
-    matches.map((m) => m.route.id),
-    routesMeta,
-    manifest
-  );
 }
 
 // Vite's production build will wrap each dynamic import with `__vitePreload`,
 // which will inject preload links for asset dependencies when such dynamic import is invoked.
-async function preloadPageAssets(page: string) {
-  const { routes } = getPreloadContext();
-  const matches = matchRoutes(routes, page) ?? [];
+async function preloadCode(ctx: PreloadContext, page: string) {
+  const matches = matchRoutes(ctx.routes, page) ?? [];
   await Promise.all(matches.map((m) => m.route.lazy?.()));
 }
 
@@ -53,14 +19,16 @@ async function preloadPageAssets(page: string) {
 // https://kit.svelte.dev/docs/link-options#data-sveltekit-preload-data
 //
 
-export function setupGlobalPreloadHandler() {
+export function setupPreload(ctx: PreloadContext) {
   // TODO: not sure perf impact of global "mouseover" and "touchstart"
   function handler(e: MouseEvent | TouchEvent) {
     if (e.target instanceof HTMLAnchorElement) {
       const dataPreload = e.target.getAttribute("data-preload");
       if (dataPreload) {
-        // e.target.href always full url?
-        injectPreloadLinks(e.target.href);
+        const url = new URL(e.target.href, window.location.href);
+        if (url.host === window.location.host) {
+          preloadCode(ctx, url.pathname);
+        }
       }
     }
   }
@@ -72,32 +40,4 @@ export function setupGlobalPreloadHandler() {
     document.removeEventListener("mouseover", handler);
     document.removeEventListener("touchstart", handler);
   };
-}
-
-// TODO: memoize?
-function injectPreloadLinks(href: string) {
-  const url = new URL(href, window.location.href);
-
-  // TODO: prefetch external links?
-  if (url.host !== window.location.host) {
-    return;
-  }
-
-  preloadPageAssets(url.pathname);
-  if (1) {
-    return;
-  }
-
-  // resolve page dependencies
-  const deps = getRouteDependencies(url.pathname);
-  for (const href of deps.js) {
-    // TODO: escapeHtml
-    const found = document.querySelector(`link[href="${href}"]`);
-    if (!found) {
-      const el = document.createElement("link");
-      el.setAttribute("rel", "modulepreload");
-      el.setAttribute("href", href);
-      document.body.appendChild(el);
-    }
-  }
 }

--- a/packages/vite-glob-routes/src/react-router/features/preload/client.ts
+++ b/packages/vite-glob-routes/src/react-router/features/preload/client.ts
@@ -42,7 +42,7 @@ function getRouteDependencies(page: string): RouteDependencies {
 async function preloadPageAssets(page: string) {
   const { routes } = getPreloadContext();
   const matches = matchRoutes(routes, page) ?? [];
-  await Promise.all(matches.map(m => m.route.lazy?.()));
+  await Promise.all(matches.map((m) => m.route.lazy?.()));
 }
 
 //

--- a/packages/vite-glob-routes/src/react-router/features/preload/shared.ts
+++ b/packages/vite-glob-routes/src/react-router/features/preload/shared.ts
@@ -41,6 +41,7 @@ function resolveRouteDependenciesById(
 }
 
 // need to probe vite client manifest to map production asset url
+// TODO: is it easier with ssrManifest? https://vitejs.dev/guide/ssr.html#generating-preload-directives
 function resolveManifestEntries(
   files: string[],
   manifest: Manifest


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/vite-plugins/issues/149

It seems to just work. Technically dynamic import could have a side effect and it also affects actual js memory usage compared to "pure" modulepreload.

Let's compare with what sveltekit does
- https://kit.svelte.dev/docs/link-options#data-sveltekit-preload-code
- https://kit.svelte.dev/docs/modules#$app-navigation-preloadcode

---

It looks like Sveltekit's "node" corresponds to dynamic import and those dynamic imports are triggered when `preload_code`.

https://github.com/sveltejs/kit/blob/6419d3eaa7bf1b0a756b28f06a73f71fe042de0a/packages/kit/src/core/sync/write_client_manifest.js#L43-L50
https://github.com/sveltejs/kit/blob/6419d3eaa7bf1b0a756b28f06a73f71fe042de0a/packages/kit/src/runtime/client/client.js#L344-L350

