### PR TITLE
fix(react-server): strip "use" directive to silence false warning

### DIFF
--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/react-server",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -108,6 +108,8 @@ export function vitePluginReactServer(options?: {
       },
     },
     plugins: [
+      vitePluginSilenceUseClientBuildWarning(),
+
       // expose server reference for RSC itself
       vitePluginServerUseServer({ manager }),
 
@@ -293,6 +295,7 @@ export function vitePluginReactServer(options?: {
 
   return [
     rscParentPlugin,
+    vitePluginSilenceUseClientBuildWarning(),
     vitePluginClientUseServer({ manager }),
     {
       name: "client-virtual-use-client-node-modules",
@@ -709,4 +712,42 @@ function createVirtualPlugin(name: string, load: Plugin["load"]) {
       }
     },
   } satisfies Plugin;
+}
+
+// silence warning due to "use client"
+// https://github.com/vitejs/vite-plugin-react/blob/814ed8043d321f4b4679a9f4a781d1ed14f185e4/packages/plugin-react/src/index.ts#L303
+function vitePluginSilenceUseClientBuildWarning(): Plugin {
+  return {
+    name: vitePluginSilenceUseClientBuildWarning.name,
+    enforce: "post",
+    config(config, _env) {
+      return {
+        build: {
+          rollupOptions: {
+            onwarn(warning, defaultHandler) {
+              // https://github.com/vitejs/vite/issues/15012#issuecomment-1948550039
+              if (
+                warning.code === "SOURCEMAP_ERROR" &&
+                warning.message.includes("(1:0)")
+              ) {
+                return;
+              }
+              // https://github.com/TanStack/query/pull/5161#issuecomment-1506683450
+              if (
+                warning.code === "MODULE_LEVEL_DIRECTIVE" &&
+                warning.message.includes(`"use client"`)
+              ) {
+                return;
+              }
+              if (config.build?.rollupOptions?.onwarn) {
+                config.build.rollupOptions.onwarn(warning, defaultHandler);
+              } else {
+                defaultHandler(warning);
+              }
+            },
+          },
+        },
+      };
+    },
+  };
 }

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -108,8 +108,6 @@ export function vitePluginReactServer(options?: {
       },
     },
     plugins: [
-      vitePluginSilenceUseClientBuildWarning(),
-
       // expose server reference for RSC itself
       vitePluginServerUseServer({ manager }),
 


### PR DESCRIPTION
- Alternative of https://github.com/hi-ogawa/vite-plugins/pull/221

This looks fine too.

<details><summary>Before</summary>

https://github.com/hi-ogawa/vite-plugins/actions/runs/8399434668/job/23005528718#step:9:7

![image](https://github.com/hi-ogawa/vite-plugins/assets/4232207/a356aa83-fb01-4bec-8789-fe46cf24bc00)

</details>

<details><summary>After</summary>

https://github.com/hi-ogawa/vite-plugins/actions/runs/8400502915/job/23007851073#step:9:7

![image](https://github.com/hi-ogawa/vite-plugins/assets/4232207/6bd8d846-5db0-4ad1-99c3-6304d3b8d5c9)

</details>