### PR TITLE
feat(react-server): log unexpected error

### DIFF
--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -124,18 +124,26 @@ test("error", async ({ page }) => {
   const checkClientState = await setupCheckClientState(page);
 
   await page.getByRole("link", { name: "/test/error" }).click();
-  await page.getByRole("link", { name: "Server 500" }).click();
+  await page.getByRole("link", { name: "/test/error/server?500" }).click();
   await page.getByText('server error: {"status":500}').click();
 
   await page.getByRole("link", { name: "/test/error" }).click();
-  await page.getByRole("link", { name: "Server Custom" }).click();
+  await page.getByRole("link", { name: "/test/error/server?custom" }).click();
   await page
     .getByText('server error: {"status":403,"customMessage":"hello"}')
     .click();
 
   await page.getByRole("link", { name: "/test/error" }).click();
-  await page.getByRole("link", { name: "Browser" }).click();
+  await page.getByRole("link", { name: "/test/error/browser" }).click();
   await page.getByText("server error: (N/A)").click();
+
+  await page.getByRole("link", { name: "/test/error" }).click();
+  await page.getByRole("link", { name: "/test/error/use-client" }).click();
+  await page.getByText('server error: {"status":500}').click();
+
+  await page.getByRole("link", { name: "/test/error" }).click();
+  await page.getByRole("link", { name: "/test/error/use-server" }).click();
+  await page.getByText('server error: {"status":500}').click();
 
   await page.getByRole("link", { name: "/test/other" }).click();
   await page.getByRole("heading", { name: "Other Page" }).click();

--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -115,7 +115,7 @@ test("Link modifier", async ({ page, context }) => {
 });
 
 test("error", async ({ page }) => {
-  const res = await page.goto("/test/not-found");
+  const res = await page.goto("/test/error-not-found");
   expect(res?.status()).toBe(404);
 
   await waitForHydration(page);

--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -137,13 +137,16 @@ test("error", async ({ page }) => {
   await page.getByRole("link", { name: "/test/error/browser" }).click();
   await page.getByText("server error: (N/A)").click();
 
-  await page.getByRole("link", { name: "/test/error" }).click();
-  await page.getByRole("link", { name: "/test/error/use-client" }).click();
-  await page.getByText('server error: {"status":500}').click();
+  // wrong usage errors would brew away the whole app on build?
+  if (!process.env.E2E_PREVIEW) {
+    await page.getByRole("link", { name: "/test/error" }).click();
+    await page.getByRole("link", { name: "/test/error/use-client" }).click();
+    await page.getByText('server error: {"status":500}').click();
 
-  await page.getByRole("link", { name: "/test/error" }).click();
-  await page.getByRole("link", { name: "/test/error/use-server" }).click();
-  await page.getByText('server error: {"status":500}').click();
+    await page.getByRole("link", { name: "/test/error" }).click();
+    await page.getByRole("link", { name: "/test/error/use-server" }).click();
+    await page.getByText('server error: {"status":500}').click();
+  }
 
   await page.getByRole("link", { name: "/test/other" }).click();
   await page.getByRole("heading", { name: "Other Page" }).click();

--- a/packages/react-server/examples/basic/src/routes/test/error/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/error/layout.tsx
@@ -8,6 +8,7 @@ export default function Layout(props: LayoutProps) {
       <NavMenu
         className="flex flex-col items-start gap-1"
         links={[
+          "/test/error/not-found",
           "/test/error/server?500",
           "/test/error/server?custom",
           "/test/error/browser",

--- a/packages/react-server/examples/basic/src/routes/test/error/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/error/layout.tsx
@@ -1,0 +1,21 @@
+import type { LayoutProps } from "@hiogawa/react-server/server";
+import { NavMenu } from "../../../components/nav-menu";
+
+export default function Layout(props: LayoutProps) {
+  return (
+    <div className="flex flex-col gap-2 p-2">
+      <h4 className="font-bold">Error Test</h4>
+      <NavMenu
+        className="flex flex-col items-start gap-1"
+        links={[
+          "/test/error/server?500",
+          "/test/error/server?custom",
+          "/test/error/browser",
+          "/test/error/use-client",
+          "/test/error/use-server",
+        ]}
+      />
+      <div>{props.children}</div>
+    </div>
+  );
+}

--- a/packages/react-server/examples/basic/src/routes/test/error/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/error/page.tsx
@@ -1,26 +1,3 @@
-import { Link } from "@hiogawa/react-server/client";
-
 export default async function Page() {
-  return (
-    <div className="flex gap-2 p-2">
-      <Link
-        className="antd-btn antd-btn-default px-2"
-        href="/test/error/server?500"
-      >
-        Server 500
-      </Link>
-      <Link
-        className="antd-btn antd-btn-default px-2"
-        href="/test/error/server?custom"
-      >
-        Server Custom
-      </Link>
-      <Link
-        className="antd-btn antd-btn-default px-2"
-        href="/test/error/browser"
-      >
-        Browser
-      </Link>
-    </div>
-  );
+  return null;
 }

--- a/packages/react-server/examples/basic/src/routes/test/error/use-client/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/error/use-client/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <button onClick={() => {}}>Boom!</button>;
+}

--- a/packages/react-server/examples/basic/src/routes/test/error/use-server/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/error/use-server/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <form action={() => {}}>Boom!</form>;
+}

--- a/packages/react-server/examples/basic/src/routes/test/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/layout.tsx
@@ -17,7 +17,6 @@ export default async function Layout(props: LayoutProps) {
           "/test/head",
           "/test/css",
           "/test/error",
-          "/test/not-found",
           "/test/transition",
           "/test/redirect",
           "/test/session",

--- a/packages/react-server/src/entry/react-server.tsx
+++ b/packages/react-server/src/entry/react-server.tsx
@@ -113,6 +113,9 @@ const reactServerOnError: RenderToReadableStreamOptions["onError"] = (
     error,
     errorInfo,
   });
+  if (!(error instanceof ReactServerDigestError)) {
+    console.error("[react-server:renderToReadableStream]", error);
+  }
   const serverError =
     error instanceof ReactServerDigestError
       ? error

--- a/packages/react-server/src/entry/server.tsx
+++ b/packages/react-server/src/entry/server.tsx
@@ -129,8 +129,10 @@ export async function renderHtml(
         ? []
         : assets.bootstrapModules,
       onError(error, errorInfo) {
-        // TODO: should handle SSR error which is not RSC error?
         debug("renderToReadableStream", { error, errorInfo });
+        if (!getErrorContext(error)) {
+          console.error("[react-dom:renderToReadableStream]", error);
+        }
       },
     });
   } catch (e) {


### PR DESCRIPTION
- follow up to https://github.com/hi-ogawa/react-server-demo-remix-tutorial/pull/1

Currently some common react server usage error (such as forgetting "use client", "use server", server/client props serialization) is hard to notice.
For now, having just `console.error` for unexpected errors should help DX.

## todo

- [ ] dev only? env flag to turn off? customizable logger?
- [ ] better format?
- [ ] rely on client side error?
  - https://github.com/hi-ogawa/vite-plugins/pull/272
  - or this should be enogh? https://github.com/hi-ogawa/vite-plugins/pull/274
- [x] test