### PR TITLE
refactor(react-server): minor cleanup

### DIFF
--- a/packages/react-server/src/entry/browser.tsx
+++ b/packages/react-server/src/entry/browser.tsx
@@ -18,7 +18,7 @@ import {
   createEncodedBrowserHistory,
   useRouter,
 } from "../lib/client/router";
-import { __global } from "../lib/global";
+import { $__global } from "../lib/global";
 import type { CallServerCallback } from "../lib/types";
 import { readStreamScript } from "../utils/stream-script";
 
@@ -61,7 +61,7 @@ export async function start() {
   };
 
   // expose as global to be used for createServerReference
-  __global.callServer = callServer;
+  $__global.callServer = callServer;
 
   // prepare initial layout data from inline <script>
   // TODO: needs to await for hydration formState. does it affect startup perf?

--- a/packages/react-server/src/entry/browser.tsx
+++ b/packages/react-server/src/entry/browser.tsx
@@ -34,8 +34,8 @@ export async function start() {
   const history = createEncodedBrowserHistory();
   const router = new Router(history);
 
-  let __setLayout: (v: Promise<ServerRouterData>) => void;
-  let __startActionTransition: React.TransitionStartFunction;
+  let $__setLayout: (v: Promise<ServerRouterData>) => void;
+  let $__startActionTransition: React.TransitionStartFunction;
 
   //
   // server action callback
@@ -56,7 +56,7 @@ export async function start() {
       fetch(request),
       { callServer },
     );
-    __startActionTransition(() => __setLayout(result));
+    $__startActionTransition(() => $__setLayout(result));
     return (await result).action?.data;
   };
 
