### PR TITLE
test(react-server): test 3rd party server component library

### DIFF
--- a/packages/react-server/examples/basic/deps/server-component/index.d.ts
+++ b/packages/react-server/examples/basic/deps/server-component/index.d.ts
@@ -1,0 +1,3 @@
+declare function TestDepServerComponent(): Promise<string>;
+
+export { TestDepServerComponent };

--- a/packages/react-server/examples/basic/deps/server-component/index.js
+++ b/packages/react-server/examples/basic/deps/server-component/index.js
@@ -1,0 +1,4 @@
+export async function TestDepServerComponent() {
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  return "TestDepServerComponent";
+}

--- a/packages/react-server/examples/basic/deps/server-component/index.js
+++ b/packages/react-server/examples/basic/deps/server-component/index.js
@@ -1,4 +1,6 @@
+import React from "react";
+
 export async function TestDepServerComponent() {
   await new Promise((resolve) => setTimeout(resolve, 50));
-  return "TestDepServerComponent";
+  return React.createElement("span", null, "TestDepServerComponent");
 }

--- a/packages/react-server/examples/basic/deps/server-component/package.json
+++ b/packages/react-server/examples/basic/deps/server-component/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@hiogawa/test-dep-use-client",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "types": "./index.d.ts",
+    "default": "./index.js"
+  }
+}

--- a/packages/react-server/examples/basic/deps/server-component/package.json
+++ b/packages/react-server/examples/basic/deps/server-component/package.json
@@ -5,5 +5,8 @@
   "exports": {
     "types": "./index.d.ts",
     "default": "./index.js"
+  },
+  "dependencies": {
+    "react": "*"
   }
 }

--- a/packages/react-server/examples/basic/deps/server-component/package.json
+++ b/packages/react-server/examples/basic/deps/server-component/package.json
@@ -8,5 +8,8 @@
   },
   "dependencies": {
     "react": "*"
+  },
+  "peerDependencies": {
+    "react": "*"
   }
 }

--- a/packages/react-server/examples/basic/deps/use-client/index.js
+++ b/packages/react-server/examples/basic/deps/use-client/index.js
@@ -1,5 +1,7 @@
 "use client";
 
+import React from "react";
+
 export function TestDepUseClient() {
-  return "TestDepUseClient";
+  return React.createElement("span", null, "TestDepUseClient");
 }

--- a/packages/react-server/examples/basic/deps/use-client/package.json
+++ b/packages/react-server/examples/basic/deps/use-client/package.json
@@ -5,5 +5,8 @@
   "exports": {
     "types": "./index.d.ts",
     "default": "./index.js"
+  },
+  "dependencies": {
+    "react": "*"
   }
 }

--- a/packages/react-server/examples/basic/deps/use-client/package.json
+++ b/packages/react-server/examples/basic/deps/use-client/package.json
@@ -8,5 +8,8 @@
   },
   "dependencies": {
     "react": "*"
+  },
+  "peerDependencies": {
+    "react": "*"
   }
 }

--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -161,20 +161,20 @@ test("use client > virtual module", async ({ page }) => {
   await page.getByText("TestVirtualUseClient").click();
 });
 
