### PR TITLE
refactor(react-server): simplify dev ssr module cache invalidation

### DIFF
--- a/packages/react-server/examples/basic/src/entry-rsc.tsx
+++ b/packages/react-server/examples/basic/src/entry-rsc.tsx
@@ -4,18 +4,12 @@ import type { ViteDevServer } from "vite";
 import { generateRouteTree, matchRoute, renderMatchRoute } from "./lib/router";
 import { createBundlerConfig } from "./lib/rsc";
 
-export function render({
-  request,
-  renderId,
-}: {
-  request: Request;
-  renderId: string;
-}) {
+export function render({ request }: { request: Request }) {
   const url = new URL(request.url);
   const result = router.run(url.pathname);
   const rscStream = reactServerDomServer.renderToReadableStream(
     result.node,
-    createBundlerConfig({ renderId })
+    createBundlerConfig()
   );
   return { rscStream, status: result.match.notFound ? 404 : 200 };
 }

--- a/packages/react-server/examples/basic/src/entry-server.tsx
+++ b/packages/react-server/examples/basic/src/entry-server.tsx
@@ -1,8 +1,12 @@
 import reactDomServer from "react-dom/server.edge";
 import { injectRSCPayload } from "rsc-html-stream/server";
 import type { ViteDevServer } from "vite";
-import { moduleMap, unwrapActionRequest, unwrapRscRequest } from "./lib/shared";
-import { initDomWebpackSsr, invalidateImportCacheOnFinish } from "./lib/ssr";
+import { unwrapActionRequest, unwrapRscRequest } from "./lib/shared";
+import {
+  createModuleMap,
+  initDomWebpackSsr,
+  invalidateImportCacheOnFinish,
+} from "./lib/ssr";
 
 // injected globals during dev
 declare let __devServer: ViteDevServer;
@@ -17,16 +21,12 @@ export async function handler(request: Request): Promise<Response> {
     await entryRsc.actionHandler(actionRequest);
   }
 
-  // unique id for each render (see src/lib/ssr.tsx for the detail)
-  const renderId = Math.random().toString(36).slice(2);
-
   // check rsc-only request
   const rscRequest = unwrapRscRequest(request);
 
   // rsc
   const { rscStream, status } = entryRsc.render({
     request: rscRequest ?? request,
-    renderId,
   });
   if (rscRequest) {
     return new Response(rscStream, {
@@ -38,7 +38,6 @@ export async function handler(request: Request): Promise<Response> {
 
   // ssr rsc
   let htmlStream = await renderHtml(rscStream);
-  htmlStream = htmlStream.pipeThrough(invalidateImportCacheOnFinish(renderId));
   return new Response(htmlStream, {
     status,
     headers: {
@@ -65,13 +64,15 @@ async function renderHtml(rscStream: ReadableStream): Promise<ReadableStream> {
 
   const [rscStream1, rscStream2] = rscStream.tee();
 
+  // use unique id for each render to simplify ssr module invalidation during dev
+  // (see src/lib/ssr.tsx for details)
+  const renderId = Math.random().toString(36).slice(2);
+
   const rscNode = await reactServerDomClient.createFromReadableStream(
     rscStream1,
     {
       ssrManifest: {
-        // null is fine?
-        // or use this to inject "renderId" for dev?
-        moduleMap: moduleMap,
+        moduleMap: createModuleMap({ renderId }),
         moduleLoading: null,
       },
     }
@@ -80,6 +81,7 @@ async function renderHtml(rscStream: ReadableStream): Promise<ReadableStream> {
   const ssrStream = await reactDomServer.renderToReadableStream(rscNode);
 
   return ssrStream
+    .pipeThrough(invalidateImportCacheOnFinish(renderId))
     .pipeThrough(await injectToHtmlTempalte())
     .pipeThrough(injectRSCPayload(rscStream2));
 }

--- a/packages/react-server/examples/basic/src/entry-server.tsx
+++ b/packages/react-server/examples/basic/src/entry-server.tsx
@@ -56,7 +56,7 @@ async function importEntryRsc(): Promise<typeof import("./entry-rsc")> {
 
 // TODO: full <html> render by RSC?
 async function renderHtml(rscStream: ReadableStream): Promise<ReadableStream> {
-  initDomWebpackSsr();
+  await initDomWebpackSsr();
 
   const { default: reactServerDomClient } = await import(
     "react-server-dom-webpack/client.edge"

--- a/packages/react-server/examples/basic/src/entry-server.tsx
+++ b/packages/react-server/examples/basic/src/entry-server.tsx
@@ -78,7 +78,11 @@ async function renderHtml(rscStream: ReadableStream): Promise<ReadableStream> {
     }
   );
 
-  const ssrStream = await reactDomServer.renderToReadableStream(rscNode);
+  const ssrStream = await reactDomServer.renderToReadableStream(rscNode, {
+    // TODO
+    bootstrapModules: [],
+    bootstrapScripts: [],
+  });
 
   return ssrStream
     .pipeThrough(invalidateImportCacheOnFinish(renderId))

--- a/packages/react-server/examples/basic/src/lib/csr.tsx
+++ b/packages/react-server/examples/basic/src/lib/csr.tsx
@@ -13,6 +13,7 @@ async function clientImport(id: string) {
     // transformed to "?import"
     return import(/* @vite-ignore */ id);
   } else {
+    // TODO: avoid extra round trip for this dynamic import
     const clientReferences = await import(
       "/dist/rsc/client-references.js" as string
     );

--- a/packages/react-server/examples/basic/src/lib/csr.tsx
+++ b/packages/react-server/examples/basic/src/lib/csr.tsx
@@ -6,12 +6,7 @@ import type { WebpackRequire } from "./types";
 //   https://github.com/facebook/react/pull/26926#discussion_r1236251023
 // vite uses import with timestamp paramemter during dev,
 // so manual invalidation doesn't look necessary for client?
-const memoImport = memoize(clientImport);
-
-const csrWebpackRequire: WebpackRequire = (id) => {
-  // console.log("[__webpack_require__]", { id });
-  return memoImport(id);
-};
+const csrWebpackRequire: WebpackRequire = memoize(clientImport);
 
 async function clientImport(id: string) {
   if (import.meta.env.DEV) {

--- a/packages/react-server/examples/basic/src/lib/csr.tsx
+++ b/packages/react-server/examples/basic/src/lib/csr.tsx
@@ -1,5 +1,4 @@
 import { memoize, tinyassert } from "@hiogawa/utils";
-import { unwrapRenderId } from "./shared";
 import type { WebpackRequire } from "./types";
 
 // __webpack_require__ needs to return stable promise during single render.
@@ -10,7 +9,6 @@ import type { WebpackRequire } from "./types";
 const memoImport = memoize(clientImport);
 
 const csrWebpackRequire: WebpackRequire = (id) => {
-  id = unwrapRenderId(id)[0];
   return memoImport(id);
 };
 

--- a/packages/react-server/examples/basic/src/lib/csr.tsx
+++ b/packages/react-server/examples/basic/src/lib/csr.tsx
@@ -9,12 +9,13 @@ import type { WebpackRequire } from "./types";
 const memoImport = memoize(clientImport);
 
 const csrWebpackRequire: WebpackRequire = (id) => {
+  // console.log("[__webpack_require__]", { id });
   return memoImport(id);
 };
 
 async function clientImport(id: string) {
   if (import.meta.env.DEV) {
-    // transformed to "?import" which always returns latest module
+    // transformed to "?import"
     return import(/* @vite-ignore */ id);
   } else {
     const clientReferences = await import(

--- a/packages/react-server/examples/basic/src/lib/rsc.tsx
+++ b/packages/react-server/examples/basic/src/lib/rsc.tsx
@@ -1,5 +1,4 @@
 import { tinyassert } from "@hiogawa/utils";
-import { wrapRenderId } from "./shared";
 import type { BundlerConfig, ImportManifestEntry } from "./types";
 
 // https://github.com/lazarv/react-server/blob/2ff6105e594666065be206729858ecfed6f5e8d8/packages/react-server/client/components.mjs#L15-L25
@@ -21,16 +20,11 @@ export function createClientReference(id: string): React.FC {
   }) as any;
 }
 
-// renderId: xxx (only used for dev)
 // $$id: /src/components/counter.tsx::Counter
 //   ⇕
-// id: /src/components/counter.tsx?__renderId=xxx
+// id: /src/components/counter.tsx
 // name: Counter
-export function createBundlerConfig({
-  renderId,
-}: {
-  renderId: string;
-}): BundlerConfig {
+export function createBundlerConfig(): BundlerConfig {
   return new Proxy(
     {},
     {
@@ -39,7 +33,6 @@ export function createBundlerConfig({
         let [id, name] = $$id.split("::");
         tinyassert(id);
         tinyassert(name);
-        id = wrapRenderId(id, renderId);
         return { id, name, chunks: [] } satisfies ImportManifestEntry;
       },
     }

--- a/packages/react-server/examples/basic/src/lib/shared.tsx
+++ b/packages/react-server/examples/basic/src/lib/shared.tsx
@@ -1,31 +1,5 @@
 import { tinyassert } from "@hiogawa/utils";
-import type {
-  CallServerCallback,
-  ImportManifestEntry,
-  ModuleMap,
-} from "./types";
-
-export const moduleMap: ModuleMap = new Proxy(
-  {},
-  {
-    get(_target, id, _receiver) {
-      return new Proxy(
-        {},
-        {
-          get(_target, name, _receiver) {
-            tinyassert(typeof id === "string");
-            tinyassert(typeof name === "string");
-            return {
-              id,
-              name,
-              chunks: [],
-            } satisfies ImportManifestEntry;
-          },
-        }
-      );
-    },
-  }
-);
+import type { CallServerCallback } from "./types";
 
 const RSC_PARAM = "__rsc";
 
@@ -69,19 +43,6 @@ export function unwrapActionRequest(request: Request) {
     return { request, id };
   }
   return;
-}
-
-const RENDER_ID_SEP = "?__renderId=";
-
-export function wrapRenderId(id: string, tag: string) {
-  if (import.meta.env.DEV) {
-    return `${id}${RENDER_ID_SEP}${tag}`;
-  }
-  return id;
-}
-
-export function unwrapRenderId(id: string) {
-  return id.split(RENDER_ID_SEP) as [string, string];
 }
 
 // https://github.com/facebook/react/blob/89021fb4ec9aa82194b0788566e736a4cedfc0e4/packages/react-server-dom-webpack/src/ReactFlightWebpackReferences.js#L87

--- a/packages/react-server/examples/basic/src/lib/ssr.tsx
+++ b/packages/react-server/examples/basic/src/lib/ssr.tsx
@@ -4,8 +4,7 @@ import type { ImportManifestEntry, ModuleMap, WebpackRequire } from "./types";
 const memoImport = memoize(ssrImport);
 
 // during dev, import cache needs to be isolated for each SSR run
-// so that import/ssrLoadModule will load fresh module
-// while keeping Promise stable during the single render for requireAsyncModule trick:
+// so that import/ssrLoadModule will load fresh module while keeping Promise stable
 //   https://github.com/facebook/react/pull/26985
 //   https://github.com/facebook/react/pull/26926#discussion_r1236251023
 //
@@ -29,6 +28,7 @@ export function invalidateImportCacheOnFinish<T>(renderId: string) {
 // __webpack_require__ is called at least twice for preloadModule and requireModule
 // https://github.com/facebook/react/blob/706d95f486fbdec35b771ea4aaf3e78feb907249/packages/react-server-dom-webpack/src/ReactFlightClientConfigBundlerWebpack.js
 const ssrWebpackRequire: WebpackRequire = (id) => {
+  // console.log("[__webpack_require__]", { id });
   if (import.meta.env.DEV) {
     const [file, renderId] = unwrapRenderId(id);
     return memoImportByRenderId.get(renderId)(file);

--- a/packages/react-server/examples/basic/src/lib/ssr.tsx
+++ b/packages/react-server/examples/basic/src/lib/ssr.tsx
@@ -1,7 +1,8 @@
 import { DefaultMap, memoize, tinyassert } from "@hiogawa/utils";
 import type { ImportManifestEntry, ModuleMap, WebpackRequire } from "./types";
 
-const memoImport = memoize(ssrImport);
+// __webpack_require__ is called at least twice for preloadModule and requireModule
+// https://github.com/facebook/react/blob/706d95f486fbdec35b771ea4aaf3e78feb907249/packages/react-server-dom-webpack/src/ReactFlightClientConfigBundlerWebpack.js
 
 // during dev, import cache needs to be isolated for each SSR run
 // so that import/ssrLoadModule will load fresh module while keeping Promise stable
@@ -13,48 +14,43 @@ const memoImport = memoize(ssrImport);
 //   however it's not supported well on Stackblitz, so we avoid relying on it for now.
 //
 const memoImportByRenderId = new DefaultMap<string, WebpackRequire>(() =>
-  memoize(ssrImport)
+  // `import` is transformed to `ssrLoadModule` during dev
+  memoize((id) => import(/* @vite-ignore */ id))
 );
 
 // cleanup importCache after render to avoid leaking memory during dev
 export function invalidateImportCacheOnFinish<T>(renderId: string) {
   return new TransformStream<T, T>({
     flush() {
-      memoImportByRenderId.delete(renderId);
+      if (import.meta.env.DEV) {
+        memoImportByRenderId.delete(renderId);
+      }
     },
   });
 }
 
-// __webpack_require__ is called at least twice for preloadModule and requireModule
-// https://github.com/facebook/react/blob/706d95f486fbdec35b771ea4aaf3e78feb907249/packages/react-server-dom-webpack/src/ReactFlightClientConfigBundlerWebpack.js
-const ssrWebpackRequire: WebpackRequire = (id) => {
-  // console.log("[__webpack_require__]", { id });
+async function createWebpackRequire(): Promise<WebpackRequire> {
   if (import.meta.env.DEV) {
-    const [file, renderId] = unwrapRenderId(id);
-    return memoImportByRenderId.get(renderId)(file);
-  } else {
-    return memoImport(id);
-  }
-};
-
-async function ssrImport(id: string): Promise<unknown> {
-  if (import.meta.env.DEV) {
-    // transformed to `ssrLoadModule` during dev
-    return import(/* @vite-ignore */ id);
+    return (id) => {
+      const [file, renderId] = unwrapRenderId(id);
+      return memoImportByRenderId.get(renderId)(file);
+    };
   } else {
     // `as string` to silence ts error
     const clientReferences = await import(
       "/dist/rsc/client-references.js" as string
     );
-    const dynImport = clientReferences.default[id];
-    tinyassert(dynImport, `client reference not found '${id}'`);
-    return dynImport();
+    return memoize((id) => {
+      const dynImport = clientReferences.default[id];
+      tinyassert(dynImport, `client reference not found '${id}'`);
+      return dynImport();
+    });
   }
 }
 
-export function initDomWebpackSsr() {
+export async function initDomWebpackSsr() {
   Object.assign(globalThis, {
-    __webpack_require__: ssrWebpackRequire,
+    __webpack_require__: await createWebpackRequire(),
     __webpack_chunk_load__: () => {
       throw new Error("todo: __webpack_chunk_load__");
     },


### PR DESCRIPTION
Since we can tweak `id` from `moduleMap`, RSC render doesn't need to care about `renderId` trick.
Now this trick is self-contained in SSR side.