### PR TITLE
chore(react-server): use "latest" for example dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,10 @@ jobs:
           node-version: 20
       - run: corepack enable
       - run: pnpm i
-      - run: pnpm --filter @hiogawa/react-server-example-basic... build
+      - run: pnpm --filter @hiogawa/react-server... build
       - run: npx playwright install chromium
       - run: pnpm -C packages/react-server/examples/basic test-e2e
+      - run: pnpm -C packages/react-server/examples/basic build
       - run: pnpm -C packages/react-server/examples/basic test-e2e-preview
 
   test-vite-node-miniflare:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           node-version: 20
       - run: corepack enable
       - run: pnpm i
-      - run: pnpm --filter @hiogawa/react-server... build
+      - run: pnpm build
       - run: npx playwright install chromium
       - run: pnpm -C packages/react-server/examples/basic test-e2e
       - run: pnpm -C packages/react-server/examples/basic build

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-# https://pnpm.io/npmrc#link-workspace-packages
-# examples uses "latest" of monorepo packages
-link-workspace-packages=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
 # https://pnpm.io/npmrc#link-workspace-packages
 # examples uses "latest" of monorepo packages
-link-workspace-packages=false
+link-workspace-packages=true

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "pnpm -r build",
+    "build": "pnpm -r '--filter=!*example*' build",
     "dev": "pnpm run --stream /^dev:/",
     "dev:demo": "pnpm -C packages/demo dev",
     "tsc": "tsc -b packages/*/tsconfig.json packages/*/examples/*/tsconfig.json examples/*/tsconfig.json",

--- a/packages/react-server/examples/starter/package.json
+++ b/packages/react-server/examples/starter/package.json
@@ -12,14 +12,14 @@
     "cf-release": "cd misc/cloudflare-workers && wrangler deploy"
   },
   "dependencies": {
-    "@hiogawa/react-server": "0.0.0",
+    "@hiogawa/react-server": "latest",
     "react": "18.3.0-canary-6c3b8dbfe-20240226",
     "react-dom": "18.3.0-canary-6c3b8dbfe-20240226",
     "react-server-dom-webpack": "18.3.0-canary-6c3b8dbfe-20240226"
   },
   "devDependencies": {
     "@hattip/adapter-node": "^0.0.43",
-    "@hiogawa/vite-plugin-ssr-middleware": "0.0.3",
+    "@hiogawa/vite-plugin-ssr-middleware": "latest",
     "@types/react": "18.2.59",
     "@types/react-dom": "18.2.19",
     "@vitejs/plugin-react": "^4.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -332,8 +332,8 @@ importers:
   packages/react-server/examples/starter:
     dependencies:
       '@hiogawa/react-server':
-        specifier: 0.0.0
-        version: 0.0.0(react-dom@18.3.0-canary-6c3b8dbfe-20240226)(react-server-dom-webpack@18.3.0-canary-6c3b8dbfe-20240226)(react@18.3.0-canary-6c3b8dbfe-20240226)(vite@5.1.0)
+        specifier: latest
+        version: link:../..
       react:
         specifier: 18.3.0-canary-6c3b8dbfe-20240226
         version: 18.3.0-canary-6c3b8dbfe-20240226
@@ -348,8 +348,8 @@ importers:
         specifier: ^0.0.43
         version: 0.0.43
       '@hiogawa/vite-plugin-ssr-middleware':
-        specifier: 0.0.3
-        version: 0.0.3(vite@5.1.0)
+        specifier: latest
+        version: link:../../../vite-plugin-ssr-middleware
       '@types/react':
         specifier: 18.2.59
         version: 18.2.59
@@ -2321,24 +2321,6 @@ packages:
         optional: true
     dev: true
 
-  /@hiogawa/react-server@0.0.0(react-dom@18.3.0-canary-6c3b8dbfe-20240226)(react-server-dom-webpack@18.3.0-canary-6c3b8dbfe-20240226)(react@18.3.0-canary-6c3b8dbfe-20240226)(vite@5.1.0):
-    resolution: {integrity: sha512-q0tapixzKWCO0OBGfdCDub+v2P8qBHih4pTcvYsAl4JoldFFFqU2crZgEDRgp0j24cyeWcQHwldkJypTEpxx8w==}
-    peerDependencies:
-      react: 18.3.0-canary-6c3b8dbfe-20240226
-      react-dom: 18.3.0-canary-6c3b8dbfe-20240226
-      react-server-dom-webpack: 18.3.0-canary-6c3b8dbfe-20240226
-      vite: ^5.1.0
-    dependencies:
-      '@tanstack/history': 1.15.13
-      fast-glob: 3.3.2
-      magic-string: 0.30.7
-      react: 18.3.0-canary-6c3b8dbfe-20240226
-      react-dom: 18.3.0-canary-6c3b8dbfe-20240226(react@18.3.0-canary-6c3b8dbfe-20240226)
-      react-server-dom-webpack: 18.3.0-canary-6c3b8dbfe-20240226(react-dom@18.3.0-canary-6c3b8dbfe-20240226)(react@18.3.0-canary-6c3b8dbfe-20240226)(webpack@5.90.3)
-      rsc-html-stream: 0.0.3
-      vite: 5.1.0(@types/node@18.16.18)
-    dev: false
-
   /@hiogawa/theme-script@0.0.4-pre.3(vite@5.1.6):
     resolution: {integrity: sha512-2uxVhemdAMUFE/OaUcaTT2QeZsXnxtnF/CLNs+CcrlgwaUXXfsnXUTvUZCz8MTmxzzz4Vp5hfAyi4pp58XHJCQ==}
     peerDependencies:
@@ -2417,14 +2399,6 @@ packages:
 
   /@hiogawa/utils@1.6.2:
     resolution: {integrity: sha512-t2xSsf6UZA6Y1NjrV80RUse5cElGTBxZOOs+RLSTI82O5u9yPhPXQ8xlxvExBqlR2SwjBvikCHqs4Oe6waWw1Q==}
-
-  /@hiogawa/vite-plugin-ssr-middleware@0.0.3(vite@5.1.0):
-    resolution: {integrity: sha512-84bzaAuImty4s4vHjOk5MQMzmDs0W0GP43fOTFhsBfj/MSJCNJ68elmPNZWs57WkIEzcdB4haY/P8Nf4ZGH8Qw==}
-    peerDependencies:
-      vite: '*'
-    dependencies:
-      vite: 5.1.0(@types/node@18.16.18)
-    dev: true
 
   /@iconify-json/ri@1.1.9:
     resolution: {integrity: sha512-YOSBce/bzkORxBI1mYz4b9vidaJDeorwzuddFoIV9ajazncI55VLtQ+puIra0d3HQhYfswNSwRy8PrHTZmvaOg==}


### PR DESCRIPTION
notes
- [x] skip building examples on CI (magical pnpm --filter?)
- [x] keep `latest` for the ease of degit template
- [x] ~`pnpm.overrides` to locally overrides to `workspace:*`~ probably this is already the default behavior

later
- [ ] test fresh installation by running same e2e on degit template
  - [ ] requires setting up override or `file:` protocol
- [ ] move current `examples` and `packages/demo` to `packages/vite-glob-routes/examples`