-test("use client > lib fixture", async ({ page }) => {
+test("use client > fixture", async ({ page }) => {
   await page.goto("/test/deps");
   await page.getByText("TestDepUseClient").click();
 });
 
-test("use client > lib 3rd party", async ({ page }) => {
+test("use client > react-wrap-balancer", async ({ page }) => {
   await page.goto("/test/deps");
   await page.getByText("BalancerNamed").click();
   await page.getByText("BalancerDefault").click();
 });
 
-test("server compnoent > lib 3rd party", async ({ page }) => {
+test("server compnoent > fixture", async ({ page }) => {
   await page.goto("/test/deps");
-  await page.getByText('"hello brightness"').click();
+  await page.getByText("TestDepServerComponent").click();
 });
 
 test("RouteProps.request", async ({ page }) => {

--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -166,10 +166,15 @@ test("use client > lib fixture", async ({ page }) => {
   await page.getByText("TestDepUseClient").click();
 });
 
-test("use client > lib 3rd party lib", async ({ page }) => {
+test("use client > lib 3rd party", async ({ page }) => {
   await page.goto("/test/deps");
-  await page.getByText("react-wrap-balancer named import").click();
-  await page.getByText("react-wrap-balancer default import").click();
+  await page.getByText("BalancerNamed").click();
+  await page.getByText("BalancerDefault").click();
+});
+
+test("server compnoent > lib 3rd party", async ({ page }) => {
+  await page.goto("/test/deps");
+  await page.getByText('"hello brightness"').click();
 });
 
 test("RouteProps.request", async ({ page }) => {

--- a/packages/react-server/examples/basic/package.json
+++ b/packages/react-server/examples/basic/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@hiogawa/react-server": "latest",
     "@hiogawa/test-dep-use-client": "file:./deps/use-client",
+    "bright": "^0.8.5",
     "react": "18.3.0-canary-6c3b8dbfe-20240226",
     "react-dom": "18.3.0-canary-6c3b8dbfe-20240226",
     "react-server-dom-webpack": "18.3.0-canary-6c3b8dbfe-20240226",

--- a/packages/react-server/examples/basic/package.json
+++ b/packages/react-server/examples/basic/package.json
@@ -17,8 +17,8 @@
   },
   "dependencies": {
     "@hiogawa/react-server": "latest",
+    "@hiogawa/test-dep-server-component": "file:./deps/server-component",
     "@hiogawa/test-dep-use-client": "file:./deps/use-client",
-    "bright": "^0.8.5",
     "react": "18.3.0-canary-6c3b8dbfe-20240226",
     "react-dom": "18.3.0-canary-6c3b8dbfe-20240226",
     "react-server-dom-webpack": "18.3.0-canary-6c3b8dbfe-20240226",

--- a/packages/react-server/examples/basic/src/routes/test/deps/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/deps/page.tsx
@@ -1,6 +1,6 @@
 import { TestVirtualUseClient } from "virtual:test-use-client";
+import { TestDepServerComponent } from "@hiogawa/test-dep-server-component";
 import { TestDepUseClient } from "@hiogawa/test-dep-use-client";
-import { Code } from "bright";
 import {
   Balancer as BalancerNamed,
   default as BalancerDefault,
@@ -17,16 +17,9 @@ export default function Page() {
         <TestDepUseClient />
       </div>
       <div>
-        <a
-          className="text-lg font-bold antd-link"
-          href="https://github.com/code-hike/bright"
-          target="_blank"
-        >
-          code-hike/bright
-        </a>
-        <Code lang="py">print("hello brightness")</Code>
+        <TestDepServerComponent />
       </div>
-      <div>
+      <div className="border p-2">
         <a
           className="text-lg font-bold antd-link"
           href="https://github.com/shuding/react-wrap-balancer"

--- a/packages/react-server/examples/basic/src/routes/test/deps/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/deps/page.tsx
@@ -1,5 +1,6 @@
 import { TestVirtualUseClient } from "virtual:test-use-client";
 import { TestDepUseClient } from "@hiogawa/test-dep-use-client";
+import { Code } from "bright";
 import {
   Balancer as BalancerNamed,
   default as BalancerDefault,
@@ -7,7 +8,7 @@ import {
 
 export default function Page() {
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col items-start gap-2">
       <h4 className="font-bold">Test Dependencies</h4>
       <div>
         <TestVirtualUseClient />
@@ -16,10 +17,27 @@ export default function Page() {
         <TestDepUseClient />
       </div>
       <div>
-        <BalancerNamed>react-wrap-balancer named import</BalancerNamed>
+        <a
+          className="text-lg font-bold antd-link"
+          href="https://github.com/code-hike/bright"
+          target="_blank"
+        >
+          code-hike/bright
+        </a>
+        <Code lang="py">print("hello brightness")</Code>
       </div>
       <div>
-        <BalancerDefault>react-wrap-balancer default import</BalancerDefault>
+        <a
+          className="text-lg font-bold antd-link"
+          href="https://github.com/shuding/react-wrap-balancer"
+          target="_blank"
+        >
+          shuding/react-wrap-balancer
+        </a>
+        <div className="flex flex-col gap-2 p-2">
+          <BalancerNamed>BalancerNamed</BalancerNamed>
+          <BalancerDefault>BalancerDefault</BalancerDefault>
+        </div>
       </div>
     </div>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,10 +293,10 @@ importers:
         version: link:../..
       '@hiogawa/test-dep-server-component':
         specifier: file:./deps/server-component
-        version: file:packages/react-server/examples/basic/deps/server-component
+        version: file:packages/react-server/examples/basic/deps/server-component(react@18.3.0-canary-6c3b8dbfe-20240226)
       '@hiogawa/test-dep-use-client':
         specifier: file:./deps/use-client
-        version: file:packages/react-server/examples/basic/deps/use-client
+        version: file:packages/react-server/examples/basic/deps/use-client(react@18.3.0-canary-6c3b8dbfe-20240226)
       react:
         specifier: 18.3.0-canary-6c3b8dbfe-20240226
         version: 18.3.0-canary-6c3b8dbfe-20240226
@@ -9523,16 +9523,22 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: true
 
-  file:packages/react-server/examples/basic/deps/server-component:
+  file:packages/react-server/examples/basic/deps/server-component(react@18.3.0-canary-6c3b8dbfe-20240226):
     resolution: {directory: packages/react-server/examples/basic/deps/server-component, type: directory}
+    id: file:packages/react-server/examples/basic/deps/server-component
     name: '@hiogawa/test-dep-use-client'
+    peerDependencies:
+      react: '*'
     dependencies:
-      react: 18.2.0
+      react: 18.3.0-canary-6c3b8dbfe-20240226
     dev: false
 
-  file:packages/react-server/examples/basic/deps/use-client:
+  file:packages/react-server/examples/basic/deps/use-client(react@18.3.0-canary-6c3b8dbfe-20240226):
     resolution: {directory: packages/react-server/examples/basic/deps/use-client, type: directory}
+    id: file:packages/react-server/examples/basic/deps/use-client
     name: '@hiogawa/test-dep-use-client'
+    peerDependencies:
+      react: '*'
     dependencies:
-      react: 18.2.0
+      react: 18.3.0-canary-6c3b8dbfe-20240226
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9526,9 +9526,13 @@ packages:
   file:packages/react-server/examples/basic/deps/server-component:
     resolution: {directory: packages/react-server/examples/basic/deps/server-component, type: directory}
     name: '@hiogawa/test-dep-use-client'
+    dependencies:
+      react: 18.2.0
     dev: false
 
   file:packages/react-server/examples/basic/deps/use-client:
     resolution: {directory: packages/react-server/examples/basic/deps/use-client, type: directory}
     name: '@hiogawa/test-dep-use-client'
+    dependencies:
+      react: 18.2.0
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -294,6 +294,9 @@ importers:
       '@hiogawa/test-dep-use-client':
         specifier: file:./deps/use-client
         version: file:packages/react-server/examples/basic/deps/use-client
+      bright:
+        specifier: ^0.8.5
+        version: 0.8.5(react@18.3.0-canary-6c3b8dbfe-20240226)
       react:
         specifier: 18.3.0-canary-6c3b8dbfe-20240226
         version: 18.3.0-canary-6c3b8dbfe-20240226
@@ -1240,6 +1243,10 @@ packages:
   /@cloudflare/workers-types@4.20231121.0:
     resolution: {integrity: sha512-+kWfpCkqiepwAKXyHoE0gnkPgkLhz0/9HOBIGhHRsUvUKvhUtm3mbqqoGRWgF1qcjzrDUBbrrOq4MYHfFtc2RA==}
     dev: true
+
+  /@code-hike/lighter@0.8.1:
+    resolution: {integrity: sha512-St4rPmB7C2EWmAK1sAbvD3lZeM7UDInVDMjQDzEDsu4Q3B3AqF25vXedQK51U0UO0MCOASgBBdTiNwvJAfIqMQ==}
+    dev: false
 
   /@cspotcode/source-map-support@0.8.1:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -2406,7 +2413,7 @@ packages:
     peerDependencies:
       unocss: '*'
     dependencies:
-      unocss: 0.57.7(postcss@8.4.35)(vite@5.1.6)
+      unocss: 0.57.7(postcss@8.4.35)(vite@5.1.0)
     dev: true
 
   /@hiogawa/utils@1.6.3:
@@ -4125,6 +4132,16 @@ packages:
     dependencies:
       wcwidth: 1.0.1
     dev: true
+
+  /bright@0.8.5(react@18.3.0-canary-6c3b8dbfe-20240226):
+    resolution: {integrity: sha512-LOhh3jk8KLFMqhX67TSGP1kCb3qGXbiRLbyBToVOfrrrEa3omXHT44r0/L4/OOlKluaFcO7+11KLOM5xI50XvA==}
+    peerDependencies:
+      react: ^18
+    dependencies:
+      '@code-hike/lighter': 0.8.1
+      react: 18.3.0-canary-6c3b8dbfe-20240226
+      server-only: 0.0.1
+    dev: false
 
   /browserify-zlib@0.1.4:
     resolution: {integrity: sha512-19OEpq7vWgsH6WkvkBJQDFvJS1uPcbFOQ4v9CU839dO+ZZXUZO6XpE6hNCqvlIIj+4fZvRiJ6DsAQ382GwiyTQ==}
@@ -8024,6 +8041,10 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
+    dev: false
 
   /set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,9 +297,6 @@ importers:
       '@hiogawa/test-dep-use-client':
         specifier: file:./deps/use-client
         version: file:packages/react-server/examples/basic/deps/use-client
-      bright:
-        specifier: ^0.8.5
-        version: 0.8.5(react@18.3.0-canary-6c3b8dbfe-20240226)
       react:
         specifier: 18.3.0-canary-6c3b8dbfe-20240226
         version: 18.3.0-canary-6c3b8dbfe-20240226
@@ -1246,10 +1243,6 @@ packages:
   /@cloudflare/workers-types@4.20231121.0:
     resolution: {integrity: sha512-+kWfpCkqiepwAKXyHoE0gnkPgkLhz0/9HOBIGhHRsUvUKvhUtm3mbqqoGRWgF1qcjzrDUBbrrOq4MYHfFtc2RA==}
     dev: true
-
-  /@code-hike/lighter@0.8.1:
-    resolution: {integrity: sha512-St4rPmB7C2EWmAK1sAbvD3lZeM7UDInVDMjQDzEDsu4Q3B3AqF25vXedQK51U0UO0MCOASgBBdTiNwvJAfIqMQ==}
-    dev: false
 
   /@cspotcode/source-map-support@0.8.1:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -4135,16 +4128,6 @@ packages:
     dependencies:
       wcwidth: 1.0.1
     dev: true
-
-  /bright@0.8.5(react@18.3.0-canary-6c3b8dbfe-20240226):
-    resolution: {integrity: sha512-LOhh3jk8KLFMqhX67TSGP1kCb3qGXbiRLbyBToVOfrrrEa3omXHT44r0/L4/OOlKluaFcO7+11KLOM5xI50XvA==}
-    peerDependencies:
-      react: ^18
-    dependencies:
-      '@code-hike/lighter': 0.8.1
-      react: 18.3.0-canary-6c3b8dbfe-20240226
-      server-only: 0.0.1
-    dev: false
 
   /browserify-zlib@0.1.4:
     resolution: {integrity: sha512-19OEpq7vWgsH6WkvkBJQDFvJS1uPcbFOQ4v9CU839dO+ZZXUZO6XpE6hNCqvlIIj+4fZvRiJ6DsAQ382GwiyTQ==}
@@ -8044,10 +8027,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
-
-  /server-only@0.0.1:
-    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
-    dev: false
 
   /set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -291,6 +291,9 @@ importers:
       '@hiogawa/react-server':
         specifier: latest
         version: link:../..
+      '@hiogawa/test-dep-server-component':
+        specifier: file:./deps/server-component
+        version: file:packages/react-server/examples/basic/deps/server-component
       '@hiogawa/test-dep-use-client':
         specifier: file:./deps/use-client
         version: file:packages/react-server/examples/basic/deps/use-client
@@ -2413,7 +2416,7 @@ packages:
     peerDependencies:
       unocss: '*'
     dependencies:
-      unocss: 0.57.7(postcss@8.4.35)(vite@5.1.0)
+      unocss: 0.57.7(postcss@8.4.35)(vite@5.1.6)
     dev: true
 
   /@hiogawa/utils@1.6.3:
@@ -9540,6 +9543,11 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: true
+
+  file:packages/react-server/examples/basic/deps/server-component:
+    resolution: {directory: packages/react-server/examples/basic/deps/server-component, type: directory}
+    name: '@hiogawa/test-dep-use-client'
+    dev: false
 
   file:packages/react-server/examples/basic/deps/use-client:
     resolution: {directory: packages/react-server/examples/basic/deps/use-client, type: directory}


### PR DESCRIPTION
It looks like `bright` uses `fs`. Dev is working but failing on build with `noExternal: true`.
For now, let's uses fixture deps with `file:...` protocol.