### PR TITLE
feat(react-server): setup client `optimizeDeps.entries`

### DIFF
--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/react-server",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -117,46 +117,15 @@ export function vitePluginReactServer(options?: {
       vitePluginServerUseClient({ manager }),
 
       // expose server references for RSC build via virtual module
-      {
-        name: "virtual-rsc-use-server",
-        apply: "build",
-        async buildStart(_options) {
-          // we need to crawl file system to collect server references ("use server")
-          // since we currently needs RSC -> Client -> SSR build pipeline
-          // to collect client references first in RSC.
-          // TODO: what if "use server" is provided from 3rd party library?
-          //       re-export locally to workaround?
-          const files = await fg("./src/**/*.(js|jsx|ts|tsx)", {
-            absolute: true,
-            ignore: ["**/node_modules/**"],
-          });
-          for (const file of files) {
-            const data = await fs.promises.readFile(file, "utf-8");
-            if (data.match(/^("use server")|('use server')/)) {
-              manager.rscUseServerIds.add(file);
-            }
-          }
-          debug("[virtual-rsc-use-server]", [...manager.rscUseServerIds]);
-        },
-        resolveId(source, _importer, _options) {
-          if (source === "virtual:rsc-use-server") {
-            return "\0" + source;
-          }
-          return;
-        },
-        async load(id, _options) {
-          if (id === "\0virtual:rsc-use-server") {
-            let result = `export default {\n`;
-            for (const id of manager.rscUseServerIds) {
-              let key = manager.buildType ? hashString(id) : id;
-              result += `"${key}": () => import("${id}"),\n`;
-            }
-            result += "};\n";
-            return result;
-          }
-          return;
-        },
-      },
+      createVirtualPlugin("rsc-use-server", () => {
+        let result = `export default {\n`;
+        for (const id of manager.rscUseServerIds) {
+          let key = manager.buildType ? hashString(id) : id;
+          result += `"${key}": () => import("${id}"),\n`;
+        }
+        result += "};\n";
+        return result;
+      }),
 
       createVirtualPlugin(
         ENTRY_REACT_SERVER_WRAPPER.slice("virtual:".length),

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -176,6 +176,7 @@ export function vitePluginReactServer(options?: {
             "react/jsx-dev-runtime",
             "react-dom/client",
             "react-server-dom-webpack/client.browser",
+            "@hiogawa/react-server > @tanstack/history",
             "@hiogawa/react-server > use-sync-external-store/shim/with-selector.js",
           ],
         },
@@ -747,7 +748,9 @@ async function findDirectiveFiles() {
   };
   await Promise.all(
     files.map(async (file) => {
-      const stream = nodeStream.Readable.toWeb(fs.createReadStream(file));
+      const stream = nodeStream.Readable.toWeb(
+        fs.createReadStream(file, "utf-8"),
+      );
       const line = await getFirstLine(stream as any);
       if (line.match(USE_CLIENT_RE)) {
         result.client.push(file);
@@ -784,6 +787,7 @@ async function getFirstLine(stream: ReadableStream<string>) {
   const reader = lines.getReader();
   const result = await reader.read();
   const line = result.value ?? "";
+  reader.releaseLock();
   await lines.cancel();
   return line;
 }

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -168,7 +168,9 @@ export function vitePluginReactServer(options?: {
 
       return {
         optimizeDeps: {
-          entries: directiveFiles.client,
+          // this can potentially include unnecessary server only deps for client,
+          // but there should be no issues except making deps optimization slightly slower.
+          entries: ["./src/routes/**/(page|layout|error).(js|jsx|ts|tsx)"],
           exclude: ["@hiogawa/react-server"],
           include: [
             "react",

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -188,6 +188,9 @@ export function vitePluginReactServer(options?: {
       parentEnv = env;
       return {
         optimizeDeps: {
+          // this can potentially include unnecessary server only deps for client,
+          // but there should be no issues except making deps optimization slightly slower.
+          entries: ["./src/routes/**/(page|layout|error).(js|jsx|ts|tsx)"],
           exclude: ["@hiogawa/react-server"],
           include: [
             "react",
@@ -195,6 +198,7 @@ export function vitePluginReactServer(options?: {
             "react/jsx-dev-runtime",
             "react-dom/client",
             "react-server-dom-webpack/client.browser",
+            "@hiogawa/react-server > @tanstack/history",
             "@hiogawa/react-server > use-sync-external-store/shim/with-selector.js",
           ],
         },


### PR DESCRIPTION
I'm guessing this single flakiness is due to `react-dom` optimize deps reload https://github.com/hi-ogawa/vite-plugins/pull/209.

<details><summary>comment about old approach</summary>

Collecting local `"use client"` as deps optimization entries should help, but this actually cannot cover the cases where `"use client"` comes as external and directly imported to server component, for example:

https://github.com/hi-ogawa/vite-plugins/blob/561c68111c3c279438d920414582b315ff4948e2/packages/react-server/examples/basic/src/routes/test/deps/page.tsx#L3-L7

Implementing own deps scan for server routes `src/routes/**/*(page|layout).tsx` might be possible, but I guess it's fine for now. Or maybe we can just put all the routes like I did for Remix:
- https://github.com/hi-ogawa/ytsub-v3/pull/536

</details>

Well, this should just work:

```ts
        optimizeDeps: {
          entries: ["./src/routes/**/(page|layout|error).(js|jsx|ts|tsx)"],
````

---

CI is looking better https://github.com/hi-ogawa/vite-plugins/actions/runs/8506087978/job/23295704291