### PR TITLE
feat(error-overlay): collect errors from `console.error`

### DIFF
--- a/packages/error-overlay/CHANGELOG.md
+++ b/packages/error-overlay/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.0.1
 
-- feat: collect errors from `console.error`
+- feat: collect errors from `console.error` ([#273](https://github.com/hi-ogawa/vite-plugins/pull/293))
 
 ## v0.0.0
 

--- a/packages/error-overlay/CHANGELOG.md
+++ b/packages/error-overlay/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## v0.0.1
+
+- feat: collect errors from `console.error`
+
+## v0.0.0
+
+- feat: create `vite-plugin-error-overlay` ([#272](https://github.com/hi-ogawa/vite-plugins/pull/272))

--- a/packages/error-overlay/package.json
+++ b/packages/error-overlay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/vite-plugin-error-overlay",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "homepage": "https://github.com/hi-ogawa/vite-plugins/tree/main/packages/error-overlay",
   "repository": {
     "type": "git",

--- a/packages/react-server/examples/basic/package.json
+++ b/packages/react-server/examples/basic/package.json
@@ -30,6 +30,7 @@
     "@hattip/adapter-node": "^0.0.44",
     "@hiogawa/unocss-preset-antd": "2.2.1-pre.7",
     "@hiogawa/utils": "^1.6.3",
+    "@hiogawa/vite-plugin-error-overlay": "latest",
     "@hiogawa/vite-plugin-ssr-middleware": "latest",
     "@iconify-json/ri": "^1.1.20",
     "@playwright/test": "^1.42.1",

--- a/packages/react-server/examples/basic/src/routes/test/error.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/error.tsx
@@ -1,8 +1,13 @@
 "use client";
 
 import type { ErrorPageProps } from "@hiogawa/react-server/server";
+import React from "react";
 
 export default function ErrorPage(props: ErrorPageProps) {
+  React.useEffect(() => {
+    (async () => { throw props.error; })();
+  }, []);
+
   return (
     <div className="flex flex-col gap-2">
       <h4>ErrorPage</h4>

--- a/packages/react-server/examples/basic/src/routes/test/error.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/error.tsx
@@ -1,15 +1,8 @@
 "use client";
 
 import type { ErrorPageProps } from "@hiogawa/react-server/server";
-import React from "react";
 
 export default function ErrorPage(props: ErrorPageProps) {
-  React.useEffect(() => {
-    (async () => {
-      // throw props.error;
-    })();
-  }, []);
-
   return (
     <div className="flex flex-col gap-2">
       <h4>ErrorPage</h4>

--- a/packages/react-server/examples/basic/src/routes/test/error.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/error.tsx
@@ -5,7 +5,9 @@ import React from "react";
 
 export default function ErrorPage(props: ErrorPageProps) {
   React.useEffect(() => {
-    (async () => { throw props.error; })();
+    (async () => {
+      throw props.error;
+    })();
   }, []);
 
   return (

--- a/packages/react-server/examples/basic/src/routes/test/error.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/error.tsx
@@ -6,7 +6,7 @@ import React from "react";
 export default function ErrorPage(props: ErrorPageProps) {
   React.useEffect(() => {
     (async () => {
-      throw props.error;
+      // throw props.error;
     })();
   }, []);
 

--- a/packages/react-server/examples/basic/vite.config.ts
+++ b/packages/react-server/examples/basic/vite.config.ts
@@ -1,10 +1,10 @@
 import path from "node:path";
 import { vitePluginReactServer } from "@hiogawa/react-server/plugin";
+import { vitePluginErrorOverlay } from "@hiogawa/vite-plugin-error-overlay";
 import {
   vitePluginLogger,
   vitePluginSsrMiddleware,
 } from "@hiogawa/vite-plugin-ssr-middleware";
-import { vitePluginErrorOverlay } from "@hiogawa/vite-plugin-error-overlay"
 import react from "@vitejs/plugin-react";
 import unocss from "unocss/vite";
 import { type Plugin, defineConfig } from "vite";

--- a/packages/react-server/examples/basic/vite.config.ts
+++ b/packages/react-server/examples/basic/vite.config.ts
@@ -4,6 +4,7 @@ import {
   vitePluginLogger,
   vitePluginSsrMiddleware,
 } from "@hiogawa/vite-plugin-ssr-middleware";
+import { vitePluginErrorOverlay } from "@hiogawa/vite-plugin-error-overlay"
 import react from "@vitejs/plugin-react";
 import unocss from "unocss/vite";
 import { type Plugin, defineConfig } from "vite";
@@ -13,6 +14,7 @@ export default defineConfig({
   plugins: [
     react(),
     unocss(),
+    vitePluginErrorOverlay(),
     vitePluginReactServer({
       plugins: [
         testVitePluginVirtual(),

--- a/packages/react-server/examples/basic/vite.config.ts
+++ b/packages/react-server/examples/basic/vite.config.ts
@@ -14,7 +14,9 @@ export default defineConfig({
   plugins: [
     react(),
     unocss(),
-    vitePluginErrorOverlay(),
+    vitePluginErrorOverlay({
+      patchConsoleError: true,
+    }),
     vitePluginReactServer({
       plugins: [
         testVitePluginVirtual(),

--- a/packages/react-server/examples/basic/vite.config.ts
+++ b/packages/react-server/examples/basic/vite.config.ts
@@ -14,9 +14,10 @@ export default defineConfig({
   plugins: [
     react(),
     unocss(),
-    vitePluginErrorOverlay({
-      patchConsoleError: true,
-    }),
+    !process.env["CI"] &&
+      vitePluginErrorOverlay({
+        patchConsoleError: true,
+      }),
     vitePluginReactServer({
       plugins: [
         testVitePluginVirtual(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,9 @@ importers:
       '@hiogawa/utils':
         specifier: ^1.6.3
         version: 1.6.3
+      '@hiogawa/vite-plugin-error-overlay':
+        specifier: latest
+        version: link:../../../error-overlay
       '@hiogawa/vite-plugin-ssr-middleware':
         specifier: latest
         version: link:../../../vite-plugin-ssr-middleware


### PR DESCRIPTION
- follow up https://github.com/hi-ogawa/vite-plugins/pull/272
- supersedes https://github.com/hi-ogawa/vite-plugins/pull/274

Since some "errors" only show on in `console.error`, so they won't be automatically processed by `vitePluginErrorOverlay`.

Either we need to do:
- re-throw some errors inside react-server so it'll trigger unhandled error event.
- extend `vitePluginErrorOverlay` to be able to receive custom error from react-server 
- extend `vitePluginErrorOverlay` to handle `console.error` log by patching
  - :heavy_check_mark: this seems robust enough and nicely covers react use cases out-of-the-box without changing anything on react-server integration.

It doesn't look like `hydrateRoot.onRecoverableError` tells about the error either.