### PR TITLE
fix(react-server): silence false warning due to `use client`

### DIFF
--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/react-server",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -108,6 +108,8 @@ export function vitePluginReactServer(options?: {
       },
     },
     plugins: [
+      vitePluginSilenceUseClientBuildWarning(),
+
       // expose server reference for RSC itself
       vitePluginServerUseServer({ manager }),
 
@@ -293,6 +295,7 @@ export function vitePluginReactServer(options?: {
 
   return [
     rscParentPlugin,
+    vitePluginSilenceUseClientBuildWarning(),
     vitePluginClientUseServer({ manager }),
     {
       name: "client-virtual-use-client-node-modules",
@@ -709,4 +712,42 @@ function createVirtualPlugin(name: string, load: Plugin["load"]) {
       }
     },
   } satisfies Plugin;
+}
+
+// silence warning due to "use client"
+// https://github.com/vitejs/vite-plugin-react/blob/814ed8043d321f4b4679a9f4a781d1ed14f185e4/packages/plugin-react/src/index.ts#L303
+function vitePluginSilenceUseClientBuildWarning(): Plugin {
+  return {
+    name: vitePluginSilenceUseClientBuildWarning.name,
+    enforce: "post",
+    config(config, _env) {
+      return {
+        build: {
+          rollupOptions: {
+            onwarn(warning, defaultHandler) {
+              // https://github.com/vitejs/vite/issues/15012#issuecomment-1948550039
+              if (
+                warning.code === "SOURCEMAP_ERROR" &&
+                warning.message.includes("(1:0)")
+              ) {
+                return;
+              }
+              // https://github.com/TanStack/query/pull/5161#issuecomment-1506683450
+              if (
+                warning.code === "MODULE_LEVEL_DIRECTIVE" &&
+                warning.message.includes(`"use client"`)
+              ) {
+                return;
+              }
+              if (config.build?.rollupOptions?.onwarn) {
+                config.build.rollupOptions.onwarn(warning, defaultHandler);
+              } else {
+                defaultHandler(warning);
+              }
+            },
+          },
+        },
+      };
+    },
+  };
 }

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -108,8 +108,6 @@ export function vitePluginReactServer(options?: {
       },
     },
     plugins: [
-      vitePluginSilenceUseClientBuildWarning(),
-
       // expose server reference for RSC itself
       vitePluginServerUseServer({ manager }),
 


### PR DESCRIPTION
## todo

- I just silenced in `onwarn`, but maybe we can make quick transform to remove `"use client"` after `createClientReference` is taken care?
  - No, this warning is not from RSC build since RSC build already removes `"use clinet"` when transforming it to `createClientReference`.
- why don't we see the same for `"use server"` for RSC build? Maybe warning happens only when build chunk's source has directive at the top? (client reference is already a separate dynamic import chunk)