### PR TITLE
fix(vite-node-miniflare): fix `miniflareOptions` typing

### DIFF
--- a/packages/vite-node-miniflare/examples/react-router/vite.config.ts
+++ b/packages/vite-node-miniflare/examples/react-router/vite.config.ts
@@ -23,7 +23,6 @@ export default defineConfig({
       entry: "/src/server/worker-entry.ts",
       miniflareOptions(options) {
         options.log = new Log();
-        // @ts-ignore
         options.compatibilityFlags = ["nodejs_compat"];
       },
     }),

--- a/packages/vite-node-miniflare/examples/remix/vite.config.ts
+++ b/packages/vite-node-miniflare/examples/remix/vite.config.ts
@@ -22,7 +22,6 @@ export default defineConfig({
       entry: "/app/worker-entry.ts",
       miniflareOptions(options) {
         options.log = new Log();
-        // @ts-ignore why type error?
         options.kvNamespaces = { kv: "0".repeat(32) };
         options.kvPersist = ".wrangler/state/v3/kv";
       },

--- a/packages/vite-node-miniflare/package.json
+++ b/packages/vite-node-miniflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/vite-node-miniflare",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "homepage": "https://github.com/hi-ogawa/vite-plugins/tree/main/packages/vite-node-miniflare",
   "repository": {
     "type": "git",

--- a/packages/vite-node-miniflare/package.json
+++ b/packages/vite-node-miniflare/package.json
@@ -22,6 +22,7 @@
     "dist"
   ],
   "scripts": {
+    "dev": "tsup --watch",
     "build": "tsup",
     "prepack": "tsup --clean",
     "release": "pnpm publish --no-git-checks --access public"

--- a/packages/vite-node-miniflare/src/server/plugin.ts
+++ b/packages/vite-node-miniflare/src/server/plugin.ts
@@ -12,6 +12,7 @@ import {
   Miniflare,
   type MiniflareOptions,
   type Request as MiniflareRequest,
+  type WorkerOptions,
 } from "miniflare";
 import {
   type HMRPayload,
@@ -38,7 +39,7 @@ export function vitePluginViteNodeMiniflare(pluginOptions: {
   entry: string;
   debug?: boolean;
   hmr?: boolean; // for now disable ssr hmr by default for react plugin
-  miniflareOptions?: (options: MiniflareOptions) => void;
+  miniflareOptions?: (options: MiniflareOptions & WorkerOptions) => void;
   customRpc?: Record<string, Function>;
 }): Plugin {
   // Initialize miniflare lazily on first request and


### PR DESCRIPTION
It looks like `MiniflareOptions` union cannot infer when used contravariantly?

```ts
export type MiniflareOptions = SharedOptions &
	(WorkerOptions | { workers: WorkerOptions[] });
```

https://github.com/cloudflare/workers-sdk/blob/d994066f255f6851759a055eac3b52a4aa4b83c3/packages/miniflare/src/index.ts#L134-L136

Pinning `MiniflareOptions & WorkerOptions` should help easier usage.