@@ -81,7 +81,7 @@ export async function start() {
       React.useState<Promise<ServerRouterData>>(initialLayoutPromise);
 
     // very shaky trick to merge with current layout
-    __setLayout = (nextPromise) => {
+    $__setLayout = (nextPromise) => {
       setLayoutPromise(
         memoize(async (currentPromise: Promise<ServerRouterData>) => {
           const current = await currentPromise;
@@ -99,7 +99,7 @@ export async function start() {
 
     const [isPending, startTransition] = React.useTransition();
     const [isActionPending, startActionTransition] = React.useTransition();
-    __startActionTransition = startActionTransition;
+    $__startActionTransition = startActionTransition;
 
     React.useEffect(() => router.setup(), []);
 
@@ -134,7 +134,7 @@ export async function start() {
         }),
       );
       startTransition(() => {
-        __setLayout(
+        $__setLayout(
           reactServerDomClient.createFromFetch<ServerRouterData>(
             fetch(request),
             {

--- a/packages/react-server/src/entry/server.tsx
+++ b/packages/react-server/src/entry/server.tsx
@@ -16,7 +16,7 @@ import {
   getStatusText,
   isRedirectError,
 } from "../lib/error";
-import { __global } from "../lib/global";
+import { $__global } from "../lib/global";
 import {
   ENTRY_REACT_SERVER_WRAPPER,
   type SsrAssetsType,
@@ -53,7 +53,7 @@ export async function importReactServer(): Promise<
   typeof import("./react-server")
 > {
   if (import.meta.env.DEV) {
-    return __global.dev.reactServer.ssrLoadModule(
+    return $__global.dev.reactServer.ssrLoadModule(
       ENTRY_REACT_SERVER_WRAPPER,
     ) as any;
   } else {
@@ -109,8 +109,8 @@ export async function renderHtml(
 
   if (import.meta.env.DEV) {
     // ensure latest css
-    invalidateModule(__global.dev.server, "\0virtual:react-server-css.js");
-    invalidateModule(__global.dev.server, "\0virtual:dev-ssr-css.css?direct");
+    invalidateModule($__global.dev.server, "\0virtual:react-server-css.js");
+    invalidateModule($__global.dev.server, "\0virtual:dev-ssr-css.css?direct");
   }
   const assets: SsrAssetsType = (await import("virtual:ssr-assets" as string))
     .default;
@@ -208,10 +208,10 @@ async function devInspectHandler(request: Request) {
   if (data.type === "module") {
     let mod: ModuleNode | undefined;
     if (data.environment === "ssr") {
-      mod = await getModuleNode(__global.dev.server, data.url, true);
+      mod = await getModuleNode($__global.dev.server, data.url, true);
     }
     if (data.environment === "react-server") {
-      mod = await getModuleNode(__global.dev.reactServer, data.url, true);
+      mod = await getModuleNode($__global.dev.reactServer, data.url, true);
     }
     const result = mod && {
       id: mod.id,

--- a/packages/react-server/src/features/router/client.tsx
+++ b/packages/react-server/src/features/router/client.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { RedirectHandler } from "../../lib/client/error-boundary";
 import { isRedirectError } from "../../lib/error";
-import { __global } from "../../lib/global";
+import { $__global } from "../../lib/global";
 import { ActionRedirectHandler } from "../server-action/client";
 import { LAYOUT_ROOT_NAME, type ServerRouterData } from "./utils";
 

--- a/packages/react-server/src/features/router/client.tsx
+++ b/packages/react-server/src/features/router/client.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { RedirectHandler } from "../../lib/client/error-boundary";
 import { isRedirectError } from "../../lib/error";
-import { $__global } from "../../lib/global";
 import { ActionRedirectHandler } from "../server-action/client";
 import { LAYOUT_ROOT_NAME, type ServerRouterData } from "./utils";
 

--- a/packages/react-server/src/features/server-action/browser.tsx
+++ b/packages/react-server/src/features/server-action/browser.tsx
@@ -1,10 +1,10 @@
 import reactServerDomClient from "react-server-dom-webpack/client.browser";
-import { __global } from "../../lib/global";
+import { $__global } from "../../lib/global";
 
 // https://github.com/facebook/react/blob/c8a035036d0f257c514b3628e927dd9dd26e5a09/packages/react-client/src/ReactFlightReplyClient.js#L758
 
 export function createServerReference(id: string) {
   return reactServerDomClient.createServerReference(id, (...args) =>
-    __global.callServer(...args),
+    $__global.callServer(...args),
   );
 }

--- a/packages/react-server/src/features/server-action/client.tsx
+++ b/packages/react-server/src/features/server-action/client.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { $__global } from "../../lib/global";
 import { RedirectBoundary } from "../../runtime-client";
 import { createError } from "../../server";
 import { LayoutStateContext } from "../router/client";

--- a/packages/react-server/src/features/server-action/client.tsx
+++ b/packages/react-server/src/features/server-action/client.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { __global } from "../../lib/global";
+import { $__global } from "../../lib/global";
 import { RedirectBoundary } from "../../runtime-client";
 import { createError } from "../../server";
 import { LayoutStateContext } from "../router/client";

--- a/packages/react-server/src/features/server-action/react-server.tsx
+++ b/packages/react-server/src/features/server-action/react-server.tsx
@@ -73,7 +73,7 @@ async function importServerReference(id: string): Promise<unknown> {
   if (import.meta.env.DEV) {
     return await import(/* @vite-ignore */ id);
   } else {
-    const mod = await import("virtual:rsc-use-server" as string);
+    const mod = await import("virtual:server-references" as string);
     const dynImport = mod.default[id];
     tinyassert(dynImport, `server reference not found '${id}'`);
     return dynImport();

--- a/packages/react-server/src/features/use-client/browser.tsx
+++ b/packages/react-server/src/features/use-client/browser.tsx
@@ -11,9 +11,8 @@ async function importWrapper(id: string) {
     // transformed to "?import"
     return import(/* @vite-ignore */ id);
   } else {
-    // TODO: avoid extra round trip for this dynamic import
     const clientReferences = await import(
-      "/dist/rsc/client-references.js" as string
+      "virtual:client-references" as string
     );
     const dynImport = clientReferences.default[id];
     tinyassert(dynImport, `client reference not found '${id}'`);

--- a/packages/react-server/src/features/use-client/server.tsx
+++ b/packages/react-server/src/features/use-client/server.tsx
@@ -28,7 +28,7 @@ async function ssrImport(id: string) {
     return import(/* @vite-ignore */ id);
   } else {
     const clientReferences = await import(
-      "/dist/rsc/client-references.js" as string
+      "virtual:client-references" as string
     );
     const dynImport = clientReferences.default[id];
     tinyassert(dynImport, `client reference not found '${id}'`);

--- a/packages/react-server/src/lib/global.ts
+++ b/packages/react-server/src/lib/global.ts
@@ -3,7 +3,7 @@ import type { CallServerCallback } from "./types";
 
 // centeralize quick global hacks...
 
-export const __global: {
+export const $__global: {
   dev: {
     server: ViteDevServer;
     reactServer: ViteDevServer;

--- a/packages/react-server/src/lib/router.tsx
+++ b/packages/react-server/src/lib/router.tsx
@@ -2,7 +2,7 @@ import { objectHas, sortBy, tinyassert } from "@hiogawa/utils";
 import React from "react";
 import { getPathPrefixes, normalizePathname } from "../features/router/utils";
 import { type ReactServerErrorContext, createError } from "./error";
-import { __global } from "./global";
+import { $__global } from "./global";
 
 // TODO: move to features/router/react-server
 

--- a/packages/react-server/src/lib/router.tsx
+++ b/packages/react-server/src/lib/router.tsx
@@ -2,7 +2,6 @@ import { objectHas, sortBy, tinyassert } from "@hiogawa/utils";
 import React from "react";
 import { getPathPrefixes, normalizePathname } from "../features/router/utils";
 import { type ReactServerErrorContext, createError } from "./error";
-import { $__global } from "./global";
 
 // TODO: move to features/router/react-server
 

--- a/packages/react-server/src/plugin/ast-utils.ts
+++ b/packages/react-server/src/plugin/ast-utils.ts
@@ -110,5 +110,5 @@ export function getExportNames(
   return exportNames;
 }
 
-export const USE_CLIENT_RE = /^("use client")|('use client')/;
-export const USE_SERVER_RE = /^("use server")|('use server')/;
+export const USE_CLIENT_RE = /^("use client"|'use client')/;
+export const USE_SERVER_RE = /^("use server"|'use server')/;

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -295,17 +295,6 @@ export function vitePluginReactServer(options?: {
       }
       return ctx.modules;
     },
-    resolveId(source, _importer, _options) {
-      // weird trick to silence import analysis error during dev
-      // by pointing to a file which always exists
-      if (
-        parentEnv.command === "serve" &&
-        source === "/dist/rsc/client-references.js"
-      ) {
-        return "/package.json";
-      }
-      return;
-    },
   };
 
   // plugins for main vite dev server (browser / ssr)
@@ -313,6 +302,10 @@ export function vitePluginReactServer(options?: {
     rscParentPlugin,
     vitePluginSilenceUseClientBuildWarning(),
     vitePluginClientUseServer({ manager }),
+    createVirtualPlugin("client-references", () => {
+      tinyassert(manager.buildType && manager.buildType !== "rsc");
+      return fs.promises.readFile("dist/rsc/client-references.js", "utf-8");
+    }),
     {
       name: "client-virtual-use-client-node-modules",
       resolveId(source, _importer, _options) {

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -84,10 +84,6 @@ export function vitePluginReactServer(options?: {
     clearScreen: false,
     configFile: false,
     cacheDir: "./node_modules/.vite-rsc",
-    // server: {
-    //   // TODO: for now this is to silence build only virtual:... resolution error
-    //   preTransformRequests: false,
-    // },
     optimizeDeps: {
       noDiscovery: true,
       include: [],

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -18,7 +18,7 @@ import {
   createServer,
   parseAstAsync,
 } from "vite";
-import { __global } from "../lib/global";
+import { $__global } from "../lib/global";
 import { USE_CLIENT_RE, USE_SERVER_RE, getExportNames } from "./ast-utils";
 import { collectStyle, collectStyleUrls } from "./css";
 import {
@@ -256,7 +256,7 @@ export function vitePluginReactServer(options?: {
         tinyassert(parentServer);
         const reactServer = await createServer(rscConfig);
         reactServer.pluginContainer.buildStart({});
-        __global.dev = {
+        $__global.dev = {
           server: parentServer,
           reactServer: reactServer,
         };
@@ -273,8 +273,8 @@ export function vitePluginReactServer(options?: {
     },
     async buildEnd(_options) {
       if (parentEnv.command === "serve") {
-        await __global.dev.reactServer.close();
-        delete (__global as any).dev;
+        await $__global.dev.reactServer.close();
+        delete ($__global as any).dev;
       }
     },
     transform(_code, id, _options) {
@@ -354,7 +354,7 @@ export function vitePluginReactServer(options?: {
       // dev
       if (!manager.buildType) {
         // extract <head> injected by plugins
-        const html = await __global.dev.server.transformIndexHtml(
+        const html = await $__global.dev.server.transformIndexHtml(
           "/",
           "<html><head></head></html>",
         );
@@ -442,9 +442,9 @@ export function vitePluginReactServer(options?: {
       tinyassert(!manager.buildType);
       const styles = await Promise.all([
         `/******* react-server ********/`,
-        collectStyle(__global.dev.reactServer, [ENTRY_REACT_SERVER]),
+        collectStyle($__global.dev.reactServer, [ENTRY_REACT_SERVER]),
         `/******* client **************/`,
-        collectStyle(__global.dev.server, [ENTRY_CLIENT]),
+        collectStyle($__global.dev.server, [ENTRY_CLIENT]),
       ]);
       return styles.join("\n\n");
     }),
@@ -452,7 +452,7 @@ export function vitePluginReactServer(options?: {
       // virtual module proxy css imports from react server to client
       // TODO: invalidate + full reload when add/remove css file?
       if (!manager.buildType) {
-        const urls = await collectStyleUrls(__global.dev.reactServer, [
+        const urls = await collectStyleUrls($__global.dev.reactServer, [
           ENTRY_REACT_SERVER,
         ]);
         const code = urls.map((url) => `import "${url}";\n`).join("");

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -115,7 +115,7 @@ export function vitePluginReactServer(options?: {
       vitePluginServerUseClient({ manager }),
 
       // expose server references for RSC build via virtual module
-      createVirtualPlugin("rsc-use-server", async () => {
+      createVirtualPlugin("server-references", async () => {
         tinyassert(manager.buildType === "rsc");
         // we need to crawl file system to collect server references ("use server")
         // since we currently needs RSC -> Client -> SSR build pipeline
@@ -140,7 +140,7 @@ export function vitePluginReactServer(options?: {
           result += `"${key}": () => import("${id}"),\n`;
         }
         result += "};\n";
-        debug("[virtual-rsc-use-server]", result);
+        debug("[virtual:server-references]", result);
         return result;
       }),
 

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -131,6 +131,7 @@ export function vitePluginReactServer(options?: {
           const data = await fs.promises.readFile(file, "utf-8");
           if (USE_SERVER_RE.test(data)) {
             ids.push(file);
+            manager.rscUseServerIds.add(file);
           }
         }
         let result = `export default {\n`;

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -285,7 +285,6 @@ export function vitePluginReactServer(options?: {
         // In this case, reload all importers (for css hmr),
         // and return empty modules to avoid full-reload
         if (ctx.modules.every((m) => m.id && !manager.parentIds.has(m.id))) {
-          // in this case
           for (const m of ctx.modules) {
             for (const imod of m.importers) {
               await parentServer.reloadModule(imod);


### PR DESCRIPTION
Let's try to sync with cleaner structure in https://github.com/hi-ogawa/vite-environment-examples/tree/main/examples/react-server

- [x] https://github.com/hi-ogawa/vite-environment-examples/pull/43
  - indeed there are unused imports https://github.com/hi-ogawa/vite-plugins/pull/298/commits/56ebc4473e3dc2ccbc7e6ffa5cad39c38e720540
- [x] rename virtual modules

Next plan is to split `plugin/index.ts` into `features`.