### PR TITLE
chore(examples): more `useFormStatus` example

### DIFF
--- a/packages/react-server/examples/basic/src/routes/test/action/_client.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/action/_client.tsx
@@ -65,11 +65,6 @@ export function Counter2({
 export function Chat(props: { messages: ReturnType<typeof getMessages> }) {
   const [input, setInput] = React.useState("");
 
-  // clear input after submit (really this way?)
-  React.useEffect(() => {
-    setInput("");
-  }, [props.messages]);
-
   return (
     <div className="flex flex-col gap-2">
       <h4 className="font-bold">Messages</h4>
@@ -81,6 +76,7 @@ export function Chat(props: { messages: ReturnType<typeof getMessages> }) {
         ))}
       </ul>
       <form className="flex flex-col items-start gap-2" action={addMessage}>
+        <ClearInputOnAction clear={() => setInput("")} />
         <div className="flex gap-2">
           <input
             name="message"
@@ -95,6 +91,29 @@ export function Chat(props: { messages: ReturnType<typeof getMessages> }) {
       </form>
     </div>
   );
+}
+
+function ClearInputOnAction(props: { clear: () => void }) {
+  const { pending } = ReactDom.useFormStatus();
+  const lastPending = usePrevious(pending)
+
+  React.useEffect(() => {
+    if (!pending && lastPending) {
+      props.clear();
+    }
+  }, [pending, lastPending]);
+
+  return <></>;
+}
+
+function usePrevious<T>(v: T) {
+  const ref = React.useRef(v);
+
+  React.useEffect(() => {
+    ref.current = v;
+  }, [v]);
+
+  return ref.current;
 }
 
 // https://react.dev/reference/react-dom/hooks/useFormStatus

--- a/packages/react-server/examples/basic/src/routes/test/action/_client.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/action/_client.tsx
@@ -95,7 +95,7 @@ export function Chat(props: { messages: ReturnType<typeof getMessages> }) {
 
 function ClearInputOnAction(props: { clear: () => void }) {
   const { pending } = ReactDom.useFormStatus();
-  const lastPending = usePrevious(pending)
+  const lastPending = usePrevious(pending);
 
   React.useEffect(() => {
     if (!pending && lastPending) {

--- a/packages/react-server/examples/basic/src/routes/test/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/layout.tsx
@@ -7,7 +7,7 @@ export default async function Layout(props: LayoutProps) {
     <div className="flex flex-col gap-2">
       <h2 className="text-lg">Test</h2>
       <NavMenu
-        className="grid grid-cols-2 w-xs gap-1"
+        className="grid grid-cols-3 w-lg gap-1"
         links={[
           "/test",
           "/test/other",


### PR DESCRIPTION
I wonder if this is a "right" way, but I guess it's better than previous way.
Maybe some conventional way to do it with `useFormState` or `useOptimistic`?
- https://react.dev/reference/react-dom/hooks/useFormState
- https://react.dev/reference/react/useOptimistic


Well, actually there's a really similar looking example in https://react.dev/reference/react/useOptimistic#optimistically-updating-with-forms