### PR TITLE
feat(react-server): dynamic import glob routes

### DIFF
--- a/packages/react-server/src/entry/react-server.tsx
+++ b/packages/react-server/src/entry/react-server.tsx
@@ -163,9 +163,6 @@ function createRouter() {
   // for now hard code /src/routes as convention
   const glob = import.meta.glob(
     "/src/routes/**/(page|layout|error).(js|jsx|ts|tsx)",
-    {
-      eager: true,
-    },
   );
   const tree = generateRouteModuleTree(
     objectMapKeys(glob, (_v, k) => k.slice("/src/routes".length)),

--- a/packages/react-server/src/entry/server.tsx
+++ b/packages/react-server/src/entry/server.tsx
@@ -3,6 +3,7 @@ import { createMemoryHistory } from "@tanstack/history";
 import ReactDOMServer from "react-dom/server.edge";
 import type { ModuleNode, ViteDevServer } from "vite";
 import type { SsrAssetsType } from "../features/assets/plugin";
+import { DEV_SSR_CSS, SERVER_CSS_PROXY } from "../features/assets/shared";
 import {
   LayoutRoot,
   LayoutStateContext,
@@ -135,8 +136,8 @@ export async function renderHtml(
 
   if (import.meta.env.DEV) {
     // ensure latest css
-    invalidateModule($__global.dev.server, "\0virtual:react-server-css.js");
-    invalidateModule($__global.dev.server, "\0virtual:dev-ssr-css.css?direct");
+    invalidateModule($__global.dev.server, `\0${SERVER_CSS_PROXY}`);
+    invalidateModule($__global.dev.server, `\0${DEV_SSR_CSS}?direct`);
   }
   const assets: SsrAssetsType = (await import("virtual:ssr-assets" as string))
     .default;

--- a/packages/react-server/src/features/assets/plugin.ts
+++ b/packages/react-server/src/features/assets/plugin.ts
@@ -11,13 +11,12 @@ import {
   createVirtualPlugin,
 } from "../../plugin/utils";
 import { collectStyle, collectStyleUrls } from "./css";
+import { DEV_SSR_CSS, SERVER_CSS_PROXY } from "./shared";
 
 export interface SsrAssetsType {
   bootstrapModules: string[];
   head: string;
 }
-
-export const SERVER_CSS_PROXY = "virtual:server-css-proxy.js";
 
 export function vitePluginServerAssets({
   manager,
@@ -41,7 +40,7 @@ export function vitePluginServerAssets({
           <link
             data-ssr-dev-css
             rel="stylesheet"
-            href="/@id/__x00__virtual:dev-ssr-css.css?direct"
+            href="/@id/__x00__${DEV_SSR_CSS}?direct"
           />
           <script type="module">
             import { createHotContext } from "/@vite/client";
@@ -90,7 +89,7 @@ export function vitePluginServerAssets({
       tinyassert(false);
     }),
 
-    createVirtualPlugin("dev-ssr-css.css", async () => {
+    createVirtualPlugin(DEV_SSR_CSS.split(":")[1]!, async () => {
       tinyassert(!manager.buildType);
       const styles = await Promise.all([
         `/******* react-server ********/`,
@@ -105,7 +104,7 @@ export function vitePluginServerAssets({
       return styles.join("\n\n");
     }),
 
-    createVirtualPlugin(SERVER_CSS_PROXY.slice("virtual:".length), async () => {
+    createVirtualPlugin(SERVER_CSS_PROXY.split(":")[1]!, async () => {
       // virtual module to proxy css imports from react server to client
       // TODO: invalidate + full reload when add/remove css file?
       if (!manager.buildType) {

--- a/packages/react-server/src/features/assets/shared.ts
+++ b/packages/react-server/src/features/assets/shared.ts
@@ -1,0 +1,2 @@
+export const SERVER_CSS_PROXY = "virtual:server-css-proxy.js";
+export const DEV_SSR_CSS = "virtual:dev-ssr-css.css";

--- a/packages/react-server/src/features/router/__snapshots__/server.test.tsx.snap
+++ b/packages/react-server/src/features/router/__snapshots__/server.test.tsx.snap
@@ -76,7 +76,30 @@ exports[`generateRouteModuleTree > basic 2`] = `
     </React.Fragment>,
   },
   "pages": {
-    "/x": Promise {},
+    "/x": </X/PAGE.TSX
+      params={{}}
+      request={
+        {
+          "headers": {},
+          "url": "https://test.local/x",
+        }
+      }
+      url={
+        {
+          "hash": "",
+          "host": "test.local",
+          "hostname": "test.local",
+          "href": "https://test.local/x",
+          "origin": "https://test.local",
+          "password": "",
+          "pathname": "/x",
+          "port": "",
+          "protocol": "https:",
+          "search": "",
+          "username": "",
+        }
+      }
+    />,
   },
 }
 `;
@@ -158,7 +181,30 @@ exports[`generateRouteModuleTree > basic 3`] = `
     <//X/Y/LAYOUT.TSX>,
   },
   "pages": {
-    "/x/y": Promise {},
+    "/x/y": </X/Y/PAGE.TSX
+      params={{}}
+      request={
+        {
+          "headers": {},
+          "url": "https://test.local/x/y",
+        }
+      }
+      url={
+        {
+          "hash": "",
+          "host": "test.local",
+          "hostname": "test.local",
+          "href": "https://test.local/x/y",
+          "origin": "https://test.local",
+          "password": "",
+          "pathname": "/x/y",
+          "port": "",
+          "protocol": "https:",
+          "search": "",
+          "username": "",
+        }
+      }
+    />,
   },
 }
 `;
@@ -206,7 +252,30 @@ exports[`generateRouteModuleTree > basic 4`] = `
     </React.Fragment>,
   },
   "pages": {
-    "/z": Promise {},
+    "/z": <ThrowNotFound
+      params={{}}
+      request={
+        {
+          "headers": {},
+          "url": "https://test.local/z",
+        }
+      }
+      url={
+        {
+          "hash": "",
+          "host": "test.local",
+          "hostname": "test.local",
+          "href": "https://test.local/z",
+          "origin": "https://test.local",
+          "password": "",
+          "pathname": "/z",
+          "port": "",
+          "protocol": "https:",
+          "search": "",
+          "username": "",
+        }
+      }
+    />,
   },
 }
 `;

--- a/packages/react-server/src/features/router/__snapshots__/server.test.tsx.snap
+++ b/packages/react-server/src/features/router/__snapshots__/server.test.tsx.snap
@@ -9,32 +9,20 @@ exports[`generateRouteModuleTree > basic 1`] = `
           "children": {
             "y": {
               "value": {
-                "layout": {
-                  "default": "/X/Y/LAYOUT.TSX",
-                },
-                "page": {
-                  "default": "/X/Y/PAGE.TSX",
-                },
+                "layout": [Function],
+                "page": [Function],
               },
             },
           },
           "value": {
-            "error": {
-              "default": "/X/ERROR.TSX",
-            },
-            "page": {
-              "default": "/X/PAGE.TSX",
-            },
+            "error": [Function],
+            "page": [Function],
           },
         },
       },
       "value": {
-        "layout": {
-          "default": "/LAYOUT.TSX",
-        },
-        "page": {
-          "default": "/PAGE.TSX",
-        },
+        "layout": [Function],
+        "page": [Function],
       },
     },
   },
@@ -88,30 +76,7 @@ exports[`generateRouteModuleTree > basic 2`] = `
     </React.Fragment>,
   },
   "pages": {
-    "/x": </X/PAGE.TSX
-      params={{}}
-      request={
-        {
-          "headers": {},
-          "url": "https://test.local/x",
-        }
-      }
-      url={
-        {
-          "hash": "",
-          "host": "test.local",
-          "hostname": "test.local",
-          "href": "https://test.local/x",
-          "origin": "https://test.local",
-          "password": "",
-          "pathname": "/x",
-          "port": "",
-          "protocol": "https:",
-          "search": "",
-          "username": "",
-        }
-      }
-    />,
+    "/x": Promise {},
   },
 }
 `;
@@ -193,30 +158,7 @@ exports[`generateRouteModuleTree > basic 3`] = `
     <//X/Y/LAYOUT.TSX>,
   },
   "pages": {
-    "/x/y": </X/Y/PAGE.TSX
-      params={{}}
-      request={
-        {
-          "headers": {},
-          "url": "https://test.local/x/y",
-        }
-      }
-      url={
-        {
-          "hash": "",
-          "host": "test.local",
-          "hostname": "test.local",
-          "href": "https://test.local/x/y",
-          "origin": "https://test.local",
-          "password": "",
-          "pathname": "/x/y",
-          "port": "",
-          "protocol": "https:",
-          "search": "",
-          "username": "",
-        }
-      }
-    />,
+    "/x/y": Promise {},
   },
 }
 `;
@@ -264,30 +206,7 @@ exports[`generateRouteModuleTree > basic 4`] = `
     </React.Fragment>,
   },
   "pages": {
-    "/z": <ThrowNotFound
-      params={{}}
-      request={
-        {
-          "headers": {},
-          "url": "https://test.local/z",
-        }
-      }
-      url={
-        {
-          "hash": "",
-          "host": "test.local",
-          "hostname": "test.local",
-          "href": "https://test.local/z",
-          "origin": "https://test.local",
-          "password": "",
-          "pathname": "/z",
-          "port": "",
-          "protocol": "https:",
-          "search": "",
-          "username": "",
-        }
-      }
-    />,
+    "/z": Promise {},
   },
 }
 `;

--- a/packages/react-server/src/features/router/server.test.tsx
+++ b/packages/react-server/src/features/router/server.test.tsx
@@ -12,7 +12,7 @@ describe(generateRouteModuleTree, () => {
       "/x/y/page.tsx",
     ];
     const input = Object.fromEntries(
-      files.map((k) => [k, { default: k.toUpperCase() }]),
+      files.map((k) => [k, async () => ({ default: k.toUpperCase() })]),
     );
     const tree = generateRouteModuleTree(input);
     expect(tree).toMatchSnapshot();

--- a/packages/react-server/src/features/router/server.tsx
+++ b/packages/react-server/src/features/router/server.tsx
@@ -81,7 +81,7 @@ export async function renderRouteMap(
     if (m.type === "layout") {
       layouts[m.prefix] = await renderLayout(m.node, props, m.prefix);
     } else if (m.type === "page") {
-      pages[m.prefix] = renderPage(m.node, props);
+      pages[m.prefix] = await renderPage(m.node, props);
     } else {
       m.type satisfies never;
     }

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -12,10 +12,8 @@ import {
   createServer,
 } from "vite";
 import { CSS_LANGS_RE } from "../features/assets/css";
-import {
-  SERVER_CSS_PROXY,
-  vitePluginServerAssets,
-} from "../features/assets/plugin";
+import { vitePluginServerAssets } from "../features/assets/plugin";
+import { SERVER_CSS_PROXY } from "../features/assets/shared";
 import { prerenderPlugin } from "../features/prerender/plugin";
 import type { RouteManifest } from "../features/router/manifest";
 import {


### PR DESCRIPTION
Cherry picked from
- https://github.com/hi-ogawa/vite-plugins/pull/257/

---

This will probably make server css crawling to miss on first render, but that's probably not a huge deal. If needed, it should be possible to cover them by more eagerly evaluating module and that's a trade off.

https://github.com/hi-ogawa/vite-plugins/blob/0e7b718406375fb1ae81531de02a207a5c0e72c4/packages/react-server/src/plugin/css.ts#L39-L40

EDIT: hmm, maybe not. It doesn't look good. For example, navigating from `/test` to `/test/css` misses css import and it requires a reload to get styles.

---

TODO
- [x] see if it helps cold start (probably not when everything is bundled on edge)
  - doesn't seem so