### PR TITLE
feat(react-server): action return value (implement `useActionData`)

### DIFF
--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -481,8 +481,6 @@ test("redirect server action @nojs", async ({ browser }) => {
 });
 
 test("redirect server action @js", async ({ page }) => {
-  checkNoError(page);
-
   await page.goto("/test/redirect");
   await waitForHydration(page);
   await page.getByRole("button", { name: "From Server Action" }).click();

--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -489,6 +489,31 @@ test("redirect server action @js", async ({ page }) => {
   await page.waitForURL("/test/redirect?ok=server-action");
 });
 
+test("action return value @js", async ({ page }) => {
+  checkNoError(page);
+  await page.goto("/test/action");
+  await waitForHydration(page);
+  await testActionReturnValue(page, { js: true });
+});
+
+test("action return value @nojs", async ({ browser }) => {
+  const page = await browser.newPage({ javaScriptEnabled: false });
+  checkNoError(page);
+  await page.goto("/test/action");
+  await testActionReturnValue(page, { js: false });
+});
+
+async function testActionReturnValue(page: Page, { js }: { js: boolean }) {
+  await page.getByPlaceholder("Answer?").fill("3");
+  await page.getByPlaceholder("Answer?").press("Enter");
+  await page.getByText("Wrong!").click();
+  await expect(page.getByPlaceholder("Answer?")).toHaveValue(js ? "3" : "");
+
+  await page.getByPlaceholder("Answer?").fill("2");
+  await page.getByPlaceholder("Answer?").press("Enter");
+  await page.getByText("Correct!").click();
+}
+
 test("action context @js", async ({ page }) => {
   checkNoError(page);
   await page.goto("/test/session");

--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -513,7 +513,6 @@ async function testActionReturnValue(page: Page, { js }: { js: boolean }) {
 }
 
 test("action context @js", async ({ page }) => {
-  checkNoError(page);
   await page.goto("/test/session");
   await waitForHydration(page);
   await testActionContext(page);
@@ -527,8 +526,6 @@ test("action context @nojs", async ({ browser }) => {
 });
 
 async function testActionContext(page: Page) {
-  await page.goto("/test/session");
-
   // redirected from auth protected action
   await page.getByText("Hi, anonymous user!").click();
   await page.getByRole("button", { name: "+1" }).click();

--- a/packages/react-server/examples/basic/src/routes/test/action/_action.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/action/_action.tsx
@@ -29,3 +29,9 @@ export function addMessage(formData: FormData) {
 export async function slowAction(formData: FormData) {
   await sleep(Number(formData.get("sleep")));
 }
+
+export async function actionCheckAnswer(formData: FormData) {
+  const answer = Number(formData.get("answer"));
+  const message = answer === 2 ? "Correct!" : "Wrong!";
+  return { message };
+}

--- a/packages/react-server/examples/basic/src/routes/test/action/_client.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/action/_client.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import { useActionData } from "@hiogawa/react-server/client";
 import React from "react";
 import ReactDom from "react-dom";
 import {
+  actionCheckAnswer,
   addMessage,
   changeCounter,
   type getMessages,
@@ -94,6 +96,24 @@ export function Chat(props: { messages: ReturnType<typeof getMessages> }) {
         </div>
       </form>
     </div>
+  );
+}
+
+export function ActionDataTest() {
+  const data = useActionData(actionCheckAnswer);
+  return (
+    <form action={actionCheckAnswer} className="flex flex-col gap-2">
+      <h4 className="font-bold">Action Data</h4>
+      <div className="flex gap-2">
+        <div>1 + 1 = </div>
+        <input
+          className="antd-input px-2 max-w-30"
+          name="answer"
+          placeholder="Answer?"
+        />
+        <div>{data?.message}</div>
+      </div>
+    </form>
   );
 }
 

--- a/packages/react-server/examples/basic/src/routes/test/action/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/action/page.tsx
@@ -1,5 +1,11 @@
 import { changeCounter, getCounter, getMessages } from "./_action";
-import { Chat, Counter, Counter2, FormStateTest } from "./_client";
+import {
+  ActionDataTest,
+  Chat,
+  Counter,
+  Counter2,
+  FormStateTest,
+} from "./_client";
 
 export default async function Page() {
   return (
@@ -10,6 +16,7 @@ export default async function Page() {
         <Counter3 />
       </div>
       <Chat messages={getMessages()} />
+      <ActionDataTest />
       <FormStateTest />
     </div>
   );

--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/react-server",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/packages/react-server/src/client.tsx
+++ b/packages/react-server/src/client.tsx
@@ -2,3 +2,4 @@
 
 export { Link } from "./lib/client/link";
 export { useRouter } from "./lib/client/router";
+export { useActionData } from "./features/server-action/client";

--- a/packages/react-server/src/entry/browser.tsx
+++ b/packages/react-server/src/entry/browser.tsx
@@ -135,6 +135,7 @@ export async function start() {
       const lastPathname = lastLocation.current.pathname;
       lastLocation.current = location;
 
+      // TODO: (refactor) server can find `newKeys` based on from/to location
       const pathname = location.pathname;
       let newKeys = getNewLayoutContentKeys(lastPathname, pathname);
       if (RSC_HMR_STATE_KEY in location.state) {

--- a/packages/react-server/src/entry/browser.tsx
+++ b/packages/react-server/src/entry/browser.tsx
@@ -2,11 +2,7 @@ import { createDebug, memoize, tinyassert } from "@hiogawa/utils";
 import { createBrowserHistory } from "@tanstack/history";
 import React from "react";
 import reactDomClient from "react-dom/client";
-import {
-  LayoutRoot,
-  LayoutStateContext,
-  ServerActionRedirectHandler,
-} from "../features/router/client";
+import { LayoutRoot, LayoutStateContext } from "../features/router/client";
 import {
   type ServerRouterData,
   createLayoutContentRequest,
@@ -168,7 +164,6 @@ export async function start() {
       <RootErrorBoundary>
         <LayoutHandler>
           <LayoutRoot />
-          <ServerActionRedirectHandler />
         </LayoutHandler>
       </RootErrorBoundary>
     </RouterContext.Provider>

--- a/packages/react-server/src/entry/react-server.tsx
+++ b/packages/react-server/src/entry/react-server.tsx
@@ -55,29 +55,29 @@ export const handler: ReactServerHandler = async (ctx) => {
     const { result } = await actionHandler(ctx);
     actionResult = result;
     // TODO: can go through normal layout stream generation instead of returning early
-    if (result.error) {
-      const errorCtx = result.error;
-      if (rscOnly) {
-        // returns empty layout to keep current layout and
-        // let browser initiate client-side navigation for redirection error
-        const data: ServerRouterData = {
-          action: { error: errorCtx },
-          layout: {},
-        };
-        const stream = reactServerDomServer.renderToReadableStream(data, {});
-        return new Response(stream, {
-          headers: {
-            ...errorCtx.headers,
-            "content-type": "text/x-component; charset=utf-8",
-          },
-        });
-      }
-      // TODO: general action error handling?
-      return new Response(null, {
-        status: errorCtx.status,
-        headers: errorCtx.headers,
-      });
-    }
+    // if (result.error) {
+    //   const errorCtx = result.error;
+    //   if (rscOnly) {
+    //     // returns empty layout to keep current layout and
+    //     // let browser initiate client-side navigation for redirection error
+    //     const data: ServerRouterData = {
+    //       action: { error: errorCtx },
+    //       layout: {},
+    //     };
+    //     const stream = reactServerDomServer.renderToReadableStream(data, {});
+    //     return new Response(stream, {
+    //       headers: {
+    //         ...errorCtx.headers,
+    //         "content-type": "text/x-component; charset=utf-8",
+    //       },
+    //     });
+    //   }
+    //   // TODO: general action error handling?
+    //   return new Response(null, {
+    //     status: errorCtx.status,
+    //     headers: errorCtx.headers,
+    //   });
+    // }
   }
 
   const request = rscOnly?.request ?? ctx.request;

--- a/packages/react-server/src/entry/react-server.tsx
+++ b/packages/react-server/src/entry/react-server.tsx
@@ -7,6 +7,7 @@ import {
 import type { RenderToReadableStreamOptions } from "react-dom/server";
 import reactServerDomServer from "react-server-dom-webpack/server.edge";
 import {
+  type ActionResult,
   type LayoutRequest,
   type ServerRouterData,
   createLayoutContentRequest,
@@ -18,7 +19,6 @@ import { createBundlerConfig } from "../features/use-client/react-server";
 import {
   DEFAULT_ERROR_CONTEXT,
   ReactServerDigestError,
-  type ReactServerErrorContext,
   createError,
   getErrorContext,
 } from "../lib/error";
@@ -171,13 +171,6 @@ function createRouter() {
 // server action
 //
 
-// TODO(refactor): discrimate union, move to features
-export type ActionResult = {
-  id?: string;
-  error?: ReactServerErrorContext;
-  data?: unknown;
-};
-
 async function actionHandler({ request }: { request: Request }) {
   const formData = await request.formData();
   if (0) {
@@ -201,7 +194,6 @@ async function actionHandler({ request }: { request: Request }) {
   const responseHeaders = new Headers();
   actionContextMap.set(formData, { request, responseHeaders });
 
-  // TODO: action return value?
   const result: ActionResult = { id };
   try {
     result.data = await action(formData);

--- a/packages/react-server/src/entry/react-server.tsx
+++ b/packages/react-server/src/entry/react-server.tsx
@@ -95,6 +95,7 @@ export const handler: ReactServerHandler = async (ctx) => {
   if (rscOnly) {
     return new Response(stream, {
       headers: {
+        ...actionResult?.error?.headers,
         "content-type": "text/x-component; charset=utf-8",
       },
     });

--- a/packages/react-server/src/entry/server.tsx
+++ b/packages/react-server/src/entry/server.tsx
@@ -168,6 +168,7 @@ export async function renderHtml(
   return new Response(htmlStream, {
     status,
     headers: {
+      ...result.actionResult?.responseHeaders,
       "content-type": "text/html",
     },
   });

--- a/packages/react-server/src/features/router/client.tsx
+++ b/packages/react-server/src/features/router/client.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { RedirectHandler } from "../../lib/client/error-boundary";
 import { isRedirectError } from "../../lib/error";
 import { __global } from "../../lib/global";
+import { ActionRedirectHandler } from "../server-action/client";
 import { LAYOUT_ROOT_NAME, type ServerRouterData } from "./utils";
 
 type LayoutStateContextType = {
@@ -19,9 +20,15 @@ export function LayoutContent(props: { name: string }) {
 }
 
 export function LayoutRoot() {
-  return <LayoutContent name={LAYOUT_ROOT_NAME} />;
+  return (
+    <>
+      <LayoutContent name={LAYOUT_ROOT_NAME} />
+      <ActionRedirectHandler />
+    </>
+  );
 }
 
+// TODO: remove
 // TODO: handle non redirect action error
 export function ServerActionRedirectHandler() {
   const ctx = React.useContext(LayoutStateContext);

--- a/packages/react-server/src/features/router/client.tsx
+++ b/packages/react-server/src/features/router/client.tsx
@@ -22,6 +22,7 @@ export function LayoutRoot() {
   return <LayoutContent name={LAYOUT_ROOT_NAME} />;
 }
 
+// TODO: handle non redirect action error
 export function ServerActionRedirectHandler() {
   const ctx = React.useContext(LayoutStateContext);
   const data = React.use(ctx.data);

--- a/packages/react-server/src/features/router/utils.tsx
+++ b/packages/react-server/src/features/router/utils.tsx
@@ -9,9 +9,11 @@ export type LayoutRequest = Record<
 >;
 
 export type ServerRouterData = {
-  // TODO: can action return other things too?
+  // TODO: include action stream for SSR (i.e. progressive enhancement)
   action?: {
     error?: ReactServerErrorContext;
+    id?: string;
+    data?: unknown;
   };
   layout: Record<string, React.ReactNode>;
 };

--- a/packages/react-server/src/features/router/utils.tsx
+++ b/packages/react-server/src/features/router/utils.tsx
@@ -9,7 +9,6 @@ export type LayoutRequest = Record<
 >;
 
 export type ServerRouterData = {
-  // TODO: include action stream for SSR (i.e. progressive enhancement)
   action?: ActionResult;
   layout: Record<string, React.ReactNode>;
 };

--- a/packages/react-server/src/features/router/utils.tsx
+++ b/packages/react-server/src/features/router/utils.tsx
@@ -1,4 +1,4 @@
-import type { ActionResult } from "../../entry/react-server";
+import type { ReactServerErrorContext } from "../../server";
 
 export type LayoutRequest = Record<
   string,
@@ -7,6 +7,13 @@ export type LayoutRequest = Record<
     name: string;
   }
 >;
+
+// TODO: discriminated union
+export type ActionResult = {
+  id?: string;
+  error?: ReactServerErrorContext;
+  data?: unknown;
+};
 
 export type ServerRouterData = {
   action?: ActionResult;

--- a/packages/react-server/src/features/router/utils.tsx
+++ b/packages/react-server/src/features/router/utils.tsx
@@ -1,4 +1,4 @@
-import type { ReactServerErrorContext } from "../../lib/error";
+import type { ActionResult } from "../../entry/react-server";
 
 export type LayoutRequest = Record<
   string,
@@ -10,11 +10,7 @@ export type LayoutRequest = Record<
 
 export type ServerRouterData = {
   // TODO: include action stream for SSR (i.e. progressive enhancement)
-  action?: {
-    error?: ReactServerErrorContext;
-    id?: string;
-    data?: unknown;
-  };
+  action?: ActionResult;
   layout: Record<string, React.ReactNode>;
 };
 

--- a/packages/react-server/src/features/router/utils.tsx
+++ b/packages/react-server/src/features/router/utils.tsx
@@ -13,6 +13,7 @@ export type ActionResult = {
   id?: string;
   error?: ReactServerErrorContext;
   data?: unknown;
+  responseHeaders?: Record<string, string>;
 };
 
 export type ServerRouterData = {

--- a/packages/react-server/src/features/server-action/client.tsx
+++ b/packages/react-server/src/features/server-action/client.tsx
@@ -1,4 +1,7 @@
+import { tinyassert } from "@hiogawa/utils";
+import React from "react";
 import { __global } from "../../lib/global";
+import { LayoutStateContext } from "../router/client";
 import { injectActionId } from "./utils";
 
 // https://github.com/facebook/react/blob/89021fb4ec9aa82194b0788566e736a4cedfc0e4/packages/react-server-dom-webpack/src/ReactFlightWebpackReferences.js#L87
@@ -38,4 +41,19 @@ export function createServerReference(id: string): React.FC {
       },
     },
   ) as any;
+}
+
+export function useActionData<T extends (...args: any[]) => any>(
+  action: T,
+): Awaited<ReturnType<T>> | undefined {
+  const actionId = (action as any).$$id;
+  tinyassert(actionId);
+  const ctx = React.useContext(LayoutStateContext);
+  const data = React.use(ctx.data);
+  if (data.action) {
+    if (data.action.id === actionId) {
+      return data.action.data as any;
+    }
+  }
+  return;
 }

--- a/packages/react-server/src/features/server-action/client.tsx
+++ b/packages/react-server/src/features/server-action/client.tsx
@@ -1,6 +1,8 @@
 import { tinyassert } from "@hiogawa/utils";
 import React from "react";
+import { RedirectBoundary } from "../../client-internal";
 import { __global } from "../../lib/global";
+import { createError } from "../../server";
 import { LayoutStateContext } from "../router/client";
 import { injectActionId } from "./utils";
 
@@ -56,4 +58,22 @@ export function useActionData<T extends (...args: any[]) => any>(
     }
   }
   return;
+}
+
+export function ActionRedirectHandler() {
+  return (
+    <RedirectBoundary>
+      <ThrowActionError />
+    </RedirectBoundary>
+  );
+}
+
+// TODO: how to trigger nearest error page on action error?
+function ThrowActionError() {
+  const ctx = React.useContext(LayoutStateContext);
+  const data = React.use(ctx.data);
+  if (data.action?.error) {
+    throw createError(data.action?.error);
+  }
+  return null;
 }

--- a/packages/react-server/src/features/server-action/react-server.tsx
+++ b/packages/react-server/src/features/server-action/react-server.tsx
@@ -26,7 +26,7 @@ export const actionContextMap = new WeakMap<FormData, ActionContext>();
 
 export interface ActionContext {
   request: Request;
-  responseHeaders: Headers;
+  responseHeaders: Record<string, string>; // TODO: Headers?
 }
 
 export function getActionContext(formData: FormData) {

--- a/packages/react-server/src/lib/error.tsx
+++ b/packages/react-server/src/lib/error.tsx
@@ -28,10 +28,6 @@ export function redirect(
   });
 }
 
-export function setActionResult(): never {
-  throw createError({ status: 200 });
-}
-
 export function isRedirectError(ctx: ReactServerErrorContext) {
   const location = ctx.headers?.["location"];
   if (300 <= ctx.status && ctx.status <= 399 && typeof location === "string") {

--- a/packages/react-server/src/lib/error.tsx
+++ b/packages/react-server/src/lib/error.tsx
@@ -28,6 +28,10 @@ export function redirect(
   });
 }
 
+export function setActionResult(): never {
+  throw createError({ status: 200 });
+}
+
 export function isRedirectError(ctx: ReactServerErrorContext) {
   const location = ctx.headers?.["location"];
   if (300 <= ctx.status && ctx.status <= 399 && typeof location === "string") {


### PR DESCRIPTION
Probably I should start to look into official `useFormState/useActionState`, or can we get away with custom formData and server reference management?

<details><summary>Demo</summary>

![image](https://github.com/hi-ogawa/vite-plugins/assets/4232207/fc5e0941-9fb9-491c-84b9-d0eb4498d391)

![image](https://github.com/hi-ogawa/vite-plugins/assets/4232207/2f01f5f9-509d-47d1-b910-f3c3232da279)

![image](https://github.com/hi-ogawa/vite-plugins/assets/4232207/6d8570f8-71ec-460b-9fc2-13f5e81fc6f1)

</details>

## todo

- [x] browser state only first
  - return action data in rsc stream and provide as react context
- [x] ssr and progressive enhancement
  - ~probably can do similar to remix, handoff action data from server to client~
- [ ] action response header mutation with action data
- [x] test
- [x] refactor
  - uniform action stream handling for error case
- [ ] trigger current error page on action error? (later)
