### PR TITLE
refactor(vite-node-miniflare): simplify RPC 

### DIFF
--- a/packages/vite-node-miniflare/package.json
+++ b/packages/vite-node-miniflare/package.json
@@ -28,12 +28,14 @@
   "dependencies": {
     "@hattip/adapter-node": "^0.0.34",
     "@hattip/compose": "^0.0.34",
-    "miniflare": "^3.20231030.3"
+    "miniflare": "^3.20231030.3",
+    "ws": "^8.16.0"
   },
   "devDependencies": {
-    "@hiogawa/tiny-rpc": "^0.2.3-pre.16",
+    "@hiogawa/tiny-rpc": "^0.2.3-pre.18",
     "@hiogawa/utils": "1.6.1-pre.10",
     "@microsoft/fetch-event-source": "^2.0.1",
+    "@types/ws": "^8.5.10",
     "vite": "^5.1.0"
   },
   "peerDependencies": {

--- a/packages/vite-node-miniflare/package.json
+++ b/packages/vite-node-miniflare/package.json
@@ -31,8 +31,9 @@
     "miniflare": "^3.20231030.3"
   },
   "devDependencies": {
-    "@hiogawa/tiny-rpc": "^0.2.3-pre.11",
+    "@hiogawa/tiny-rpc": "^0.2.3-pre.16",
     "@hiogawa/utils": "1.6.1-pre.10",
+    "@microsoft/fetch-event-source": "^2.0.1",
     "vite": "^5.1.0"
   },
   "peerDependencies": {

--- a/packages/vite-node-miniflare/src/client/event-source.ts
+++ b/packages/vite-node-miniflare/src/client/event-source.ts
@@ -1,0 +1,57 @@
+import { DefaultMap } from "@hiogawa/utils";
+import { fetchEventSource } from "@microsoft/fetch-event-source";
+
+// EventSource polyfill based on https://github.com/Azure/fetch-event-source
+// since Worked doesn't have EventSource
+
+class TypedEventTarget<T> {
+  private listeners = new DefaultMap<keyof T, Set<Function>>(() => new Set());
+
+  addEventListener<K extends keyof T>(type: K, listener: (ev: T[K]) => void) {
+    this.listeners.get(type).add(listener);
+  }
+
+  removeEventListener<K extends keyof T>(
+    type: K,
+    listener: (ev: T[K]) => void
+  ) {
+    this.listeners.get(type).delete(listener);
+  }
+
+  notify<K extends keyof T>(type: K, data: T[K]) {
+    for (const listener of this.listeners.get(type)) {
+      listener(data);
+    }
+  }
+}
+
+export class FetchEventSource extends TypedEventTarget<EventSourceEventMap> {
+  public fetchPromise: Promise<void>;
+
+  constructor(public url: string) {
+    super();
+    console.log("[FetchEventSource]", { url });
+    this.fetchPromise = fetchEventSource(url, {
+      fetch: globalThis.fetch,
+      openWhenHidden: true,
+      onopen: async (response) => {
+        console.log("[FetchEventSource.onopen]");
+        this.notify("open", response as any);
+      },
+      onerror: (e) => {
+        console.log("[FetchEventSource.onerror]");
+        this.notify("error", e);
+      },
+      onmessage: (ev) => {
+        console.log("[FetchEventSource.onmessage]", ev);
+        if (!ev.data) {
+          return;
+        }
+        this.notify("message", ev as any);
+      },
+      onclose: () => {
+        console.log("[FetchEventSource.onclose]");
+      },
+    });
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,11 +280,14 @@ importers:
         version: 3.20231030.4
     devDependencies:
       '@hiogawa/tiny-rpc':
-        specifier: ^0.2.3-pre.11
-        version: 0.2.3-pre.11
+        specifier: ^0.2.3-pre.16
+        version: 0.2.3-pre.16
       '@hiogawa/utils':
         specifier: 1.6.1-pre.10
         version: 1.6.1-pre.10
+      '@microsoft/fetch-event-source':
+        specifier: ^2.0.1
+        version: 2.0.1
       vite:
         specifier: ^5.1.0
         version: 5.1.0(@types/node@18.16.18)
@@ -2180,8 +2183,8 @@ packages:
       zod: 3.21.4
     dev: true
 
-  /@hiogawa/tiny-rpc@0.2.3-pre.11:
-    resolution: {integrity: sha512-YYFssKJ+abyHMfYSK1IyuL9NccPWWcziG5xf4HVXHmXuT+nLK402WMheSl5A0qlpCBdaO0obtUZfKPAPQj3GfQ==}
+  /@hiogawa/tiny-rpc@0.2.3-pre.16:
+    resolution: {integrity: sha512-gjJhuZm9v9iNyUAMZDXVM6HjsyQfH3dwN0rWmzCerYK9Pn62rSAiEXAm6t6QHobj3hmht11W3rSKcsozYLWIjQ==}
     dev: true
 
   /@hiogawa/tiny-toast@0.1.1-pre.7(react@18.2.0):
@@ -2338,6 +2341,10 @@ packages:
       vfile: 5.3.7
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@microsoft/fetch-event-source@2.0.1:
+    resolution: {integrity: sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==}
     dev: true
 
   /@nodelib/fs.scandir@2.1.5:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,16 +278,22 @@ importers:
       miniflare:
         specifier: ^3.20231030.3
         version: 3.20231030.4
+      ws:
+        specifier: ^8.16.0
+        version: 8.16.0
     devDependencies:
       '@hiogawa/tiny-rpc':
-        specifier: ^0.2.3-pre.16
-        version: 0.2.3-pre.16
+        specifier: ^0.2.3-pre.18
+        version: 0.2.3-pre.18
       '@hiogawa/utils':
         specifier: 1.6.1-pre.10
         version: 1.6.1-pre.10
       '@microsoft/fetch-event-source':
         specifier: ^2.0.1
         version: 2.0.1
+      '@types/ws':
+        specifier: ^8.5.10
+        version: 8.5.10
       vite:
         specifier: ^5.1.0
         version: 5.1.0(@types/node@18.16.18)
@@ -2183,8 +2189,8 @@ packages:
       zod: 3.21.4
     dev: true
 
-  /@hiogawa/tiny-rpc@0.2.3-pre.16:
-    resolution: {integrity: sha512-gjJhuZm9v9iNyUAMZDXVM6HjsyQfH3dwN0rWmzCerYK9Pn62rSAiEXAm6t6QHobj3hmht11W3rSKcsozYLWIjQ==}
+  /@hiogawa/tiny-rpc@0.2.3-pre.18:
+    resolution: {integrity: sha512-BiNHrutG9G9yV622QvkxZxF+PhkaH2Aspp4/X1KYTfnaQTcg4fFUTBWf5Kf533swon2SuVJwi6U6H1LQbhVOQQ==}
     dev: true
 
   /@hiogawa/tiny-toast@0.1.1-pre.7(react@18.2.0):
@@ -2958,6 +2964,12 @@ packages:
 
   /@types/unist@2.0.10:
     resolution: {integrity: sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA==}
+    dev: true
+
+  /@types/ws@8.5.10:
+    resolution: {integrity: sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==}
+    dependencies:
+      '@types/node': 18.16.18
     dev: true
 
   /@unocss/astro@0.57.7(vite@5.1.0):
@@ -6056,7 +6068,7 @@ packages:
       stoppable: 1.1.0
       undici: 5.28.2
       workerd: 1.20231030.0
-      ws: 8.15.1
+      ws: 8.16.0
       youch: 3.3.3
       zod: 3.21.4
     transitivePeerDependencies:
@@ -8338,8 +8350,8 @@ packages:
         optional: true
     dev: true
 
-  /ws@8.15.1:
-    resolution: {integrity: sha512-W5OZiCjXEmk0yZ66ZN82beM5Sz7l7coYxpRkzS+p9PP+ToQry8szKh+61eNktr7EA9DOwvFGhfC605jDHbP6QQ==}
+  /ws@8.16.0:
+    resolution: {integrity: sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1


### PR DESCRIPTION
_note_

- Test `EventSource` based RPC
  - https://github.com/hi-ogawa/js-utils/pull/206
  - actually `EventSource` is not available on Workerd
  - easy to create polyfill based on https://github.com/Azure/fetch-event-source/,
    but then `fetch` based long polling isn't meant to work on Workerd?
    - `Error: The script will never generate a response.` on 2nd request
- try websocket
  - Single instance of `WebSocket` cannot be used for multiple request?
    - `Cannot perform I/O on behalf of a different request. I/O objects (such as streams, request/response bodies, and others) created in the context of one request handler cannot be accessed from a different request's handler. This is a limitation of Cloudflare Workers which allows us to improve overall performance.`
  - we might need to move WebSocket server on Workerd?