### PR TITLE
fix(react-server): intercept only simple click on `Link`

### DIFF
--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -25,6 +25,21 @@ test("navigation", async ({ page }) => {
   await checkClientState();
 });
 
+test("Link modifier", async ({ page, context }) => {
+  checkNoError(page);
+
+  await page.goto("/test");
+  await page.getByText("hydrated: true").click();
+
+  const newPagePromise = context.waitForEvent("page");
+  await page.getByRole("link", { name: "/test/other" }).click({
+    modifiers: ["Control"],
+  });
+  const newPage = await newPagePromise;
+  await newPage.waitForURL("/test/other");
+  await page.waitForURL("/test");
+});
+
 test("error", async ({ page }) => {
   const res = await page.goto("/test/not-found");
   expect(res?.status()).toBe(404);

--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/react-server",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/packages/react-server/src/lib/components/link.tsx
+++ b/packages/react-server/src/lib/components/link.tsx
@@ -2,13 +2,24 @@
 
 import { __history } from "../csr";
 
+// TODO: study prior art
+// https://github.com/TanStack/router/blame/a1030ef24de104eb32f7a781cda247458e0ec90a/packages/react-router/src/link.tsx
+// https://github.com/remix-run/react-router/blob/9e7486b89e712b765d947297f228650cdc0c488e/packages/react-router-dom/index.tsx#L1394
+
 export function Link(props: JSX.IntrinsicElements["a"] & { href: string }) {
   return (
     <a
       {...props}
       onClick={(e) => {
-        e.preventDefault();
-        __history.push(props.href!);
+        const target = e.currentTarget.target;
+        if (
+          e.button === 0 &&
+          !(e.metaKey || e.altKey || e.ctrlKey || e.shiftKey) &&
+          (!target || target === "_self")
+        ) {
+          e.preventDefault();
+          __history.push(props.href!);
+        }
       }}
     />
   );


### PR DESCRIPTION
Started to checkout other client side routers. This one was really bugging me, so just a quick fix.