### PR TITLE
test(react-server): further more hmr tests

### DIFF
--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -250,6 +250,15 @@ test("rsc + client + rsc hmr @dev", async ({ page }) => {
   );
   await page.getByText("Server (EDIT 2) Time").click();
   await page.getByText("Count: 0").click();
+
+  // edit client again should work
+  await page.getByRole("button", { name: "+" }).click();
+  await page.getByText("Count: 1").click();
+  await editFile("./src/components/counter.tsx", (s) =>
+    s.replace("test-hmr-edit-div", "test-hmr-edit-edit-div"),
+  );
+  await page.getByText("test-hmr-edit-edit-div").click();
+  await page.getByText("Count: 1").click();
 });
 
 test("module invalidation @dev", async ({ page }) => {


### PR DESCRIPTION
- follow up to https://github.com/hi-ogawa/vite-plugins/pull/265
- related https://github.com/hi-ogawa/vite-environment-examples/pull/16

I thought this last step was broken, but it's actually fine, so probably the DX wouldn't be that bad after all.

The reason why https://github.com/hi-ogawa/vite-environment-examples/pull/16 is failing is simply because of rsc reload and client reload is happening at the same time.