### PR TITLE
test(react-server): test hydration mismatch error

### DIFF
--- a/packages/react-server/examples/basic/src/routes/test/error/hydration/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/error/hydration/page.tsx
@@ -1,0 +1,5 @@
+"use client";
+
+export default function Page() {
+  return <div>{import.meta.env.SSR ? "server" : "client"}</div>
+}

--- a/packages/react-server/examples/basic/src/routes/test/error/hydration/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/error/hydration/page.tsx
@@ -1,5 +1,5 @@
 "use client";
 
 export default function Page() {
-  return <div>{import.meta.env.SSR ? "server" : "client"}</div>
+  return <div>{import.meta.env.SSR ? "server" : "client"}</div>;
 }

--- a/packages/react-server/examples/basic/src/routes/test/error/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/error/layout.tsx
@@ -14,6 +14,7 @@ export default function Layout(props: LayoutProps) {
           "/test/error/browser",
           "/test/error/use-client",
           "/test/error/use-server",
+          "/test/error/hydration",
         ]}
       />
       <div>{props.children}</div>


### PR DESCRIPTION
Though client component ssr/csr mismatch is really unlikely in react server framework, I wanted to test this feature out:
- https://github.com/facebook/react/pull/28512

<details><summary>Show screenshots</summary>

### before 

![image](https://github.com/hi-ogawa/vite-plugins/assets/4232207/8f430bc8-ffc8-4eca-a6a2-1d81f3b4957d)

### after canary 20240408 https://github.com/hi-ogawa/vite-plugins/pull/280

![image](https://github.com/hi-ogawa/vite-plugins/assets/4232207/6be15259-651c-4b04-8cfd-5d56e41cdd62)

</details>

It would be cool if it can be shown in vite error overlay by
- https://github.com/hi-ogawa/vite-plugins/pull/272