### PR TITLE
feat(react-server): progressive enhancement

### DIFF
--- a/packages/react-server/README.md
+++ b/packages/react-server/README.md
@@ -37,6 +37,13 @@ npm run preview
 - [`./examples/starter`](./examples/starter)
 - [`./examples/basic`](./examples/basic)
 
+## Development
+
+```sh
+pnpm -C packages/react-server dev
+pnpm -C packages/react-server/examples/basic dev
+```
+
 ## Credits
 
 - https://github.com/dai-shi/waku

--- a/packages/react-server/README.md
+++ b/packages/react-server/README.md
@@ -1,6 +1,8 @@
 # @hiogawa/react-server
 
-[Try it on Stackblitz](https://stackblitz.com/edit/github-4eut84?file=README.md)
+[Try it on Stackblitz](https://stackblitz.com/edit/github-4eut84?file=src%2Froutes%2Fserver-action%2Fserver.tsx)
+
+![image](https://github.com/hi-ogawa/vite-plugins/assets/4232207/119a42ee-d68e-401d-830a-161cc53c8b24)
 
 See https://github.com/hi-ogawa/vite-plugins/issues/174 for known issues.
 

--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -116,11 +116,8 @@ test("@dev css hmr", async ({ page }) => {
   );
 });
 
-test("server action", async ({ page }) => {
+test("server action with js", async ({ page }) => {
   await page.goto("/test/action");
-
-  // TODO: should work without hydration (progressive enhancement)
-  await page.getByText("hydrated: true").click();
 
   const checkClientState = await setupCheckClientState(page);
 
@@ -139,6 +136,24 @@ test("server action", async ({ page }) => {
   await page.getByText("Count: 0").click();
 
   await checkClientState();
+});
+
+test("server action no js", async ({ browser }) => {
+  const page = await browser.newPage({ javaScriptEnabled: false });
+  await page.goto("/test/action");
+  await page.getByText("Count: 0").click();
+  await page.getByRole("button", { name: "+1" }).first().click();
+  await page.getByText("Count: 1").click();
+  await page.getByRole("button", { name: "+1" }).nth(1).click();
+  await page.getByText("Count: 2").click();
+  await page.getByRole("button", { name: "+1" }).nth(2).click();
+  await page.getByText("Count: 3").click();
+  await page.getByRole("button", { name: "-1" }).first().click();
+  await page.getByText("Count: 2").click();
+  await page.getByRole("button", { name: "-1" }).nth(1).click();
+  await page.getByText("Count: 1").click();
+  await page.getByRole("button", { name: "-1" }).nth(2).click();
+  await page.getByText("Count: 0").click();
 });
 
 test("virtual module", async ({ page }) => {

--- a/packages/react-server/examples/basic/src/routes/test/action/action.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/action/action.tsx
@@ -1,5 +1,7 @@
 "use server";
 
+import { tinyassert } from "@hiogawa/utils";
+
 let counter = 0;
 
 export function getCounter() {
@@ -8,4 +10,18 @@ export function getCounter() {
 
 export function changeCounter(formData: FormData) {
   counter += Number(formData.get("delta"));
+}
+
+let messageId = 1;
+let messages: [number, string][] = [];
+
+export function getMessages() {
+  return messages;
+}
+
+export function addMessage(formData: FormData) {
+  const message = formData.get("message");
+  tinyassert(typeof message === "string");
+  messages.push([messageId++, message]);
+  messages = messages.slice(-5);
 }

--- a/packages/react-server/examples/basic/src/routes/test/action/client.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/action/client.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { changeCounter } from "./action";
+import { addMessage, changeCounter, type getMessages } from "./action";
 
 export function Counter(props: { value: number }) {
   return (
     <form action={changeCounter} className="flex flex-col items-start gap-2">
-      <div>Count: {props.value}</div>
+      <div className="font-bold">Count: {props.value}</div>
       <div className="flex gap-2">
         <button
           className="antd-btn antd-btn-default px-2"
@@ -52,5 +52,38 @@ export function Counter2({
         <div>(client form with action via server prop)</div>
       </div>
     </form>
+  );
+}
+
+export function Chat(props: { messages: ReturnType<typeof getMessages> }) {
+  return (
+    <div className="flex flex-col gap-2">
+      <h4 className="font-bold">Messages</h4>
+      <form
+        className="flex flex-col items-start gap-2"
+        action={addMessage}
+        onSubmit={(e) => {
+          // e.currentTarget.f
+          console.log(e);
+          e.target;
+        }}
+      >
+        <div className="flex gap-2">
+          <input
+            name="message"
+            className="antd-input px-2"
+            placeholder="write something..."
+          />
+          <button className="antd-btn antd-btn-default px-2">Send</button>
+        </div>
+      </form>
+      <ul>
+        {props.messages.map(([id, message]) => (
+          <li key={id}>
+            [{id}] {message}
+          </li>
+        ))}
+      </ul>
+    </div>
   );
 }

--- a/packages/react-server/examples/basic/src/routes/test/action/client.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/action/client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import React from "react";
 import { addMessage, changeCounter, type getMessages } from "./action";
 
 export function Counter(props: { value: number }) {
@@ -56,27 +57,16 @@ export function Counter2({
 }
 
 export function Chat(props: { messages: ReturnType<typeof getMessages> }) {
+  const [input, setInput] = React.useState("");
+
+  // clear input after submit (really this way?)
+  React.useEffect(() => {
+    setInput("");
+  }, [props.messages]);
+
   return (
     <div className="flex flex-col gap-2">
       <h4 className="font-bold">Messages</h4>
-      <form
-        className="flex flex-col items-start gap-2"
-        action={addMessage}
-        onSubmit={(e) => {
-          // e.currentTarget.f
-          console.log(e);
-          e.target;
-        }}
-      >
-        <div className="flex gap-2">
-          <input
-            name="message"
-            className="antd-input px-2"
-            placeholder="write something..."
-          />
-          <button className="antd-btn antd-btn-default px-2">Send</button>
-        </div>
-      </form>
       <ul>
         {props.messages.map(([id, message]) => (
           <li key={id}>
@@ -84,6 +74,19 @@ export function Chat(props: { messages: ReturnType<typeof getMessages> }) {
           </li>
         ))}
       </ul>
+      <form className="flex flex-col items-start gap-2" action={addMessage}>
+        <div className="flex gap-2">
+          <input
+            name="message"
+            className="antd-input px-2"
+            placeholder="write something..."
+            required
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+          />
+          <button className="antd-btn antd-btn-default px-2">Send</button>
+        </div>
+      </form>
     </div>
   );
 }

--- a/packages/react-server/examples/basic/src/routes/test/action/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/action/page.tsx
@@ -1,12 +1,15 @@
-import { changeCounter, getCounter } from "./action";
-import { Counter, Counter2 } from "./client";
+import { changeCounter, getCounter, getMessages } from "./action";
+import { Chat, Counter, Counter2 } from "./client";
 
 export default async function Page() {
   return (
-    <div className="flex flex-col gap-2">
-      <Counter value={getCounter()} />
-      <Counter2 action={changeCounter} />
-      <Counter3 />
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-2">
+        <Counter value={getCounter()} />
+        <Counter2 action={changeCounter} />
+        <Counter3 />
+      </div>
+      <Chat messages={getMessages()} />
     </div>
   );
 }

--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/react-server",
-  "version": "0.0.0",
+  "version": "0.1.0-pre.0",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/packages/react-server/src/entry/browser.tsx
+++ b/packages/react-server/src/entry/browser.tsx
@@ -36,7 +36,6 @@ export async function start() {
       // TODO: proper encoding?
       await reactServerDomClient.encodeReply(args);
     } else {
-      // TODO
       // $ACTION_ID is injected during SSR
       // but it can stripped away on client re-render (e.g. HMR?)
       // so we do it here again to inject on client.

--- a/packages/react-server/src/entry/browser.tsx
+++ b/packages/react-server/src/entry/browser.tsx
@@ -4,7 +4,7 @@ import reactDomClient from "react-dom/client";
 import { rscStream } from "rsc-html-stream/client";
 import { __history, initDomWebpackCsr, initHistory } from "../lib/csr";
 import { createDebug } from "../lib/debug";
-import { wrapActionRequest, wrapRscRequestUrl } from "../lib/shared";
+import { wrapRscRequestUrl } from "../lib/shared";
 import type { CallServerCallback } from "../lib/types";
 
 const debug = createDebug("browser");
@@ -31,13 +31,16 @@ export async function start() {
 
   // server action callback
   const callServer: CallServerCallback = async (id, args) => {
-    updateRscByFetch(
-      wrapActionRequest(
-        __history.location.href,
-        id,
-        await reactServerDomClient.encodeReply(args)
-      )
-    );
+    debug("callServer", { id, args });
+    if (0) {
+      // TODO: proper encoding?
+      await reactServerDomClient.encodeReply(args);
+    }
+    const request = new Request(wrapRscRequestUrl(__history.location.href), {
+      method: "POST",
+      body: args[0],
+    });
+    updateRscByFetch(request);
   };
 
   // expose as global to be used for createServerReference

--- a/packages/react-server/src/entry/browser.tsx
+++ b/packages/react-server/src/entry/browser.tsx
@@ -4,7 +4,7 @@ import reactDomClient from "react-dom/client";
 import { rscStream } from "rsc-html-stream/client";
 import { __history, initDomWebpackCsr, initHistory } from "../lib/csr";
 import { createDebug } from "../lib/debug";
-import { wrapRscRequestUrl } from "../lib/shared";
+import { injectActionId, wrapRscRequestUrl } from "../lib/shared";
 import type { CallServerCallback } from "../lib/types";
 
 const debug = createDebug("browser");
@@ -35,6 +35,13 @@ export async function start() {
     if (0) {
       // TODO: proper encoding?
       await reactServerDomClient.encodeReply(args);
+    } else {
+      // TODO
+      // $ACTION_ID is injected during SSR
+      // but it can stripped away on client re-render (e.g. HMR?)
+      // so we do it here again to inject on client.
+      tinyassert(args[0] instanceof FormData);
+      injectActionId(args[0], id);
     }
     const request = new Request(wrapRscRequestUrl(__history.location.href), {
       method: "POST",

--- a/packages/react-server/src/entry/react-server.tsx
+++ b/packages/react-server/src/entry/react-server.tsx
@@ -2,7 +2,6 @@
 import rscGlobRoutes from "virtual:rsc-glob-routes";
 import { objectMapKeys } from "@hiogawa/utils";
 import reactServerDomServer from "react-server-dom-webpack/server.edge";
-import type { ViteDevServer } from "vite";
 import { generateRouteTree, matchRoute, renderMatchRoute } from "../lib/router";
 import { createBundlerConfig } from "../lib/rsc";
 
@@ -36,8 +35,6 @@ function createRouter() {
 //
 // server action
 //
-
-declare let __rscDevServer: ViteDevServer;
 
 export async function actionHandler({
   request,

--- a/packages/react-server/src/entry/react-server.tsx
+++ b/packages/react-server/src/entry/react-server.tsx
@@ -4,6 +4,11 @@ import { objectMapKeys } from "@hiogawa/utils";
 import reactServerDomServer from "react-server-dom-webpack/server.edge";
 import { generateRouteTree, matchRoute, renderMatchRoute } from "../lib/router";
 import { createBundlerConfig } from "../lib/rsc";
+import { ejectActionId } from "../lib/shared";
+
+//
+// render RSC
+//
 
 export function render({ request }: { request: Request }) {
   const url = new URL(request.url);
@@ -14,6 +19,10 @@ export function render({ request }: { request: Request }) {
   );
   return { rscStream, status: result.match.notFound ? 404 : 200 };
 }
+
+//
+// glob import routes
+//
 
 const router = createRouter();
 
@@ -36,13 +45,14 @@ function createRouter() {
 // server action
 //
 
-export async function actionHandler({
-  request,
-  id,
-}: {
-  request: Request;
-  id: string;
-}) {
+export async function actionHandler({ request }: { request: Request }) {
+  const formData = await request.formData();
+  if (0) {
+    // TODO: proper decoding?
+    await reactServerDomServer.decodeReply(formData);
+  }
+  const id = ejectActionId(formData);
+
   let action: Function;
   const [file, name] = id.split("::") as [string, string];
   if (import.meta.env.DEV) {
@@ -54,8 +64,7 @@ export async function actionHandler({
     const mod = await virtual.default[file]();
     action = mod[name];
   }
-  // TODO: decode properly?
-  let formData = await request.formData();
-  const decoded = (await reactServerDomServer.decodeReply(formData)) as any;
-  await action(decoded[0]);
+
+  // TODO: action return value?
+  await action(formData);
 }

--- a/packages/react-server/src/entry/server.tsx
+++ b/packages/react-server/src/entry/server.tsx
@@ -1,7 +1,7 @@
 import { typedBoolean } from "@hiogawa/utils";
 import reactDomServer from "react-dom/server.edge";
 import { injectRSCPayload } from "rsc-html-stream/server";
-import { unwrapActionRequest, unwrapRscRequest } from "../lib/shared";
+import { unwrapRscRequest } from "../lib/shared";
 import {
   createModuleMap,
   initDomWebpackSsr,
@@ -9,12 +9,11 @@ import {
 } from "../lib/ssr";
 
 export async function handler(request: Request): Promise<Response> {
-  const entryRsc = (await importEntryRsc()) as any;
+  const entryRsc = await importEntryRsc();
 
   // action
-  const actionRequest = unwrapActionRequest(request);
-  if (actionRequest) {
-    await entryRsc.actionHandler(actionRequest);
+  if (request.method === "POST") {
+    await entryRsc.actionHandler({ request });
   }
 
   // check rsc-only request

--- a/packages/react-server/src/entry/server.tsx
+++ b/packages/react-server/src/entry/server.tsx
@@ -1,17 +1,12 @@
 import { typedBoolean } from "@hiogawa/utils";
 import reactDomServer from "react-dom/server.edge";
 import { injectRSCPayload } from "rsc-html-stream/server";
-import type { ViteDevServer } from "vite";
 import { unwrapActionRequest, unwrapRscRequest } from "../lib/shared";
 import {
   createModuleMap,
   initDomWebpackSsr,
   invalidateImportCacheOnFinish,
 } from "../lib/ssr";
-
-// injected globals during dev
-declare let __devServer: ViteDevServer;
-declare let __rscDevServer: ViteDevServer;
 
 export async function handler(request: Request): Promise<Response> {
   const entryRsc = (await importEntryRsc()) as any;
@@ -98,10 +93,10 @@ async function injectToHtmlTempalte() {
 
   if (import.meta.env.DEV) {
     // fix dev FOUC (cf. https://github.com/hi-ogawa/vite-plugins/pull/110)
-    // TODO: for now only direct dependency of entry-client only...
-    const modNode = await __devServer.moduleGraph.getModuleByUrl(
-      "/src/entry-client"
-    );
+    // for now crawl only direct dependency of entry-client
+    const entry = "/src/entry-client";
+    await __devServer.transformRequest(entry);
+    const modNode = await __devServer.moduleGraph.getModuleByUrl(entry);
     if (modNode) {
       const links = [...modNode.importedModules]
         .map((modNode) => modNode.id)

--- a/packages/react-server/src/entry/types-global.d.ts
+++ b/packages/react-server/src/entry/types-global.d.ts
@@ -1,0 +1,4 @@
+// accessing ViteDevServer from anywhere
+// injected by vitePluginReactServer during dev
+declare const __devServer: import("vite").ViteDevServer;
+declare const __rscDevServer: import("vite").ViteDevServer;

--- a/packages/react-server/src/lib/debug.ts
+++ b/packages/react-server/src/lib/debug.ts
@@ -17,3 +17,7 @@ export function createDebug(tag: string) {
     }
   };
 }
+
+// TODO: better api?
+//   debug.plugin("...")
+//   debug.ssr.serverReference("");

--- a/packages/react-server/src/lib/shared.tsx
+++ b/packages/react-server/src/lib/shared.tsx
@@ -29,7 +29,7 @@ export function unwrapRscRequest(request: Request): Request | undefined {
 // cf. https://github.com/facebook/react/pull/26774
 const ACTION_ID_PREFIX = "$ACTION_ID_";
 
-function injectActionId(formData: FormData, id: string) {
+export function injectActionId(formData: FormData, id: string) {
   formData.set(ACTION_ID_PREFIX + id, "");
 }
 

--- a/packages/react-server/src/lib/shared.tsx
+++ b/packages/react-server/src/lib/shared.tsx
@@ -65,7 +65,6 @@ export function createServerReference(id: string): React.FC {
       $$bound: { value: null, configurable: true },
       $$FORM_ACTION: {
         value: (name: string) => {
-          console.log("[createServerReference]", { id, name });
           const data = new FormData();
           injectActionId(data, id);
           return {
@@ -86,7 +85,6 @@ export function createServerReference(id: string): React.FC {
   ) as any;
 }
 
-// TODO: refactor with createServerReference
 export function createServerReferenceForRsc(
   id: string,
   action: Function
@@ -100,18 +98,6 @@ export function createServerReferenceForRsc(
       configurable: true,
     },
     $$bound: { value: null, configurable: true },
-    // TODO: progressive enhancement?
-    // https://github.com/facebook/react/pull/26774
-    $$FORM_ACTION: {
-      value: (name: string) => {
-        return {
-          name,
-          method: "POST",
-          encType: "multipart/form-data",
-          data: new FormData(),
-        };
-      },
-    },
     bind: {
       value: () => {
         throw new Error("todo: createServerReference.bind");

--- a/packages/react-server/src/lib/types.ts
+++ b/packages/react-server/src/lib/types.ts
@@ -31,4 +31,4 @@ export type WebpackRequire = (id: string) => Promise<unknown>;
 // TODO
 export type WebpackChunkLoad = (id: string) => Promise<unknown>;
 
-export type CallServerCallback = (id: any, args: unknown) => Promise<unknown>;
+export type CallServerCallback = (id: any, args: any) => Promise<unknown>;


### PR DESCRIPTION
I'm not sure what's `encodeReply/decodeReply` is doing, but it looks like I can ditch them for now.
I simplified action id encoding to support progressive enhancement by manually injecting `$ACTION_ID_` via `$$FORM_ACTION`.
Probably this works only because there's no magical `bind`, but I guess it's fine for now.

related?
- https://github.com/facebook/react/pull/26774