### PR TITLE
test(react-server): test client render count

### DIFF
--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -25,6 +25,26 @@ test("navigation", async ({ page }) => {
   await checkClientState();
 });
 
+test("render count", async ({ page }) => {
+  await page.goto("/test");
+  await waitForHydration(page);
+
+  if (process.env.E2E_PREVIEW) {
+    await page.getByText('[effect: 1]').click();
+    await page.getByRole('link', { name: '/test/other' }).click();
+    await page.getByText('[effect: 2]').click();
+    await page.goBack();
+    await page.getByText('[effect: 3]').click();
+  } else {
+    // strict mode doubles initial effect
+    await page.getByText('[effect: 1]').click();
+    await page.getByRole('link', { name: '/test/other' }).click();
+    await page.getByText('[effect: 3]').click();
+    await page.goBack();
+    await page.getByText('[effect: 4]').click();
+  }
+})
+
 test("ServerTransitionContext.isPending", async ({ page }) => {
   checkNoError(page);
 
@@ -420,5 +440,5 @@ async function setupCheckClientState(page: Page) {
 }
 
 async function waitForHydration(page: Page) {
-  await expect(page.getByText("hydrated: 1")).toBeVisible();
+  await expect(page.getByText("[hydrated: 1]")).toBeVisible();
 }

--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -420,5 +420,5 @@ async function setupCheckClientState(page: Page) {
 }
 
 async function checkHydration(page: Page) {
-  await expect(page.getByText("hydrated: true")).toBeVisible();
+  await expect(page.getByText("hydrated: 1")).toBeVisible();
 }

--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -5,14 +5,14 @@ test("basic", async ({ page }) => {
   checkNoError(page);
 
   await page.goto("/test");
-  await page.getByText("hydrated: true").click();
+  await checkHydration(page);
 });
 
 test("navigation", async ({ page }) => {
   checkNoError(page);
 
   await page.goto("/test");
-  await page.getByText("hydrated: true").click();
+  await checkHydration(page);
 
   const checkClientState = await setupCheckClientState(page);
 
@@ -29,7 +29,7 @@ test("ServerTransitionContext.isPending", async ({ page }) => {
   checkNoError(page);
 
   await page.goto("/test/transition");
-  await page.getByText("hydrated: true").click();
+  await checkHydration(page);
 
   await expect(page.getByRole("link", { name: "About" })).toHaveAttribute(
     "aria-selected",
@@ -61,7 +61,7 @@ test("ServerTransitionContext.isActionPending", async ({ page }) => {
   checkNoError(page);
 
   await page.goto("/test/transition");
-  await page.getByText("hydrated: true").click();
+  await checkHydration(page);
 
   await expect(page.getByText("Count: 0")).not.toHaveClass(/opacity-50/);
   await page.getByRole("button", { name: "-1 (2.0 sec)" }).click();
@@ -73,7 +73,7 @@ test("Link modifier", async ({ page, context }) => {
   checkNoError(page);
 
   await page.goto("/test");
-  await page.getByText("hydrated: true").click();
+  await checkHydration(page);
 
   const newPagePromise = context.waitForEvent("page");
   await page.getByRole("link", { name: "/test/other" }).click({
@@ -88,7 +88,7 @@ test("error", async ({ page }) => {
   const res = await page.goto("/test/not-found");
   expect(res?.status()).toBe(404);
 
-  await page.getByText("hydrated: true").click();
+  await checkHydration(page);
   await page.getByText(`server error: {"status":404}`).click();
 
   const checkClientState = await setupCheckClientState(page);
@@ -124,7 +124,7 @@ test("rsc hmr @dev", async ({ page }) => {
 
   await page.goto("/test");
   await page.getByRole("heading", { name: "RSC Experiment" }).click();
-  await page.getByText("hydrated: true").click();
+  await checkHydration(page);
 
   const checkClientState = await setupCheckClientState(page);
 
@@ -132,7 +132,7 @@ test("rsc hmr @dev", async ({ page }) => {
     s.replace("RSC Experiment", "RSC (EDIT) Experiment"),
   );
   await page.getByRole("heading", { name: "RSC (EDIT) Experiment" }).click();
-  await page.getByText("hydrated: true").click();
+  await checkHydration(page);
 
   await checkClientState();
 });
@@ -143,7 +143,7 @@ test("common hmr @dev", async ({ page }) => {
   await page.goto("/test");
   await page.getByText("Common component (from server)").click();
   await page.getByText("Common component (from client)").click();
-  await page.getByText("hydrated: true").click();
+  await checkHydration(page);
 
   const checkClientState = await setupCheckClientState(page);
 
@@ -152,7 +152,7 @@ test("common hmr @dev", async ({ page }) => {
   );
   await page.getByText("Common (EDIT) component (from server)").click();
   await page.getByText("Common (EDIT) component (from client)").click();
-  await page.getByText("hydrated: true").click();
+  await checkHydration(page);
 
   await checkClientState();
 });
@@ -161,7 +161,7 @@ test("client hmr @dev", async ({ page }) => {
   checkNoError(page);
 
   await page.goto("/test");
-  await page.getByText("hydrated: true").click();
+  await checkHydration(page);
 
   const checkClientState = await setupCheckClientState(page);
 
@@ -199,7 +199,7 @@ test("unocss hmr @dev", async ({ page, browser }) => {
   checkNoError(page);
 
   await page.goto("/test");
-  await page.getByText("hydrated: true").click();
+  await checkHydration(page);
 
   const checkClientState = await setupCheckClientState(page);
 
@@ -257,7 +257,7 @@ test("react-server css hmr @dev", async ({ page, browser }) => {
   checkNoError(page);
 
   await page.goto("/test/css");
-  await page.getByText("hydrated: true").click();
+  await checkHydration(page);
 
   const checkClientState = await setupCheckClientState(page);
 
@@ -306,7 +306,7 @@ test("server action with js", async ({ page }) => {
   checkNoError(page);
 
   await page.goto("/test/action");
-  await page.getByText("hydrated: true").click();
+  await checkHydration(page);
 
   const checkClientState = await setupCheckClientState(page);
 
@@ -347,7 +347,7 @@ test("server action no js", async ({ browser }) => {
 
 test("ReactDom.useFormStatus", async ({ page }) => {
   await page.goto("/test/action");
-  await page.getByText("hydrated: true").click();
+  await checkHydration(page);
   await page.getByRole("button", { name: "1.0 sec" }).click();
   await page.getByText("pending: true").click();
   await page.getByText("pending: false").click();
@@ -388,7 +388,7 @@ test("custom entry-react-server", async ({ request }) => {
 
 test("head in rsc", async ({ page }) => {
   await page.goto("/test/head");
-  await page.getByText("hydrated: true").click();
+  await checkHydration(page);
 
   const checkClientState = await setupCheckClientState(page);
 
@@ -417,4 +417,8 @@ async function setupCheckClientState(page: Page) {
     // verify client state is preserved
     await expect(page.getByPlaceholder("test-input")).toHaveValue("hello");
   };
+}
+
+async function checkHydration(page: Page) {
+  await expect(page.getByText("hydrated: true")).toBeVisible();
 }

--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -5,14 +5,14 @@ test("basic", async ({ page }) => {
   checkNoError(page);
 
   await page.goto("/test");
-  await checkHydration(page);
+  await waitForHydration(page);
 });
 
 test("navigation", async ({ page }) => {
   checkNoError(page);
 
   await page.goto("/test");
-  await checkHydration(page);
+  await waitForHydration(page);
 
   const checkClientState = await setupCheckClientState(page);
 
@@ -29,7 +29,7 @@ test("ServerTransitionContext.isPending", async ({ page }) => {
   checkNoError(page);
 
   await page.goto("/test/transition");
-  await checkHydration(page);
+  await waitForHydration(page);
 
   await expect(page.getByRole("link", { name: "About" })).toHaveAttribute(
     "aria-selected",
@@ -61,7 +61,7 @@ test("ServerTransitionContext.isActionPending", async ({ page }) => {
   checkNoError(page);
 
   await page.goto("/test/transition");
-  await checkHydration(page);
+  await waitForHydration(page);
 
   await expect(page.getByText("Count: 0")).not.toHaveClass(/opacity-50/);
   await page.getByRole("button", { name: "-1 (2.0 sec)" }).click();
@@ -73,7 +73,7 @@ test("Link modifier", async ({ page, context }) => {
   checkNoError(page);
 
   await page.goto("/test");
-  await checkHydration(page);
+  await waitForHydration(page);
 
   const newPagePromise = context.waitForEvent("page");
   await page.getByRole("link", { name: "/test/other" }).click({
@@ -88,7 +88,7 @@ test("error", async ({ page }) => {
   const res = await page.goto("/test/not-found");
   expect(res?.status()).toBe(404);
 
-  await checkHydration(page);
+  await waitForHydration(page);
   await page.getByText(`server error: {"status":404}`).click();
 
   const checkClientState = await setupCheckClientState(page);
@@ -124,7 +124,7 @@ test("rsc hmr @dev", async ({ page }) => {
 
   await page.goto("/test");
   await page.getByRole("heading", { name: "RSC Experiment" }).click();
-  await checkHydration(page);
+  await waitForHydration(page);
 
   const checkClientState = await setupCheckClientState(page);
 
@@ -132,7 +132,7 @@ test("rsc hmr @dev", async ({ page }) => {
     s.replace("RSC Experiment", "RSC (EDIT) Experiment"),
   );
   await page.getByRole("heading", { name: "RSC (EDIT) Experiment" }).click();
-  await checkHydration(page);
+  await waitForHydration(page);
 
   await checkClientState();
 });
@@ -143,7 +143,7 @@ test("common hmr @dev", async ({ page }) => {
   await page.goto("/test");
   await page.getByText("Common component (from server)").click();
   await page.getByText("Common component (from client)").click();
-  await checkHydration(page);
+  await waitForHydration(page);
 
   const checkClientState = await setupCheckClientState(page);
 
@@ -152,7 +152,7 @@ test("common hmr @dev", async ({ page }) => {
   );
   await page.getByText("Common (EDIT) component (from server)").click();
   await page.getByText("Common (EDIT) component (from client)").click();
-  await checkHydration(page);
+  await waitForHydration(page);
 
   await checkClientState();
 });
@@ -161,7 +161,7 @@ test("client hmr @dev", async ({ page }) => {
   checkNoError(page);
 
   await page.goto("/test");
-  await checkHydration(page);
+  await waitForHydration(page);
 
   const checkClientState = await setupCheckClientState(page);
 
@@ -199,7 +199,7 @@ test("unocss hmr @dev", async ({ page, browser }) => {
   checkNoError(page);
 
   await page.goto("/test");
-  await checkHydration(page);
+  await waitForHydration(page);
 
   const checkClientState = await setupCheckClientState(page);
 
@@ -257,7 +257,7 @@ test("react-server css hmr @dev", async ({ page, browser }) => {
   checkNoError(page);
 
   await page.goto("/test/css");
-  await checkHydration(page);
+  await waitForHydration(page);
 
   const checkClientState = await setupCheckClientState(page);
 
@@ -306,7 +306,7 @@ test("server action with js", async ({ page }) => {
   checkNoError(page);
 
   await page.goto("/test/action");
-  await checkHydration(page);
+  await waitForHydration(page);
 
   const checkClientState = await setupCheckClientState(page);
 
@@ -347,7 +347,7 @@ test("server action no js", async ({ browser }) => {
 
 test("ReactDom.useFormStatus", async ({ page }) => {
   await page.goto("/test/action");
-  await checkHydration(page);
+  await waitForHydration(page);
   await page.getByRole("button", { name: "1.0 sec" }).click();
   await page.getByText("pending: true").click();
   await page.getByText("pending: false").click();
@@ -388,7 +388,7 @@ test("custom entry-react-server", async ({ request }) => {
 
 test("head in rsc", async ({ page }) => {
   await page.goto("/test/head");
-  await checkHydration(page);
+  await waitForHydration(page);
 
   const checkClientState = await setupCheckClientState(page);
 
@@ -419,6 +419,6 @@ async function setupCheckClientState(page: Page) {
   };
 }
 
-async function checkHydration(page: Page) {
+async function waitForHydration(page: Page) {
   await expect(page.getByText("hydrated: 1")).toBeVisible();
 }

--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -30,20 +30,20 @@ test("render count", async ({ page }) => {
   await waitForHydration(page);
 
   if (process.env.E2E_PREVIEW) {
-    await page.getByText('[effect: 1]').click();
-    await page.getByRole('link', { name: '/test/other' }).click();
-    await page.getByText('[effect: 2]').click();
+    await page.getByText("[effect: 1]").click();
+    await page.getByRole("link", { name: "/test/other" }).click();
+    await page.getByText("[effect: 2]").click();
     await page.goBack();
-    await page.getByText('[effect: 3]').click();
+    await page.getByText("[effect: 3]").click();
   } else {
     // strict mode doubles initial effect
-    await page.getByText('[effect: 1]').click();
-    await page.getByRole('link', { name: '/test/other' }).click();
-    await page.getByText('[effect: 3]').click();
+    await page.getByText("[effect: 1]").click();
+    await page.getByRole("link", { name: "/test/other" }).click();
+    await page.getByText("[effect: 3]").click();
     await page.goBack();
-    await page.getByText('[effect: 4]').click();
+    await page.getByText("[effect: 4]").click();
   }
-})
+});
 
 test("ServerTransitionContext.isPending", async ({ page }) => {
   checkNoError(page);

--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -37,7 +37,7 @@ test("render count", async ({ page }) => {
     await page.getByText("[effect: 3]").click();
   } else {
     // strict mode doubles initial effect
-    await page.getByText("[effect: 1]").click();
+    await page.getByText("[effect: 2]").click();
     await page.getByRole("link", { name: "/test/other" }).click();
     await page.getByText("[effect: 3]").click();
     await page.goBack();

--- a/packages/react-server/examples/basic/src/routes/test/_client.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/_client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { tinyassert } from "@hiogawa/utils";
 import React from "react";
 
 export function Hydrated() {
@@ -13,9 +14,18 @@ export function Hydrated() {
 // test client re-rendering
 // https://github.com/pmndrs/jotai/blob/419ab5cda3503e70463dc340076e21e438db89b6/tests/react/basic.test.tsx#L27-L33
 export function EffectCount() {
-  const commitCountRef = React.useRef(1);
+  const elRef = React.useRef<HTMLElement>(null);
+  const countRef = React.useRef(0);
+
   React.useEffect(() => {
-    commitCountRef.current += 1;
+    countRef.current++;
+    tinyassert(elRef.current);
+    elRef.current.textContent = String(countRef.current);
   });
-  return <div>[effect: {commitCountRef.current}]</div>;
+
+  return (
+    <div>
+      [effect: <span ref={elRef}>0</span>]
+    </div>
+  );
 }

--- a/packages/react-server/examples/basic/src/routes/test/_client.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/_client.tsx
@@ -18,5 +18,5 @@ export function EffectCount() {
   React.useEffect(() => {
     commitCountRef.current += 1;
   });
-  return <div>[EffectCount: {commitCountRef.current}]</div>;
+  return <div>[effect: {commitCountRef.current}]</div>;
 }

--- a/packages/react-server/examples/basic/src/routes/test/_client.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/_client.tsx
@@ -7,8 +7,7 @@ export function Hydrated() {
   React.useEffect(() => {
     setHydrated(true);
   }, []);
-
-  return <div>[hydrated: {String(hydrated)}]</div>;
+  return <div>[hydrated: {Number(hydrated)}]</div>;
 }
 
 // test client re-rendering

--- a/packages/react-server/examples/basic/src/routes/test/_client.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/_client.tsx
@@ -8,5 +8,15 @@ export function Hydrated() {
     setHydrated(true);
   }, []);
 
-  return <div>hydrated: {String(hydrated)}</div>;
+  return <div>[hydrated: {String(hydrated)}]</div>;
+}
+
+// test client re-rendering
+// https://github.com/pmndrs/jotai/blob/419ab5cda3503e70463dc340076e21e438db89b6/tests/react/basic.test.tsx#L27-L33
+export function EffectCount() {
+  const commitCountRef = React.useRef(1);
+  React.useEffect(() => {
+    commitCountRef.current += 1;
+  });
+  return <div>[EffectCount: {commitCountRef.current}]</div>;
 }

--- a/packages/react-server/examples/basic/src/routes/test/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/layout.tsx
@@ -1,13 +1,13 @@
 import type { LayoutProps } from "@hiogawa/react-server/server";
 import { NavMenu } from "../../components/nav-menu";
-import { Hydrated } from "./_client";
+import { EffectCount, Hydrated } from "./_client";
 
 export default async function Layout(props: LayoutProps) {
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col gap-2 max-w-lg">
       <h2 className="text-lg">Test</h2>
       <NavMenu
-        className="grid grid-cols-3 w-lg gap-1"
+        className="grid grid-cols-3 gap-1"
         links={[
           "/test",
           "/test/other",
@@ -20,9 +20,10 @@ export default async function Layout(props: LayoutProps) {
           "/test/transition",
         ]}
       />
-      <div className="flex items-center gap-2 w-sm text-sm">
+      <div className="flex items-center gap-2 text-sm">
         <input className="antd-input px-2" placeholder="test-input" />
         <Hydrated />
+        <EffectCount />
       </div>
       {props.children}
     </div>


### PR DESCRIPTION
Currently, everything is re-rendered on each RSC update, but it shouldn't be the case if we refine RSC update based on route tree?