### PR TITLE
feat(react-server): action redirect headers and context

### DIFF
--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -489,6 +489,62 @@ test("redirect server action @js", async ({ page }) => {
   await page.waitForURL("/test/redirect?ok=server-action");
 });
 
+test.only("action context @js", async ({ page }) => {
+  checkNoError(page);
+  await page.goto("/test/session");
+  await waitForHydration(page);
+
+  // redirected from auth protected action
+  await page.getByText("Hi, anonymous user!").click();
+  await page.getByRole("button", { name: "+1" }).click();
+  await page.waitForURL("/test/session/signin");
+
+  // signin
+  await page.getByPlaceholder("Input name...").fill("asdf");
+  await page.getByRole("button", { name: "Signin" }).click();
+  await page.waitForURL("/test/session");
+
+  // try auth protected action
+  await page.getByText("Hello, asdf!").click();
+  await page.getByText("Counter: 0").click();
+  await page.getByRole("button", { name: "+1" }).click();
+  await page.getByText("Counter: 1").click();
+  await page.getByRole("button", { name: "-1" }).click();
+  await page.getByText("Counter: 0").click();
+
+  // signout
+  await page.getByRole("button", { name: "Signout" }).click();
+  await page.getByText("Hi, anonymous user!").click();
+});
+
+test.only("action context @nojs", async ({ browser }) => {
+  const page = await browser.newPage({ javaScriptEnabled: false });
+  checkNoError(page);
+  await page.goto("/test/session");
+
+  // redirected from auth protected action
+  await page.getByText("Hi, anonymous user!").click();
+  await page.getByRole("button", { name: "+1" }).click();
+  await page.waitForURL("/test/session/signin");
+
+  // signin
+  await page.getByPlaceholder("Input name...").fill("asdf");
+  await page.getByRole("button", { name: "Signin" }).click();
+  await page.waitForURL("/test/session");
+
+  // try auth protected action
+  await page.getByText("Hello, asdf!").click();
+  await page.getByText("Counter: 0").click();
+  await page.getByRole("button", { name: "+1" }).click();
+  await page.getByText("Counter: 1").click();
+  await page.getByRole("button", { name: "-1" }).click();
+  await page.getByText("Counter: 0").click();
+
+  // signout
+  await page.getByRole("button", { name: "Signout" }).click();
+  await page.getByText("Hi, anonymous user!").click();
+});
+
 async function setupCheckClientState(page: Page) {
   // setup client state
   await page.getByPlaceholder("test-input").fill("hello");

--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -493,33 +493,17 @@ test("action context @js", async ({ page }) => {
   checkNoError(page);
   await page.goto("/test/session");
   await waitForHydration(page);
-
-  // redirected from auth protected action
-  await page.getByText("Hi, anonymous user!").click();
-  await page.getByRole("button", { name: "+1" }).click();
-  await page.waitForURL("/test/session/signin");
-
-  // signin
-  await page.getByPlaceholder("Input name...").fill("asdf");
-  await page.getByRole("button", { name: "Signin" }).click();
-  await page.waitForURL("/test/session");
-
-  // try auth protected action
-  await page.getByText("Hello, asdf!").click();
-  await page.getByText("Counter: 0").click();
-  await page.getByRole("button", { name: "+1" }).click();
-  await page.getByText("Counter: 1").click();
-  await page.getByRole("button", { name: "-1" }).click();
-  await page.getByText("Counter: 0").click();
-
-  // signout
-  await page.getByRole("button", { name: "Signout" }).click();
-  await page.getByText("Hi, anonymous user!").click();
+  await testActionContext(page);
 });
 
 test("action context @nojs", async ({ browser }) => {
   const page = await browser.newPage({ javaScriptEnabled: false });
   checkNoError(page);
+  await page.goto("/test/session");
+  await testActionContext(page);
+});
+
+async function testActionContext(page: Page) {
   await page.goto("/test/session");
 
   // redirected from auth protected action
@@ -543,7 +527,7 @@ test("action context @nojs", async ({ browser }) => {
   // signout
   await page.getByRole("button", { name: "Signout" }).click();
   await page.getByText("Hi, anonymous user!").click();
-});
+}
 
 async function setupCheckClientState(page: Page) {
   // setup client state

--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -489,7 +489,7 @@ test("redirect server action @js", async ({ page }) => {
   await page.waitForURL("/test/redirect?ok=server-action");
 });
 
-test.only("action context @js", async ({ page }) => {
+test("action context @js", async ({ page }) => {
   checkNoError(page);
   await page.goto("/test/session");
   await waitForHydration(page);
@@ -517,7 +517,7 @@ test.only("action context @js", async ({ page }) => {
   await page.getByText("Hi, anonymous user!").click();
 });
 
-test.only("action context @nojs", async ({ browser }) => {
+test("action context @nojs", async ({ browser }) => {
   const page = await browser.newPage({ javaScriptEnabled: false });
   checkNoError(page);
   await page.goto("/test/session");

--- a/packages/react-server/examples/basic/package.json
+++ b/packages/react-server/examples/basic/package.json
@@ -20,10 +20,12 @@
     "@hiogawa/react-server": "latest",
     "@hiogawa/test-dep-server-component": "file:deps/server-component",
     "@hiogawa/test-dep-use-client": "file:deps/use-client",
+    "cookie": "^0.6.0",
     "react": "18.3.0-canary-14898b6a9-20240318",
     "react-dom": "18.3.0-canary-14898b6a9-20240318",
     "react-server-dom-webpack": "18.3.0-canary-14898b6a9-20240318",
-    "react-wrap-balancer": "^1.1.0"
+    "react-wrap-balancer": "^1.1.0",
+    "valibot": "^0.30.0"
   },
   "devDependencies": {
     "@hattip/adapter-node": "^0.0.44",
@@ -32,6 +34,7 @@
     "@hiogawa/vite-plugin-ssr-middleware": "latest",
     "@iconify-json/ri": "^1.1.20",
     "@playwright/test": "^1.42.1",
+    "@types/cookie": "^0.6.0",
     "@types/react": "18.2.66",
     "@types/react-dom": "18.2.22",
     "@unocss/postcss": "^0.58.6",

--- a/packages/react-server/examples/basic/package.json
+++ b/packages/react-server/examples/basic/package.json
@@ -24,8 +24,7 @@
     "react": "18.3.0-canary-14898b6a9-20240318",
     "react-dom": "18.3.0-canary-14898b6a9-20240318",
     "react-server-dom-webpack": "18.3.0-canary-14898b6a9-20240318",
-    "react-wrap-balancer": "^1.1.0",
-    "valibot": "^0.30.0"
+    "react-wrap-balancer": "^1.1.0"
   },
   "devDependencies": {
     "@hattip/adapter-node": "^0.0.44",

--- a/packages/react-server/examples/basic/src/routes/test/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/layout.tsx
@@ -19,6 +19,7 @@ export default async function Layout(props: LayoutProps) {
           "/test/not-found",
           "/test/transition",
           "/test/redirect",
+          "/test/session",
         ]}
       />
       <div className="flex items-center gap-2 text-sm">

--- a/packages/react-server/examples/basic/src/routes/test/session/_action.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/session/_action.tsx
@@ -1,0 +1,29 @@
+"use server";
+
+import { getActionContext, redirect } from "@hiogawa/react-server/server";
+import { tinyassert } from "@hiogawa/utils";
+import { setSession } from "./utils";
+
+export async function signin(formData: FormData) {
+  // TODO: check if already signed in
+  const ctx = getActionContext(formData);
+  ctx.request.headers;
+
+  // TODO: return error on invalid input
+  const name = formData.get("name");
+  tinyassert(typeof name === "string");
+
+  throw redirect("/test/session", {
+    headers: {
+      "set-cookie": setSession({ user: { name } }),
+    },
+  });
+}
+
+export async function signout() {
+  throw redirect("/test/session", {
+    headers: {
+      "set-cookie": setSession({}),
+    },
+  });
+}

--- a/packages/react-server/examples/basic/src/routes/test/session/_action.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/session/_action.tsx
@@ -36,5 +36,5 @@ export async function incrementCounter(formData: FormData) {
   if (!session?.name) {
     throw redirect("/test/session/signin");
   }
-  counter++;
+  counter += Number(formData.get("delta"));
 }

--- a/packages/react-server/examples/basic/src/routes/test/session/_action.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/session/_action.tsx
@@ -2,13 +2,9 @@
 
 import { getActionContext, redirect } from "@hiogawa/react-server/server";
 import { tinyassert } from "@hiogawa/utils";
-import { setSession } from "./utils";
+import { getSession, setSession } from "./utils";
 
 export async function signin(formData: FormData) {
-  // TODO: check if already signed in
-  const ctx = getActionContext(formData);
-  ctx.request.headers;
-
   // TODO: return error on invalid input
   const name = formData.get("name");
   tinyassert(typeof name === "string");
@@ -26,4 +22,19 @@ export async function signout() {
       "set-cookie": setSession({}),
     },
   });
+}
+
+let counter = 0;
+
+export function getCounter() {
+  return counter;
+}
+
+export async function incrementCounter(formData: FormData) {
+  const ctx = getActionContext(formData);
+  const session = getSession(ctx.request);
+  if (!session?.name) {
+    throw redirect("/test/session/signin");
+  }
+  counter++;
 }

--- a/packages/react-server/examples/basic/src/routes/test/session/_action.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/session/_action.tsx
@@ -15,7 +15,7 @@ export async function signin(formData: FormData) {
 
   throw redirect("/test/session", {
     headers: {
-      "set-cookie": setSession({ user: { name } }),
+      "set-cookie": setSession({ name }),
     },
   });
 }

--- a/packages/react-server/examples/basic/src/routes/test/session/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/session/layout.tsx
@@ -1,0 +1,10 @@
+import type { LayoutProps } from "@hiogawa/react-server/server";
+
+export default function Layout(props: LayoutProps) {
+  return (
+    <div className="flex flex-col gap-2 p-2">
+      <h3 className="font-bold">Session Demo</h3>
+      <div>{props.children}</div>
+    </div>
+  );
+}

--- a/packages/react-server/examples/basic/src/routes/test/session/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/session/page.tsx
@@ -1,27 +1,35 @@
+import { Link } from "@hiogawa/react-server/client";
 import type { PageProps } from "@hiogawa/react-server/server";
-import { signin, signout } from "./_action";
+import { getCounter, incrementCounter, signout } from "./_action";
 import { getSession } from "./utils";
 
 export default function Page(props: PageProps) {
   const session = getSession(props.request);
-  if (session?.name) {
-    return (
-      <form className="flex flex-col gap-2 p-2 max-w-sm" action={signout}>
-        Hello {session.name}!
-        <button className="antd-btn antd-btn-default">Signout</button>
-      </form>
-    );
-  }
-
   return (
-    <form className="flex flex-col gap-2 p-2 max-w-sm" action={signin}>
-      <input
-        className="antd-input px-2"
-        name="name"
-        placeholder="Input name..."
-        required
-      />
-      <button className="antd-btn antd-btn-primary">Signin</button>
-    </form>
+    <div className="flex flex-col gap-4 p-3 max-w-sm">
+      <form className="flex items-center gap-2" action={incrementCounter}>
+        <p>Counter: {getCounter()}</p>
+        <button className="antd-btn antd-btn-default px-2">+1</button>
+        <span className="text-colorTextLabel text-sm">(signin required)</span>
+      </form>
+      {session?.name && (
+        <div className="flex items-center gap-3">
+          <p>Hello {session.name}!</p>
+          <form action={signout}>
+            <button className="antd-btn antd-btn-default px-2">Signout</button>
+          </form>
+        </div>
+      )}
+      {!session?.name && (
+        <div className="flex">
+          <Link
+            className="antd-btn antd-btn-default px-2"
+            href="/test/session/signin"
+          >
+            Signin
+          </Link>
+        </div>
+      )}
+    </div>
   );
 }

--- a/packages/react-server/examples/basic/src/routes/test/session/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/session/page.tsx
@@ -1,0 +1,27 @@
+import type { PageProps } from "@hiogawa/react-server/server";
+import { signin, signout } from "./_action";
+import { getSession } from "./utils";
+
+export default function Page(props: PageProps) {
+  const session = getSession(props.request);
+  if (session?.user) {
+    return (
+      <form className="flex flex-col gap-2 p-2 max-w-sm" action={signout}>
+        Hello {session?.user?.name || "TODO"}!
+        <button className="antd-btn antd-btn-default">Signout</button>
+      </form>
+    );
+  }
+
+  return (
+    <form className="flex flex-col gap-2 p-2 max-w-sm" action={signin}>
+      <input
+        className="antd-input px-2"
+        name="name"
+        placeholder="Input name..."
+        required
+      />
+      <button className="antd-btn antd-btn-primary">Signin</button>
+    </form>
+  );
+}

--- a/packages/react-server/examples/basic/src/routes/test/session/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/session/page.tsx
@@ -9,19 +9,33 @@ export default function Page(props: PageProps) {
     <div className="flex flex-col gap-4 p-3 max-w-sm">
       <form className="flex items-center gap-2" action={incrementCounter}>
         <p>Counter: {getCounter()}</p>
-        <button className="antd-btn antd-btn-default px-2">+1</button>
+        <button
+          className="antd-btn antd-btn-default px-2"
+          name="delta"
+          value={-1}
+        >
+          -1
+        </button>
+        <button
+          className="antd-btn antd-btn-default px-2"
+          name="delta"
+          value={+1}
+        >
+          +1
+        </button>
         <span className="text-colorTextLabel text-sm">(signin required)</span>
       </form>
       {session?.name && (
         <div className="flex items-center gap-3">
-          <p>Hello {session.name}!</p>
+          <p>Hello, {session.name}!</p>
           <form action={signout}>
             <button className="antd-btn antd-btn-default px-2">Signout</button>
           </form>
         </div>
       )}
       {!session?.name && (
-        <div className="flex">
+        <div className="flex items-center gap-3 ">
+          <p>Hi, anonymous user!</p>
           <Link
             className="antd-btn antd-btn-default px-2"
             href="/test/session/signin"

--- a/packages/react-server/examples/basic/src/routes/test/session/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/session/page.tsx
@@ -4,10 +4,10 @@ import { getSession } from "./utils";
 
 export default function Page(props: PageProps) {
   const session = getSession(props.request);
-  if (session?.user) {
+  if (session?.name) {
     return (
       <form className="flex flex-col gap-2 p-2 max-w-sm" action={signout}>
-        Hello {session?.user?.name || "TODO"}!
+        Hello {session.name}!
         <button className="antd-btn antd-btn-default">Signout</button>
       </form>
     );

--- a/packages/react-server/examples/basic/src/routes/test/session/signin/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/session/signin/page.tsx
@@ -1,0 +1,22 @@
+import { type PageProps, redirect } from "@hiogawa/react-server/server";
+import { signin } from "../_action";
+import { getSession } from "../utils";
+
+export default function Page(props: PageProps) {
+  const session = getSession(props.request);
+  if (session?.name) {
+    throw redirect("/test/session");
+  }
+
+  return (
+    <form className="flex flex-col gap-2 p-2 max-w-sm" action={signin}>
+      <input
+        className="antd-input px-2"
+        name="name"
+        placeholder="Input name..."
+        required
+      />
+      <button className="antd-btn antd-btn-primary">Signin</button>
+    </form>
+  );
+}

--- a/packages/react-server/examples/basic/src/routes/test/session/utils.ts
+++ b/packages/react-server/examples/basic/src/routes/test/session/utils.ts
@@ -1,7 +1,7 @@
 import { objectHas, tinyassert } from "@hiogawa/utils";
 import * as cookieLib from "cookie";
 
-// mini cookie utils
+// mini cookie session utils
 
 type SessionData = {
   name?: string;
@@ -20,9 +20,7 @@ export function getSession(request: Request): SessionData | undefined {
         tinyassert(objectHas(data, "name"));
         tinyassert(typeof data.name === "string");
         return { name: data.name };
-      } catch (e) {
-        console.error(e);
-      }
+      } catch (e) {}
     }
   }
 }

--- a/packages/react-server/examples/basic/src/routes/test/session/utils.ts
+++ b/packages/react-server/examples/basic/src/routes/test/session/utils.ts
@@ -1,18 +1,11 @@
-import { tinyassert } from "@hiogawa/utils";
+import { objectHas, tinyassert } from "@hiogawa/utils";
 import * as cookieLib from "cookie";
-import * as z from "valibot";
 
 // mini cookie utils
 
-const sessionSchema = z.object({
-  user: z.optional(
-    z.object({
-      name: z.string(),
-    }),
-  ),
-});
-
-type SessionData = z.Output<typeof sessionSchema>;
+type SessionData = {
+  name?: string;
+};
 
 const SESSION_KEY = "__session";
 
@@ -24,7 +17,9 @@ export function getSession(request: Request): SessionData | undefined {
     if (token) {
       try {
         const data = JSON.parse(decodeURIComponent(token));
-        return z.parse(sessionSchema, data);
+        tinyassert(objectHas(data, "name"));
+        tinyassert(typeof data.name === "string");
+        return { name: data.name };
       } catch (e) {
         console.error(e);
       }

--- a/packages/react-server/examples/basic/src/routes/test/session/utils.ts
+++ b/packages/react-server/examples/basic/src/routes/test/session/utils.ts
@@ -1,0 +1,46 @@
+import { tinyassert } from "@hiogawa/utils";
+import * as cookieLib from "cookie";
+import * as z from "valibot";
+
+// mini cookie utils
+
+const sessionSchema = z.object({
+  user: z.optional(
+    z.object({
+      name: z.string(),
+    }),
+  ),
+});
+
+type SessionData = z.Output<typeof sessionSchema>;
+
+const SESSION_KEY = "__session";
+
+export function getSession(request: Request): SessionData | undefined {
+  const raw = request.headers.get("cookie");
+  if (raw) {
+    const parsed = cookieLib.parse(raw);
+    const token = parsed[SESSION_KEY];
+    if (token) {
+      try {
+        const data = JSON.parse(decodeURIComponent(token));
+        return z.parse(sessionSchema, data);
+      } catch (e) {
+        console.error(e);
+      }
+    }
+  }
+}
+
+export function setSession(data: SessionData) {
+  const token = encodeURIComponent(JSON.stringify(data));
+  const cookie = cookieLib.serialize(SESSION_KEY, token, {
+    httpOnly: true,
+    secure: true,
+    sameSite: "lax",
+    path: "/",
+    maxAge: 14 * 24 * 60 * 60, // two week
+  });
+  tinyassert(cookie.length < 2 ** 12, "too large cookie session");
+  return cookie;
+}

--- a/packages/react-server/examples/basic/vite.config.ts
+++ b/packages/react-server/examples/basic/vite.config.ts
@@ -14,7 +14,21 @@ export default defineConfig({
     react(),
     unocss(),
     vitePluginReactServer({
-      plugins: [testVitePluginVirtual()],
+      plugins: [
+        testVitePluginVirtual(),
+        {
+          name: "cusotm-react-server-config",
+          config() {
+            return {
+              ssr: {
+                optimizeDeps: {
+                  include: ["cookie"],
+                },
+              },
+            };
+          },
+        },
+      ],
     }),
     vitePluginLogger(),
     vitePluginSsrMiddleware({

--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/react-server",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/packages/react-server/src/entry/react-server.tsx
+++ b/packages/react-server/src/entry/react-server.tsx
@@ -55,7 +55,7 @@ export const handler: ReactServerHandler = async (ctx) => {
       const errorCtx = getErrorContext(e) ?? DEFAULT_ERROR_CONTEXT;
       if (rscOnly) {
         // returns empty layout to keep current layout and
-        // let browser initiate cliet-side navigation for redirection error
+        // let browser initiate client-side navigation for redirection error
         const data: ServerRouterData = {
           action: { error: errorCtx },
           layout: {},

--- a/packages/react-server/src/entry/react-server.tsx
+++ b/packages/react-server/src/entry/react-server.tsx
@@ -63,6 +63,7 @@ export const handler: ReactServerHandler = async (ctx) => {
         const stream = reactServerDomServer.renderToReadableStream(data, {});
         return new Response(stream, {
           headers: {
+            ...errorCtx.headers,
             "content-type": "text/x-component; charset=utf-8",
           },
         });

--- a/packages/react-server/src/entry/react-server.tsx
+++ b/packages/react-server/src/entry/react-server.tsx
@@ -11,6 +11,7 @@ import {
   type ServerRouterData,
   createLayoutContentRequest,
 } from "../features/router/utils";
+import { actionContextMap } from "../features/server-action/react-server";
 import { ejectActionId } from "../features/server-action/utils";
 import { unwrapRscRequest } from "../features/server-component/utils";
 import { createBundlerConfig } from "../features/use-client/react-server";
@@ -185,6 +186,12 @@ async function actionHandler({ request }: { request: Request }) {
     action = mod[name];
   }
 
+  const responseHeaders = new Headers();
+  actionContextMap.set(formData, { request, responseHeaders });
+
   // TODO: action return value?
   await action(formData);
+
+  // TODO: write headers on successfull action
+  return { responseHeaders };
 }

--- a/packages/react-server/src/entry/react-server.tsx
+++ b/packages/react-server/src/entry/react-server.tsx
@@ -55,7 +55,7 @@ export const handler: ReactServerHandler = async (ctx) => {
       const errorCtx = getErrorContext(e) ?? DEFAULT_ERROR_CONTEXT;
       if (rscOnly) {
         // returns empty layout to keep current layout and
-        // let browser initiate clie-side navigation for redirection error
+        // let browser initiate cliet-side navigation for redirection error
         const data: ServerRouterData = {
           action: { error: errorCtx },
           layout: {},
@@ -70,11 +70,7 @@ export const handler: ReactServerHandler = async (ctx) => {
       // TODO: general action error handling?
       return new Response(null, {
         status: errorCtx.status,
-        headers: errorCtx.redirectLocation
-          ? {
-              location: errorCtx.redirectLocation,
-            }
-          : {},
+        headers: errorCtx.headers,
       });
     }
   }

--- a/packages/react-server/src/features/router/client.tsx
+++ b/packages/react-server/src/features/router/client.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { RedirectHandler } from "../../lib/client/error-boundary";
+import { isRedirectError } from "../../lib/error";
 import { __global } from "../../lib/global";
 import { LAYOUT_ROOT_NAME, type ServerRouterData } from "./utils";
 
@@ -25,14 +26,16 @@ export function ServerActionRedirectHandler() {
   const ctx = React.useContext(LayoutStateContext);
   const data = React.use(ctx.data);
 
-  if (data.action?.error?.redirectLocation) {
-    return (
-      <RedirectHandler
-        suspensionKey={data.action?.error}
-        redirectLocation={data.action?.error.redirectLocation}
-      />
-    );
+  if (data.action?.error) {
+    const redirect = isRedirectError(data.action.error);
+    if (redirect) {
+      return (
+        <RedirectHandler
+          suspensionKey={data.action.error}
+          redirectLocation={redirect.location}
+        />
+      );
+    }
   }
-
   return null;
 }

--- a/packages/react-server/src/features/server-action/react-server.tsx
+++ b/packages/react-server/src/features/server-action/react-server.tsx
@@ -1,3 +1,5 @@
+import { tinyassert } from "@hiogawa/utils";
+
 export function createServerReference(id: string, action: Function): React.FC {
   return Object.defineProperties(action, {
     $$typeof: {
@@ -15,4 +17,20 @@ export function createServerReference(id: string, action: Function): React.FC {
       configurable: true,
     },
   }) as any;
+}
+
+// Builtin action context system based on FormData identity.
+// Users can easilty setup own AsyncLocalStorage based request context using custom handler,
+// but we don't make it as an builtin feature until async hooks are properly supported on Stackblitz.
+export const actionContextMap = new WeakMap<FormData, ActionContext>();
+
+export interface ActionContext {
+  request: Request;
+  responseHeaders: Headers;
+}
+
+export function getActionContext(formData: FormData) {
+  const ctx = actionContextMap.get(formData);
+  tinyassert(ctx);
+  return ctx;
 }

--- a/packages/react-server/src/features/server-action/react-server.tsx
+++ b/packages/react-server/src/features/server-action/react-server.tsx
@@ -21,7 +21,7 @@ export function createServerReference(id: string, action: Function): React.FC {
 
 // Builtin action context system based on FormData identity.
 // Users can easilty setup own AsyncLocalStorage based request context using custom handler,
-// but we don't make it as an builtin feature until async hooks are properly supported on Stackblitz.
+// but we don't make it as a builtin feature until async hooks are properly supported on Stackblitz.
 export const actionContextMap = new WeakMap<FormData, ActionContext>();
 
 export interface ActionContext {

--- a/packages/react-server/src/lib/client/error-boundary.tsx
+++ b/packages/react-server/src/lib/client/error-boundary.tsx
@@ -1,6 +1,6 @@
 import { tinyassert } from "@hiogawa/utils";
 import React from "react";
-import { getErrorContext, getStatusText } from "../error";
+import { getErrorContext, getStatusText, isRedirectError } from "../error";
 import type { ErrorPageProps } from "../router";
 import { useRouter } from "./router";
 
@@ -89,8 +89,9 @@ export class RedirectBoundary extends React.Component<React.PropsWithChildren> {
   static getDerivedStateFromError(error: Error) {
     if (!import.meta.env.SSR) {
       const ctx = getErrorContext(error);
-      if (ctx?.redirectLocation) {
-        return { redirectLocation: ctx.redirectLocation };
+      const redirect = ctx && isRedirectError(ctx);
+      if (redirect) {
+        return { redirectLocation: redirect.location };
       }
     }
     throw error;

--- a/packages/react-server/src/lib/error.tsx
+++ b/packages/react-server/src/lib/error.tsx
@@ -1,12 +1,7 @@
 // TODO: custom (de)serialization?
 export interface ReactServerErrorContext {
   status: number;
-  // TODO: hide from public typing?
-  redirectLocation?: string;
-}
-
-export interface ReactServerRedirectErrorContext {
-  redirectLocation: string;
+  headers?: Record<string, string>;
 }
 
 export class ReactServerDigestError extends Error {
@@ -21,7 +16,18 @@ export function createError(ctx: ReactServerErrorContext) {
 }
 
 export function redirect(location: string, status: number = 302) {
-  return createError({ status, redirectLocation: location });
+  return createError({
+    status,
+    headers: { location },
+  });
+}
+
+export function isRedirectError(ctx: ReactServerErrorContext) {
+  const location = ctx.headers?.["location"];
+  if (300 <= ctx.status && ctx.status <= 399 && typeof location === "string") {
+    return { location };
+  }
+  return false;
 }
 
 export function getErrorContext(

--- a/packages/react-server/src/lib/error.tsx
+++ b/packages/react-server/src/lib/error.tsx
@@ -15,10 +15,16 @@ export function createError(ctx: ReactServerErrorContext) {
   return new ReactServerDigestError(digest);
 }
 
-export function redirect(location: string, status: number = 302) {
+export function redirect(
+  location: string,
+  options?: { status?: number; headers?: Record<string, string> },
+) {
   return createError({
-    status,
-    headers: { location },
+    status: options?.status ?? 302,
+    headers: {
+      ...options?.headers,
+      location,
+    },
   });
 }
 

--- a/packages/react-server/src/server.ts
+++ b/packages/react-server/src/server.ts
@@ -4,3 +4,4 @@ export {
   redirect,
   type ReactServerErrorContext,
 } from "./lib/error";
+export { getActionContext } from "./features/server-action/react-server";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       '@hiogawa/test-dep-use-client':
         specifier: file:deps/use-client
         version: file:packages/react-server/examples/basic/deps/use-client(react@18.3.0-canary-14898b6a9-20240318)
+      cookie:
+        specifier: ^0.6.0
+        version: 0.6.0
       react:
         specifier: 18.3.0-canary-14898b6a9-20240318
         version: 18.3.0-canary-14898b6a9-20240318
@@ -117,6 +120,9 @@ importers:
       react-wrap-balancer:
         specifier: ^1.1.0
         version: 1.1.0(react@18.3.0-canary-14898b6a9-20240318)
+      valibot:
+        specifier: ^0.30.0
+        version: 0.30.0
     devDependencies:
       '@hattip/adapter-node':
         specifier: ^0.0.44
@@ -136,6 +142,9 @@ importers:
       '@playwright/test':
         specifier: ^1.42.1
         version: 1.42.1
+      '@types/cookie':
+        specifier: ^0.6.0
+        version: 0.6.0
       '@types/react':
         specifier: 18.2.66
         version: 18.2.66
@@ -7160,6 +7169,10 @@ packages:
       kleur: 4.1.5
       sade: 1.8.1
     dev: true
+
+  /valibot@0.30.0:
+    resolution: {integrity: sha512-5POBdbSkM+3nvJ6ZlyQHsggisfRtyT4tVTo1EIIShs6qCdXJnyWU5TJ68vr8iTg5zpOLjXLRiBqNx+9zwZz/rA==}
+    dev: false
 
   /validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,9 +120,6 @@ importers:
       react-wrap-balancer:
         specifier: ^1.1.0
         version: 1.1.0(react@18.3.0-canary-14898b6a9-20240318)
-      valibot:
-        specifier: ^0.30.0
-        version: 0.30.0
     devDependencies:
       '@hattip/adapter-node':
         specifier: ^0.0.44
@@ -7169,10 +7166,6 @@ packages:
       kleur: 4.1.5
       sade: 1.8.1
     dev: true
-
-  /valibot@0.30.0:
-    resolution: {integrity: sha512-5POBdbSkM+3nvJ6ZlyQHsggisfRtyT4tVTo1EIIShs6qCdXJnyWU5TJ68vr8iTg5zpOLjXLRiBqNx+9zwZz/rA==}
-    dev: false
 
   /validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}


### PR DESCRIPTION
- supersedes https://github.com/hi-ogawa/vite-plugins/pull/253

Having access to `request` is obviously necessary (e.g. for `request.header.get("cookie")`), but I'm not sure about how `responseHeaders` mutation could be used for "successful" response as returning `set-cookie` for redirection error is already possible by https://github.com/hi-ogawa/vite-plugins/pull/253

## todo

- [x] cookie session demo
- [x] test