### PR TITLE
refactor(react-server): tweak context

### DIFF
--- a/packages/react-server/src/entry/browser.tsx
+++ b/packages/react-server/src/entry/browser.tsx
@@ -20,6 +20,7 @@ export async function start() {
 
   const history = createBrowserHistory();
   const initialLocation = history.location;
+  const router = new Router(history);
 
   //
   // server action callback
@@ -70,8 +71,6 @@ export async function start() {
     __setRsc = setRsc;
     __startActionTransition = startActionTransition;
 
-    const router = React.use(RouterContext);
-
     React.useEffect(() => router.setup(), []);
 
     React.useEffect(() => {
@@ -107,7 +106,7 @@ export async function start() {
 
   // TODO: root error boundary? suspense?
   let reactRootEl = (
-    <RouterContext.Provider value={new Router(history)}>
+    <RouterContext.Provider value={router}>
       <Root />
     </RouterContext.Provider>
   );

--- a/packages/react-server/src/entry/server.tsx
+++ b/packages/react-server/src/entry/server.tsx
@@ -74,13 +74,14 @@ export async function renderHtml(request: Request, rscStream: ReadableStream) {
   const history = createMemoryHistory({
     initialEntries: [url.href.slice(url.origin.length)],
   });
+  const router = new Router(history);
 
   function Root() {
     return React.use(rsc);
   }
 
   const reactRootEl = (
-    <RouterContext.Provider value={new Router(history)}>
+    <RouterContext.Provider value={router}>
       <Root />
     </RouterContext.Provider>
   );


### PR DESCRIPTION
Knowing `Router` is a singleton, we can just skip `useContext` there.