### PR TITLE
fix(react-server): decode dynamic route params

### DIFF
--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -701,7 +701,7 @@ test("revalidate on navigation", async ({ page }) => {
   await checkClientState();
 });
 
-test.only("dynamic routes", async ({ page }) => {
+test("dynamic routes", async ({ page }) => {
   checkNoError(page);
 
   await page.goto("/test/dynamic");

--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -701,7 +701,7 @@ test("revalidate on navigation", async ({ page }) => {
   await checkClientState();
 });
 
-test("dynamic routes", async ({ page }) => {
+test.only("dynamic routes", async ({ page }) => {
   checkNoError(page);
 
   await page.goto("/test/dynamic");
@@ -727,6 +727,14 @@ test("dynamic routes", async ({ page }) => {
   await page.getByText("file: /test/dynamic/[id]/[nested]/page.tsx").click();
   await page.getByText("pathname: /test/dynamic/abc/def").click();
   await page.getByText('params: {"id":"abc","nested":"def"}').click();
+
+  await page.getByRole("link", { name: "/test/dynamic/🎸 + 🎷 = 🎶" }).click();
+  await page.getByText('params: {"id":"🎸 + 🎷 = 🎶"}').click();
+  await page.waitForURL("/test/dynamic/🎸 + 🎷 = 🎶");
+
+  await page.getByRole("link", { name: "/test/dynamic/%F0%9F%8E%B8%" }).click();
+  await page.getByText('params: {"id":"🎸 + 🎷 = 🎶"}').click();
+  await page.waitForURL("/test/dynamic/🎸 + 🎷 = 🎶");
 });
 
 test("full client route", async ({ page }) => {

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/layout.tsx
@@ -11,6 +11,8 @@ export default function Layout(props: LayoutProps) {
           "/test/dynamic",
           "/test/dynamic/static",
           "/test/dynamic/abc",
+          "/test/dynamic/🎸 + 🎷 = 🎶",
+          "/test/dynamic/" + encodeURI("🎸 + 🎷 = 🎶"),
           "/test/dynamic/abc/def",
         ]}
       />

--- a/packages/react-server/src/lib/router.tsx
+++ b/packages/react-server/src/lib/router.tsx
@@ -106,8 +106,7 @@ export async function renderRouteMap(
     if (next?.child) {
       node = next.child;
       if (next.param) {
-        // TODO: probably do this further up? (e.g. normalizePathname?)
-        params = { ...params, [next.param]: decodeURIComponent(key) };
+        params = { ...params, [next.param]: decodeURI(key) };
       }
     } else {
       node = initNode();

--- a/packages/react-server/src/lib/router.tsx
+++ b/packages/react-server/src/lib/router.tsx
@@ -106,7 +106,8 @@ export async function renderRouteMap(
     if (next?.child) {
       node = next.child;
       if (next.param) {
-        params = { ...params, [next.param]: key };
+        // TODO: probably do this further up? (e.g. normalizePathname?)
+        params = { ...params, [next.param]: decodeURIComponent(key) };
       }
     } else {
       node = initNode();


### PR DESCRIPTION
Not sure where decoding should be applied. We should probably check with react router and tanstack.
- https://github.com/remix-run/react-router/pull/9477
- https://github.com/TanStack/router/commit/a2019034813bea2698e89ce4861dce0d5687a176

Looking at tanstack, just running `decodeURI` for `props.params` seems enough, which is also what I did in the demo
- https://github.com/hi-ogawa/react-server-demo-remix-tutorial/blob/5ee83567cb77b667f0417f19e1fde548e82e63b5/src/routes/contacts/%5BcontactId%5D/page.tsx#L7-L8

## todo

- [x] test