### PR TITLE
fix(react-server): fix html content-type

### DIFF
--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/react-server",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/packages/react-server/src/entry/server.tsx
+++ b/packages/react-server/src/entry/server.tsx
@@ -168,7 +168,7 @@ export async function renderHtml(
   return new Response(htmlStream, {
     status,
     headers: {
-      "content-type": "text/html, charset=utf-8",
+      "content-type": "text/html",
     },
   });
 }


### PR DESCRIPTION
I just realized something is wrong on stackblitz and maybe I made a typo `","` instead of `";"`.

<details><summary>before</summary>

![image](https://github.com/hi-ogawa/vite-plugins/assets/4232207/8f6f1e74-c3b2-4a55-a7e5-a5f98f49709f)

</details>

---

Thank god, now it's back...

https://stackblitz.com/edit/github-dwdysf?file=package.json

<details><summary>after</summary>

![image](https://github.com/hi-ogawa/vite-plugins/assets/4232207/ac316974-4b41-4a65-918c-e277b6e7bf58)

</details>
