### PR TITLE
refactor(react-server): replace `ssrLoadModule` with `import`

### DIFF
--- a/packages/react-server/src/entry/react-server.tsx
+++ b/packages/react-server/src/entry/react-server.tsx
@@ -23,7 +23,6 @@ import {
   createError,
   getErrorContext,
 } from "../lib/error";
-import { __global } from "../lib/global";
 import { generateRouteTree, renderRouteMap } from "../lib/router";
 
 const debug = createDebug("react-server:rsc");
@@ -159,7 +158,7 @@ async function actionHandler({ request }: { request: Request }) {
   let action: Function;
   const [file, name] = id.split("#") as [string, string];
   if (import.meta.env.DEV) {
-    const mod: any = await __global.dev.reactServer.ssrLoadModule(file);
+    const mod: any = await import(/* @vite-ignore */ file);
     action = mod[name];
   } else {
     // include all "use server" files via virtual module on build


### PR DESCRIPTION
See https://github.com/hi-ogawa/vite-environment-examples/blob/b134ae1704cbee96d1ed21e77b9f5f0f1e99b7ae/examples/react-server/src/features/server-action/react-server.ts#L22

This should be equivalent since dynamic import is transformed by Vite