### PR TITLE
refactor(react-server): use `this: ActionContext`

### DIFF
--- a/packages/react-server/README.md
+++ b/packages/react-server/README.md
@@ -36,10 +36,9 @@ pnpm preview
 
 ## Conventions
 
-- `index.html`
 - `src/entry-client.tsx`
 - `src/entry-react-server.tsx`
-- `src/routes/**/(page|layout).tsx`
+- `src/routes/**/(page|layout|error).tsx`
 - `"use client"`
 - `"use server"`
 

--- a/packages/react-server/examples/basic/src/routes/test/session/_action.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/session/_action.tsx
@@ -1,6 +1,6 @@
 "use server";
 
-import { getActionContext, redirect } from "@hiogawa/react-server/server";
+import { type ActionContext, redirect } from "@hiogawa/react-server/server";
 import { tinyassert } from "@hiogawa/utils";
 import { getSession, setSession } from "./utils";
 
@@ -30,9 +30,11 @@ export function getCounter() {
   return counter;
 }
 
-export async function incrementCounter(formData: FormData) {
-  const ctx = getActionContext(formData);
-  const session = getSession(ctx.request);
+export async function incrementCounter(
+  this: ActionContext,
+  formData: FormData,
+) {
+  const session = getSession(this.request);
   if (!session?.name) {
     throw redirect("/test/session/signin");
   }

--- a/packages/react-server/src/entry/react-server.tsx
+++ b/packages/react-server/src/entry/react-server.tsx
@@ -12,10 +12,7 @@ import {
   type ServerRouterData,
   createLayoutContentRequest,
 } from "../features/router/utils";
-import {
-  type ActionContext,
-  actionContextMap,
-} from "../features/server-action/react-server";
+import { type ActionContext } from "../features/server-action/react-server";
 import { ejectActionId } from "../features/server-action/utils";
 import { unwrapRscRequest } from "../features/server-component/utils";
 import { createBundlerConfig } from "../features/use-client/react-server";
@@ -172,11 +169,9 @@ async function actionHandler({ request }: { request: Request }) {
   }
 
   const context: ActionContext = { request, responseHeaders: {} };
-  actionContextMap.set(formData, context);
-
   const result: ActionResult = { id };
   try {
-    result.data = await action(formData);
+    result.data = await action.apply(context, [formData]);
   } catch (e) {
     result.error = getErrorContext(e) ?? DEFAULT_ERROR_CONTEXT;
   } finally {
@@ -184,7 +179,6 @@ async function actionHandler({ request }: { request: Request }) {
       ...context.responseHeaders,
       ...result.error?.headers,
     };
-    actionContextMap.delete(formData);
   }
   return result;
 }

--- a/packages/react-server/src/features/server-action/react-server.tsx
+++ b/packages/react-server/src/features/server-action/react-server.tsx
@@ -1,5 +1,3 @@
-import { tinyassert } from "@hiogawa/utils";
-
 export function createServerReference(id: string, action: Function): React.FC {
   return Object.defineProperties(action, {
     $$typeof: {
@@ -19,18 +17,8 @@ export function createServerReference(id: string, action: Function): React.FC {
   }) as any;
 }
 
-// Builtin action context system based on FormData identity.
-// Users can easilty setup own AsyncLocalStorage based request context using custom handler,
-// but we don't make it as a builtin feature until async hooks are properly supported on Stackblitz.
-export const actionContextMap = new WeakMap<FormData, ActionContext>();
-
+// action function can access context via (this: ActionContext)
 export interface ActionContext {
   request: Request;
   responseHeaders: Record<string, string>; // TODO: Headers?
-}
-
-export function getActionContext(formData: FormData) {
-  const ctx = actionContextMap.get(formData);
-  tinyassert(ctx);
-  return ctx;
 }

--- a/packages/react-server/src/server.ts
+++ b/packages/react-server/src/server.ts
@@ -4,4 +4,4 @@ export {
   redirect,
   type ReactServerErrorContext,
 } from "./lib/error";
-export { getActionContext } from "./features/server-action/react-server";
+export type { ActionContext } from "./features/server-action/react-server";


### PR DESCRIPTION
Sine we probably don't do the official action `bind`, we could just use `this: ActionContext` for our own thing.