### PR TITLE
refactor(vite-node-miniflare): load worker entry by file path

### DIFF
--- a/packages/vite-node-miniflare/package.json
+++ b/packages/vite-node-miniflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/vite-node-miniflare",
-  "version": "0.0.2",
+  "version": "0.0.3-pre.0",
   "homepage": "https://github.com/hi-ogawa/vite-plugins/tree/main/packages/vite-node-miniflare",
   "repository": {
     "type": "git",
@@ -22,7 +22,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "BUILD_STEP=0 tsup && BUILD_STEP=1 tsup",
+    "build": "tsup",
     "release": "pnpm publish --no-git-checks --access public"
   },
   "dependencies": {

--- a/packages/vite-node-miniflare/src/client/worker-entry-script.ts
+++ b/packages/vite-node-miniflare/src/client/worker-entry-script.ts
@@ -1,3 +1,0 @@
-// injected via esbuild define
-declare let __DEFINE_WORKER_ENTRY_SCRIPT: string;
-export const WORKER_ENTRY_SCRIPT = __DEFINE_WORKER_ENTRY_SCRIPT;

--- a/packages/vite-node-miniflare/src/server/plugin.ts
+++ b/packages/vite-node-miniflare/src/server/plugin.ts
@@ -14,7 +14,7 @@ import {
   fetchModule,
 } from "vite";
 import { name as packageName } from "../../package.json";
-import { WORKER_ENTRY_SCRIPT } from "../client/worker-entry-script";
+import { fileURLToPath } from "node:url"
 
 export function vitePluginViteNodeMiniflare(pluginOptions: {
   entry: string;
@@ -154,8 +154,7 @@ export function setupViteNodeServerRpc(
       modules: [
         {
           type: "ESModule",
-          path: "/__vite_node_miniflare_entry.js",
-          contents: WORKER_ENTRY_SCRIPT,
+          path: fileURLToPath(new URL("./worker-entry.js", import.meta.url)),
         },
       ],
       modulesRoot: "/",

--- a/packages/vite-node-miniflare/src/server/plugin.ts
+++ b/packages/vite-node-miniflare/src/server/plugin.ts
@@ -103,7 +103,7 @@ export type ViteNodeRpc = Pick<
   send: (messages: string) => void;
 };
 
-export function setupViteNodeServerRpc(
+function setupViteNodeServerRpc(
   viteDevServer: ViteDevServer,
   options: { customRpc?: Record<string, Function> }
 ) {

--- a/packages/vite-node-miniflare/src/server/plugin.ts
+++ b/packages/vite-node-miniflare/src/server/plugin.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from "node:url";
 import * as httipAdapterNode from "@hattip/adapter-node/native-fetch";
 import * as httipCompose from "@hattip/compose";
 import { exposeTinyRpc, httpServerAdapter } from "@hiogawa/tiny-rpc";
@@ -14,7 +15,6 @@ import {
   fetchModule,
 } from "vite";
 import { name as packageName } from "../../package.json";
-import { fileURLToPath } from "node:url"
 
 export function vitePluginViteNodeMiniflare(pluginOptions: {
   entry: string;

--- a/packages/vite-node-miniflare/tsup.config.ts
+++ b/packages/vite-node-miniflare/tsup.config.ts
@@ -4,25 +4,16 @@ import { defineConfig } from "tsup";
 // build in two steps to export worker entry script as string
 
 export default [
-  defineConfig(() => ({
-    entry: {
-      "client/worker-entry": "src/client/worker-entry.ts",
-    },
+  defineConfig({
+    entry: ["src/client/worker-entry.ts"],
     format: ["esm"],
     platform: "browser",
     noExternal: [/.*/],
-  })),
-  defineConfig(() => ({
+  }),
+  defineConfig({
     entry: ["src/index.ts"],
     format: ["esm"],
     platform: "node",
     dts: true,
-    esbuildOptions: (options) => {
-      options.define = {
-        __DEFINE_WORKER_ENTRY_SCRIPT: JSON.stringify(
-          fs.readFileSync("./dist/client/worker-entry.js", "utf-8")
-        ),
-      };
-    },
-  })),
-][process.env["BUILD_STEP"]!];
+  }),
+];


### PR DESCRIPTION
Previously we were defining `__DEFINE_WORKER_ENTRY_SCRIPT` to pass worker entry as raw string js, but this doesn't seem necessary at all.