### PR TITLE
feat(react-server): add `ActionContext.revalidate`

### DIFF
--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -664,6 +664,27 @@ async function testActionContext(page: Page) {
   await page.getByText("Hi, anonymous user!").click();
 }
 
+test("action revalidate", async ({ page }) => {
+  checkNoError(page);
+
+  await page.goto("/test/action");
+  await waitForHydration(page);
+
+  const checkClientState = await setupCheckClientState(page);
+
+  if (process.env.E2E_PREVIEW) {
+    await page.getByText("[effect: 1]").click();
+    await page.getByRole("button", { name: "Revalidate!" }).click();
+    await page.getByText("[effect: 2]").click();
+  } else {
+    await page.getByText("[effect: 2]").click();
+    await page.getByRole("button", { name: "Revalidate!" }).click();
+    await page.getByText("[effect: 3]").click();
+  }
+
+  await checkClientState();
+});
+
 test("dynamic routes", async ({ page }) => {
   checkNoError(page);
 

--- a/packages/react-server/examples/basic/src/routes/test/action/_action.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/action/_action.tsx
@@ -1,5 +1,6 @@
 "use server";
 
+import type { ActionContext } from "@hiogawa/react-server/server";
 import { sleep, tinyassert } from "@hiogawa/utils";
 
 let counter = 0;
@@ -34,4 +35,8 @@ export async function actionCheckAnswer(formData: FormData) {
   const answer = Number(formData.get("answer"));
   const message = answer === 2 ? "Correct!" : "Wrong!";
   return { message };
+}
+
+export async function actionTestRevalidate(this: ActionContext) {
+  this.revalidate = true;
 }

--- a/packages/react-server/examples/basic/src/routes/test/action/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/action/page.tsx
@@ -1,4 +1,9 @@
-import { changeCounter, getCounter, getMessages } from "./_action";
+import {
+  actionTestRevalidate,
+  changeCounter,
+  getCounter,
+  getMessages,
+} from "./_action";
 import {
   ActionDataTest,
   Chat,
@@ -17,6 +22,10 @@ export default async function Page() {
       </div>
       <Chat messages={getMessages()} />
       <ActionDataTest />
+      <form action={actionTestRevalidate} className="flex flex-col gap-2">
+        <h4 className="font-bold">Action Revalidate</h4>
+        <button className="antd-btn antd-btn-default w-sm">Revalidate!</button>
+      </form>
       <FormStateTest />
     </div>
   );

--- a/packages/react-server/src/entry/react-server.tsx
+++ b/packages/react-server/src/entry/react-server.tsx
@@ -54,7 +54,10 @@ export const handler: ReactServerHandler = async (ctx) => {
   }
 
   // check stream only request
-  const { request, layoutRequest, isStream } = unwrapStreamRequest(ctx.request);
+  const { request, layoutRequest, isStream } = unwrapStreamRequest(
+    ctx.request,
+    actionResult,
+  );
   const stream = await render({ request, layoutRequest, actionResult });
 
   if (isStream) {

--- a/packages/react-server/src/features/router/utils.tsx
+++ b/packages/react-server/src/features/router/utils.tsx
@@ -1,4 +1,4 @@
-import type { ReactServerErrorContext } from "../../server";
+import type { ActionResult } from "../server-action/react-server";
 
 export type LayoutRequest = Record<
   string,
@@ -8,16 +8,8 @@ export type LayoutRequest = Record<
   }
 >;
 
-// TODO: discriminated union
-export type ActionResult = {
-  id?: string;
-  error?: ReactServerErrorContext;
-  data?: unknown;
-  responseHeaders?: Record<string, string>;
-};
-
 export type ServerRouterData = {
-  action?: ActionResult;
+  action?: Pick<ActionResult, "id" | "error" | "data">;
   layout: Record<string, React.ReactNode>;
 };
 

--- a/packages/react-server/src/features/server-action/react-server.tsx
+++ b/packages/react-server/src/features/server-action/react-server.tsx
@@ -1,3 +1,5 @@
+import type { ReactServerErrorContext } from "../../server";
+
 export function createServerReference(id: string, action: Function): React.FC {
   return Object.defineProperties(action, {
     $$typeof: {
@@ -17,8 +19,18 @@ export function createServerReference(id: string, action: Function): React.FC {
   }) as any;
 }
 
-// action function can access context via (this: ActionContext)
-export interface ActionContext {
-  request: Request;
-  responseHeaders: Record<string, string>; // TODO: Headers?
+// TODO: discriminated union
+export type ActionResult = {
+  id: string;
+  error?: ReactServerErrorContext;
+  data?: unknown;
+  responseHeaders?: Record<string, string>;
+  context: ActionContext;
+};
+
+export class ActionContext {
+  responseHeaders: Record<string, string> = {};
+  revalidate = false;
+
+  constructor(public request: Request) {}
 }

--- a/packages/react-server/src/features/server-component/utils.tsx
+++ b/packages/react-server/src/features/server-component/utils.tsx
@@ -30,7 +30,6 @@ export function unwrapStreamRequest(
   const url = new URL(request.url);
   const rscParam = url.searchParams.get(RSC_PARAM);
   url.searchParams.delete(RSC_PARAM);
-  actionResult?.context.revalidate;
 
   let layoutRequest = createLayoutContentRequest(url.pathname);
   if (rscParam && !actionResult?.context.revalidate) {

--- a/packages/react-server/src/features/server-component/utils.tsx
+++ b/packages/react-server/src/features/server-component/utils.tsx
@@ -3,6 +3,7 @@ import {
   createLayoutContentRequest,
   getNewLayoutContentKeys,
 } from "../router/utils";
+import type { ActionResult } from "../server-action/react-server";
 
 // TODO: use accept header x-component?
 const RSC_PARAM = "__rsc";
@@ -22,13 +23,17 @@ export function wrapStreamRequestUrl(
   return newUrl.toString();
 }
 
-export function unwrapStreamRequest(request: Request) {
+export function unwrapStreamRequest(
+  request: Request,
+  actionResult?: ActionResult,
+) {
   const url = new URL(request.url);
   const rscParam = url.searchParams.get(RSC_PARAM);
   url.searchParams.delete(RSC_PARAM);
+  actionResult?.context.revalidate;
 
   let layoutRequest = createLayoutContentRequest(url.pathname);
-  if (rscParam) {
+  if (rscParam && !actionResult?.context.revalidate) {
     const param = JSON.parse(rscParam);
     if (param.lastPathname && !param.invalidateAll) {
       const newKeys = getNewLayoutContentKeys(param.lastPathname, url.pathname);


### PR DESCRIPTION
For https://github.com/hi-ogawa/react-server-demo-remix-tutorial

## todo

- [x] demo + test
- [ ] api to revalidate on `history.push` (later)