### PR TITLE
fix(react-server): preload root js assets

### DIFF
--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -2,7 +2,7 @@ import nodeCrypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { createDebug, memoize, tinyassert } from "@hiogawa/utils";
+import { createDebug, memoize, tinyassert, typedBoolean } from "@hiogawa/utils";
 import type { Program } from "estree";
 import fg from "fast-glob";
 import MagicString from "magic-string";
@@ -367,9 +367,15 @@ export function vitePluginReactServer(options?: {
         );
         const entry = manifest[ENTRY_CLIENT_WRAPPER];
         tinyassert(entry);
-        const head = (entry.css ?? [])
-          .map((url) => `<link rel="stylesheet" href="/${url}" />`)
-          .join("");
+        const css = entry.css ?? [];
+        const js =
+          entry.dynamicImports
+            ?.map((k) => manifest[k]?.file)
+            .filter(typedBoolean) ?? [];
+        const head = [
+          ...css.map((href) => `<link rel="stylesheet" href="/${href}" />`),
+          ...js.map((href) => `<link rel="modulepreload" href="/${href}" />`),
+        ].join("\n");
         const result: SsrAssetsType = {
           bootstrapModules: [`/${entry.file}`],
           head,
@@ -393,9 +399,11 @@ export function vitePluginReactServer(options?: {
       }
       // build
       if (manager.buildType === "client") {
+        // import "client-internal" for preload
         return /* js */ `
           import "virtual:react-server-css.js";
-          import "${ENTRY_CLIENT}"
+          import("@hiogawa/react-server/client-internal");
+          import "${ENTRY_CLIENT}";
         `;
       }
       tinyassert(false);
@@ -561,8 +569,8 @@ function vitePluginServerUseClient({
      *   "some-file1": () => import("some-file1"),
      * }
      */
-    writeBundle: {
-      async handler(options, _bundle) {
+    closeBundle: {
+      async handler() {
         let result = `export default {\n`;
         for (let id of manager.rscUseClientIds) {
           // virtual module needs to be mapped back to the original form
@@ -573,11 +581,7 @@ function vitePluginServerUseClient({
           result += `"${id}": () => import("${to}"),\n`;
         }
         result += "};\n";
-        tinyassert(options.dir);
-        await fs.promises.writeFile(
-          path.join(options.dir, "client-references.js"),
-          result,
-        );
+        await fs.promises.writeFile("dist/rsc/client-references.js", result);
       },
     },
   };

--- a/packages/react-server/tsup.config.ts
+++ b/packages/react-server/tsup.config.ts
@@ -15,12 +15,6 @@ export default defineConfig([
     ],
     format: ["esm"],
     dts: !process.env["NO_DTS"],
-    external: [
-      /^virtual:/,
-      /^@hiogawa\/react-server\//,
-      // TODO: virtual module?
-      "/dist/rsc/client-references.js",
-      "/dist/rsc/index.js",
-    ],
+    external: [/^virtual:/, /^@hiogawa\/react-server\//, /^\/dist\//],
   },
 ]);


### PR DESCRIPTION
I'm still hesitant to land a large PR
- https://github.com/hi-ogawa/vite-plugins/pull/257

but, for starter, just preloading these two should be simple enough:
- `@hiogawa/react-server/client-internal`
- `/dist/rsc/client-references.js`