### PR TITLE
refactor(react-server): use self-reference imports

### DIFF
--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/react-server",
-  "version": "0.1.0-pre.10",
+  "version": "0.1.0",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/packages/react-server/src/entry/react-server.tsx
+++ b/packages/react-server/src/entry/react-server.tsx
@@ -98,7 +98,7 @@ function createRouter() {
   async function run(request: Request) {
     const url = new URL(request.url);
     const match = matchRoute(url.pathname, tree);
-    const node = renderMatchRoute(request, match);
+    const node = await renderMatchRoute(request, match);
     return { node, match };
   }
 

--- a/packages/react-server/src/lib/global.ts
+++ b/packages/react-server/src/lib/global.ts
@@ -11,7 +11,4 @@ export const __global: {
   };
   history: RouterHistory;
   callServer: CallServerCallback;
-  // see "virtual:self-reference-workaround"
-  clientInternal: typeof import("../client-internal");
-  serverInternal: typeof import("../server-internal");
 } = ((globalThis as any).__REACT_SERVER_GLOBAL ??= {});

--- a/packages/react-server/src/lib/router.tsx
+++ b/packages/react-server/src/lib/router.tsx
@@ -83,7 +83,7 @@ export async function renderMatchRoute(
     ErrorBoundary,
     DefaultRootErrorPage,
   }: typeof import("../client-internal") = await import(
-    "@hiogawa/react-server/client-internal"
+    "@hiogawa/react-server/client-internal" as string
   );
 
   const props: BaseProps = {

--- a/packages/react-server/src/lib/router.tsx
+++ b/packages/react-server/src/lib/router.tsx
@@ -74,8 +74,17 @@ export function matchRoute(
 
 // TODO: separate react code in a different file
 // TODO: just do it together with matchRoute above?
-export function renderMatchRoute(request: Request, match: MatchRouteResult) {
-  const { ErrorBoundary, DefaultRootErrorPage } = __global.clientInternal;
+export async function renderMatchRoute(
+  request: Request,
+  match: MatchRouteResult,
+) {
+  // use its own "use client" components
+  const {
+    ErrorBoundary,
+    DefaultRootErrorPage,
+  }: typeof import("../client-internal") = await import(
+    "@hiogawa/react-server/client-internal"
+  );
 
   const props: BaseProps = {
     request,

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -495,7 +495,7 @@ function vitePluginServerUseClient({
         // we need to transform to client reference directly
         // otherwise `soruce` will be resolved infinitely by recursion
         id = noramlizeClientReferenceId(id);
-        let result = `const { createClientReference } = __REACT_SERVER_GLOBAL.serverInternal;\n`;
+        let result = `import { createClientReference } from "@hiogawa/react-server/server-internal";\n`;
         for (const name of exportNames) {
           if (name === "default") {
             result += `const $$default = createClientReference("${id}::${name}");\n`;
@@ -535,7 +535,7 @@ function vitePluginServerUseClient({
         // obfuscate reference
         id = hashString(id);
       }
-      let result = `const { createClientReference } = __REACT_SERVER_GLOBAL.serverInternal;\n`;
+      let result = `import { createClientReference } from "@hiogawa/react-server/server-internal";\n`;
       for (const name of exportNames) {
         if (name === "default") {
           result += `const $$default = createClientReference("${id}::${name}");\n`;

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -157,26 +157,12 @@ export function vitePluginReactServer(options?: {
         },
       },
 
-      // TODO: workaround Vite self-reference import via global (Try Vite 5.2).
-      //       https://github.com/vitejs/vite/pull/16068
-      createVirtualPlugin("self-reference-workaround1", () => {
-        return /* js */ `
-          import * as serverInternal from "@hiogawa/react-server/server-internal";
-          Object.assign(globalThis.__REACT_SERVER_GLOBAL ??= {}, { serverInternal });
-        `;
-      }),
-      createVirtualPlugin("self-reference-workaround2", () => {
-        return /* js */ `
-          import * as clientInternal from "@hiogawa/react-server/client-internal";
-          Object.assign(globalThis.__REACT_SERVER_GLOBAL ??= {}, { clientInternal });
-        `;
-      }),
       createVirtualPlugin(
         ENTRY_REACT_SERVER_WRAPPER.slice("virtual:".length),
         () => {
+          // this virtual is not necessary anymore but have been used in the past
+          // to extend user's react-server entry like ENTRY_CLIENT_WRAPPER
           return /* js */ `
-            import "virtual:self-reference-workaround1";
-            import "virtual:self-reference-workaround2";
             export * from "${ENTRY_REACT_SERVER}";
           `;
         },

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -1,6 +1,7 @@
 import nodeCrypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { memoize, tinyassert } from "@hiogawa/utils";
 import type { Program } from "estree";
 import fg from "fast-glob";
@@ -28,6 +29,15 @@ import {
   ENTRY_REACT_SERVER_WRAPPER,
   type SsrAssetsType,
 } from "./utils";
+
+// resolve import paths for `createClientReference` and `createServerReference`
+// since `import "@hiogawa/react-server"` is not necessary visible for exernal library.
+const CLIENT_INTERNAL_PATH = fileURLToPath(
+  new URL("../client-internal.js", import.meta.url),
+);
+const SERVER_INTERNAL_PATH = fileURLToPath(
+  new URL("../server-internal.js", import.meta.url),
+);
 
 // convenient singleton to share states
 class ReactServerManager {
@@ -495,7 +505,7 @@ function vitePluginServerUseClient({
         // we need to transform to client reference directly
         // otherwise `soruce` will be resolved infinitely by recursion
         id = noramlizeClientReferenceId(id);
-        let result = `import { createClientReference } from "@hiogawa/react-server/server-internal";\n`;
+        let result = `import { createClientReference } from "${SERVER_INTERNAL_PATH}";\n`;
         for (const name of exportNames) {
           if (name === "default") {
             result += `const $$default = createClientReference("${id}::${name}");\n`;
@@ -535,7 +545,7 @@ function vitePluginServerUseClient({
         // obfuscate reference
         id = hashString(id);
       }
-      let result = `import { createClientReference } from "@hiogawa/react-server/server-internal";\n`;
+      let result = `import { createClientReference } from "${SERVER_INTERNAL_PATH}";\n`;
       for (const name of exportNames) {
         if (name === "default") {
           result += `const $$default = createClientReference("${id}::${name}");\n`;
@@ -639,7 +649,7 @@ function vitePluginClientUseServer({
       if (manager.buildType) {
         id = hashString(id);
       }
-      let result = `import { createServerReference } from "@hiogawa/react-server/client-internal";\n`;
+      let result = `import { createServerReference } from "${CLIENT_INTERNAL_PATH}";\n`;
       for (const name of exportNames) {
         if (name === "default") {
           result += `const $$default = createServerReference("${id}::${name}");\n`;
@@ -673,7 +683,7 @@ function vitePluginServerUseServer({
         exportNames,
       });
       mcode.prepend(
-        `import { createServerReference } from "@hiogawa/react-server/server-internal";\n`,
+        `import { createServerReference } from "${SERVER_INTERNAL_PATH}";\n`,
       );
       // obfuscate reference
       if (manager.buildType) {

--- a/packages/react-server/tsup.config.ts
+++ b/packages/react-server/tsup.config.ts
@@ -17,7 +17,7 @@ export default defineConfig([
     dts: !process.env["NO_DTS"],
     external: [
       /^virtual:/,
-      /^@hiogawa\/react-server/,
+      /^@hiogawa\/react-server\//,
       // TODO: virtual module?
       "/dist/rsc/client-references.js",
       "/dist/rsc/index.js",

--- a/packages/react-server/tsup.config.ts
+++ b/packages/react-server/tsup.config.ts
@@ -17,11 +17,10 @@ export default defineConfig([
     dts: !process.env["NO_DTS"],
     external: [
       /^virtual:/,
+      /^@hiogawa\/react-server/,
       // TODO: virtual module?
       "/dist/rsc/client-references.js",
       "/dist/rsc/index.js",
-      "/dist/client/index.html?raw",
-      "/index.html?raw",
     ],
   },
 ]);


### PR DESCRIPTION
- https://github.com/vitejs/vite/pull/16068
- https://nodejs.org/api/packages.html#self-referencing-a-package-using-its-name

Since Vite 5.2.0, we can use self-reference import and finally we can remove a few internal hacks.

---

Maybe not... actually external "use client" library such as this:

https://github.com/hi-ogawa/vite-plugins/blob/f972e5e376f4f365f438c9c1566bf9a96b508588/packages/react-server/examples/basic/deps/use-client/index.js#L1-L7

will be transformed to this during RSC build:

```ts
import { createClientReference } from "@hiogawa/react-server/server-internal";
export const TestDepUseClient = createClientReference("...")
```

but `@hiogawa/react-server` is not necessary visible depending on monorepo `node_modules` structure as seen in 

https://github.com/hi-ogawa/vite-plugins/actions/runs/8399007726/job/23004582160?pr=219#step:9:17

```
Error: [vitePluginReactServer] [vite]: Rollup failed to resolve import
  "@hiogawa/react-server/server-internal" from
  "/home/runner/work/vite-plugins/vite-plugins/node_modules/.pnpm/file+packages+react-server+examples+basic+deps+use-client_react@18.3.0-canary-6c3b8dbfe-20240226/node_modules/@hiogawa/test-dep-use-client/index.js".
This is most likely unintended because it can break your application at runtime.
If you do want to externalize this module explicitly add it to
`build.rollupOptions.external`
```

For now, let's use the direct path for `@hiogawa/react-server/server-internal` inside the plugin by using `new URL("../server-internal.js", import.meta.url)`.