### PR TITLE
ci: trigger ci on `pull_request`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: ci
 "on":
-  - push
+  push:
+  pull_request:
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: ci
 "on":
   push:
+    branches:
+      - main
   pull_request:
 jobs:
   test:


### PR DESCRIPTION
Not sure why CI is not running in https://github.com/hi-ogawa/vite-plugins/pull/235. Maybe I need to enable this?