### PR TITLE
refactor(vite-node-miniflare): simplify `HMRConnection` implementation

### DIFF
--- a/packages/vite-node-miniflare/examples/basic/package.json
+++ b/packages/vite-node-miniflare/examples/basic/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@hiogawa/tiny-react": "0.0.2-pre.8",
     "@hiogawa/vite-node-miniflare": "workspace:*",
+    "@hiogawa/vite-plugin-simple-hmr": "workspace:*",
     "miniflare": "^3.20231030.3",
     "vite": "^5.1.0"
   }

--- a/packages/vite-node-miniflare/examples/basic/vite.config.ts
+++ b/packages/vite-node-miniflare/examples/basic/vite.config.ts
@@ -1,5 +1,6 @@
 import { tinyReactVitePlugin } from "@hiogawa/tiny-react/dist/plugins/vite";
 import { vitePluginViteNodeMiniflare } from "@hiogawa/vite-node-miniflare";
+import { vitePluginSimpleHmr } from "@hiogawa/vite-plugin-simple-hmr";
 import { Log } from "miniflare";
 import { defineConfig } from "vite";
 
@@ -10,8 +11,12 @@ export default defineConfig({
     noExternal: true,
   },
   plugins: [
+    vitePluginSimpleHmr({
+      include: new URL("./src/**/*.tsx", import.meta.url).pathname,
+    }),
     vitePluginViteNodeMiniflare({
       debug: true,
+      hmr: true,
       entry: "/src/worker-entry.ts",
       miniflareOptions(options) {
         options.log = new Log();

--- a/packages/vite-node-miniflare/src/client/worker-entry.ts
+++ b/packages/vite-node-miniflare/src/client/worker-entry.ts
@@ -33,6 +33,7 @@ export default {
         serverRpcUrl: env.__VITE_NODE_SERVER_RPC_URL,
         root: env.__VITE_RUNTIME_ROOT,
         debug: env.__VITE_NODE_DEBUG,
+        hmr: env.__VITE_RUNTIME_HMR,
       });
 
       // fetch HMRPayload before execution
@@ -62,6 +63,7 @@ function createViteNodeClient(options: {
   serverRpcUrl: string;
   root: string;
   debug: boolean;
+  hmr: boolean;
 }): ViteNodeMiniflareClient {
   const rpc = proxyTinyRpc<ViteNodeRpc>({
     adapter: httpClientAdapter({ url: options.serverRpcUrl }),
@@ -73,6 +75,8 @@ function createViteNodeClient(options: {
       getHMRPayloads: rpc.getHMRPayloads,
       send: rpc.send,
     },
+    debug: options.debug,
+    hmr: options.hmr,
   });
 
   const runtime = new ViteRuntime(

--- a/packages/vite-node-miniflare/src/server/plugin.ts
+++ b/packages/vite-node-miniflare/src/server/plugin.ts
@@ -98,7 +98,9 @@ export type ViteNodeRpc = Pick<
   ViteDevServer,
   "transformIndexHtml" | "ssrFetchModule"
 > & {
+  // RPC endpoint to proxy ServerHMRConnector
   getHMRPayloads: () => HMRPayload[];
+  send: (messages: string) => void;
 };
 
 export function setupViteNodeServerRpc(
@@ -127,6 +129,9 @@ export function setupViteNodeServerRpc(
       const result = hmrPayloads;
       hmrPayloads = [];
       return result;
+    },
+    send: (messages: string) => {
+      connector.send(messages);
     },
     // framework can utilize custom RPC to implement some features on main Vite process and expose them to Workerd
     // (e.g. Remix's DevServerHooks)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,6 +297,9 @@ importers:
       '@hiogawa/vite-node-miniflare':
         specifier: workspace:*
         version: link:../..
+      '@hiogawa/vite-plugin-simple-hmr':
+        specifier: workspace:*
+        version: link:../../../vite-plugin-simple-hmr
       miniflare:
         specifier: ^3.20231030.3
         version: 3.20231030.4


### PR DESCRIPTION
Still holding off from setting up birpc. For now, let's refactor uni-directional RPC approach as `HMRRuntimeConnection` implementation.