### PR TITLE
feat(react-server): obfuscate reference id on production

### DIFF
--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/react-server",
-  "version": "0.1.0-pre.2",
+  "version": "0.1.0-pre.3",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/react-server",
-  "version": "0.1.0-pre.3",
+  "version": "0.1.0-pre.4",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -536,11 +536,11 @@ function vitePluginServerUseServer({
           "@hiogawa/react-server/server-internal",
         )}";\n`,
       );
+      // obfuscate reference
+      if (manager.buildType) {
+        id = hashString(id);
+      }
       for (const name of exportNames) {
-        // obfuscate reference
-        if (manager.buildType) {
-          id = hashString(id);
-        }
         mcode.append(
           `${name} = createServerReference("${id}::${name}", ${name});\n`,
         );

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -1,7 +1,8 @@
+import nodeCrypto from "node:crypto";
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
-import { hashString, memoize, tinyassert } from "@hiogawa/utils";
+import { memoize, tinyassert } from "@hiogawa/utils";
 import type { Program } from "estree";
 import fg from "fast-glob";
 import MagicString from "magic-string";
@@ -551,4 +552,12 @@ function vitePluginServerUseServer({
       };
     },
   };
+}
+
+function hashString(v: string) {
+  return nodeCrypto
+    .createHash("sha256")
+    .update(v)
+    .digest()
+    .toString("base64url");
 }

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -21,7 +21,7 @@ import { USE_CLIENT_RE, USE_SERVER_RE, getExportNames } from "./ast-utils";
 const require = createRequire(import.meta.url);
 
 // convenient singleton to track file ids to decide RSC hot reload
-class RscManager {
+class ReactServerManager {
   buildType?: "rsc" | "client" | "ssr";
 
   // expose "use client" node modules to client via virtual modules
@@ -54,7 +54,7 @@ export function vitePluginReactServer(options?: {
   plugins?: PluginOption[];
 }): Plugin[] {
   const rscEntry = options?.entry ?? "@hiogawa/react-server/entry-react-server";
-  const manager = new RscManager();
+  const manager = new ReactServerManager();
   let parentServer: ViteDevServer | undefined;
   let parentEnv: ConfigEnv;
   let rscDevServer: ViteDevServer | undefined;
@@ -292,7 +292,7 @@ export const Counter = createClientReference("<id>::Counter");
 function vitePluginServerUseClient({
   manager,
 }: {
-  manager: RscManager;
+  manager: ReactServerManager;
 }): PluginOption {
   // intercept Vite's node resolve to virtualize "use client" in node_modules
   const pluginUseClientNodeModules: Plugin = {
@@ -466,7 +466,7 @@ export const hello = createServerReference("<id>::hello");
 function vitePluginClientUseServer({
   manager,
 }: {
-  manager: RscManager;
+  manager: ReactServerManager;
 }): Plugin {
   let configEnv: ConfigEnv;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,7 +101,7 @@ importers:
     dependencies:
       '@hiogawa/react-server':
         specifier: latest
-        version: 0.1.0-pre.3(react-dom@18.3.0-canary-6c3b8dbfe-20240226)(react-server-dom-webpack@18.3.0-canary-6c3b8dbfe-20240226)(react@18.3.0-canary-6c3b8dbfe-20240226)(vite@5.1.0)
+        version: link:../..
       '@hiogawa/test-dep-server-component':
         specifier: file:deps/server-component
         version: file:packages/react-server/examples/basic/deps/server-component(react@18.3.0-canary-6c3b8dbfe-20240226)
@@ -162,7 +162,7 @@ importers:
     dependencies:
       '@hiogawa/react-server':
         specifier: latest
-        version: 0.1.0-pre.3(react-dom@18.3.0-canary-6c3b8dbfe-20240226)(react-server-dom-webpack@18.3.0-canary-6c3b8dbfe-20240226)(react@18.3.0-canary-6c3b8dbfe-20240226)(vite@5.1.0)
+        version: link:../..
       react:
         specifier: 18.3.0-canary-6c3b8dbfe-20240226
         version: 18.3.0-canary-6c3b8dbfe-20240226
@@ -2058,24 +2058,6 @@ packages:
       '@trpc/server':
         optional: true
     dev: true
-
-  /@hiogawa/react-server@0.1.0-pre.3(react-dom@18.3.0-canary-6c3b8dbfe-20240226)(react-server-dom-webpack@18.3.0-canary-6c3b8dbfe-20240226)(react@18.3.0-canary-6c3b8dbfe-20240226)(vite@5.1.0):
-    resolution: {integrity: sha512-E8nziq8s6H7eK05XbKKseDivbl90a+l8ekwZku/nyY/sJJhjDMJZdgjLYaYL6K8ixtmlZJ1VzQGlPhcXOKiRXQ==}
-    peerDependencies:
-      react: 18.3.0-canary-6c3b8dbfe-20240226
-      react-dom: 18.3.0-canary-6c3b8dbfe-20240226
-      react-server-dom-webpack: 18.3.0-canary-6c3b8dbfe-20240226
-      vite: 5.1.0
-    dependencies:
-      '@tanstack/history': 1.15.13
-      fast-glob: 3.3.2
-      magic-string: 0.30.8
-      react: 18.3.0-canary-6c3b8dbfe-20240226
-      react-dom: 18.3.0-canary-6c3b8dbfe-20240226(react@18.3.0-canary-6c3b8dbfe-20240226)
-      react-server-dom-webpack: 18.3.0-canary-6c3b8dbfe-20240226(react-dom@18.3.0-canary-6c3b8dbfe-20240226)(react@18.3.0-canary-6c3b8dbfe-20240226)(webpack@5.90.3)
-      rsc-html-stream: 0.0.3
-      vite: 5.1.0(@types/node@20.11.28)
-    dev: false
 
   /@hiogawa/theme-script@0.0.4-pre.3(vite@5.1.0):
     resolution: {integrity: sha512-2uxVhemdAMUFE/OaUcaTT2QeZsXnxtnF/CLNs+CcrlgwaUXXfsnXUTvUZCz8MTmxzzz4Vp5hfAyi4pp58XHJCQ==}


### PR DESCRIPTION
For reproducibility, we probably should just hash it.

<details><summary>before</summary>

![image](https://github.com/hi-ogawa/vite-plugins/assets/4232207/6f737018-1cf1-4310-869e-d48e311160bd)

</details>

<details><summary>after</summary>

![image](https://github.com/hi-ogawa/vite-plugins/assets/4232207/9c82441a-18aa-449f-9302-8aa4524a3235)

</details>

TODO
- [ ] ~refactor: let manager to hold the hash as reference key?~ (not really help)
- [x] use SHA