### PR TITLE
refactor(react-server): use official `registerClientReference`

### DIFF
--- a/packages/react-server/src/features/use-client/react-server.tsx
+++ b/packages/react-server/src/features/use-client/react-server.tsx
@@ -10,7 +10,9 @@ import type { BundlerConfig, ImportManifestEntry } from "../../lib/types";
 // name: Counter
 
 export function registerClientReference(id: string, name: string) {
-  // reuse everything but $$async: true for simplicity
+  // reuse everything but { $$async: true }.
+  // `$$async` is not strictly necessary if we use `__webpack_chunk_load__` trick
+  // but for now, we go with async `__webpack_require__` for simplicity.
   const reference = reactServerDomWebpack.registerClientReference({}, id, name);
   return Object.defineProperties(
     {},

--- a/packages/react-server/src/lib/types-env.d.ts
+++ b/packages/react-server/src/lib/types-env.d.ts
@@ -13,6 +13,18 @@ declare module "react-server-dom-webpack/server.edge" {
     },
   ): ReadableStream<Uint8Array>;
 
+  export function registerClientReference<T>(
+    ref: T,
+    id: string,
+    name: string,
+  ): T;
+
+  export function registerServerReference<T>(
+    ref: T,
+    id: string,
+    name: string,
+  ): T;
+
   export function decodeReply(body: string | FormData): Promise<unknown>;
 }
 

--- a/packages/react-server/src/server-internal.ts
+++ b/packages/react-server/src/server-internal.ts
@@ -1,2 +1,2 @@
-export { createClientReference } from "./features/use-client/react-server";
+export { registerClientReference } from "./features/use-client/react-server";
 export { createServerReference } from "./features/server-action/react-server";


### PR DESCRIPTION
- cf. https://github.com/hi-ogawa/vite-environment-examples/pull/17

Let's test it here too since obviously we have more coverage here.