### PR TITLE
feat(react-server): trigger error overlay on server error

### DIFF
--- a/packages/react-server/src/entry/react-server.tsx
+++ b/packages/react-server/src/entry/react-server.tsx
@@ -115,6 +115,15 @@ const reactServerOnError: RenderToReadableStreamOptions["onError"] = (
   });
   if (!(error instanceof ReactServerDigestError)) {
     console.error("[react-server:renderToReadableStream]", error);
+    if (import.meta.env.DEV && error instanceof Error) {
+      __global.dev.server.hot.send({
+        type: "error",
+        err: {
+          message: error.message,
+          stack: error.stack ?? "",
+        },
+      });
+    }
   }
   const serverError =
     error instanceof ReactServerDigestError

--- a/packages/react-server/src/entry/server.tsx
+++ b/packages/react-server/src/entry/server.tsx
@@ -132,6 +132,15 @@ export async function renderHtml(
         debug("renderToReadableStream", { error, errorInfo });
         if (!getErrorContext(error)) {
           console.error("[react-dom:renderToReadableStream]", error);
+          if (import.meta.env.DEV && error instanceof Error) {
+            __global.dev.server.hot.send({
+              type: "error",
+              err: {
+                message: error.message,
+                stack: error.stack ?? "",
+              },
+            });
+          }
         }
       },
     });


### PR DESCRIPTION
Having an overlay for unexpected errors would be nice, but probably it breaks CI. So, let's hold this off for a moment.

Also, obviously this `hot.send` is too early on ssr since client isn't even rendered yet. So, we maybe still better to use a general solution like https://github.com/hi-ogawa/vite-plugins/pull/272 since react server error would be replayed on client anyways.

<details><summary>Screenshot</summary>

![image](https://github.com/hi-ogawa/vite-plugins/assets/4232207/2a945cf4-227a-4e0a-bbb1-2b258e04ca43)

</details>