### PR TITLE
chore(examples): tweak `NavMenu`

### DIFF
--- a/packages/react-server/examples/basic/src/components/nav-menu.tsx
+++ b/packages/react-server/examples/basic/src/components/nav-menu.tsx
@@ -1,8 +1,8 @@
 import { Link } from "@hiogawa/react-server/client";
 
-export function NavMenu(props: { links: string[] }) {
+export function NavMenu(props: { links: string[]; className?: string }) {
   return (
-    <ul className="flex flex-col items-start gap-1">
+    <ul className={props.className ?? "flex flex-col items-start gap-1"}>
       {props.links.map((e) => (
         <li key={e} className="antd-link flex items-stretch">
           <Link href={e}>

--- a/packages/react-server/examples/basic/src/routes/test/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/layout.tsx
@@ -6,6 +6,7 @@ export default async function Layout(props: React.PropsWithChildren) {
     <div className="flex flex-col gap-2">
       <h2 className="text-lg">Test</h2>
       <NavMenu
+        className="grid grid-cols-2 w-xs gap-1"
         links={[
           "/test",
           "/test/other",


### PR DESCRIPTION
Using `grid-cols-2` to organize a little:

![image](https://github.com/hi-ogawa/vite-plugins/assets/4232207/8d59d7c2-7b88-416c-85f6-86b589ef7ab7)
