### PR TITLE
feat(react-server): support catch-all dynamic route

### DIFF
--- a/packages/react-server/examples/basic/src/routes/test/dynamic/catchall/[...any]/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/catchall/[...any]/page.tsx
@@ -3,9 +3,14 @@ import { TestDynamic } from "../../_utils";
 
 export default function Page(props: PageProps) {
   return (
-    <TestDynamic
-      props={props}
-      file="/test/dynamic/catchall/[...any]/page.tsx"
-    />
+    <div>
+      <TestDynamic
+        props={props}
+        file="/test/dynamic/catchall/[...any]/page.tsx"
+      />
+      <label className="flex items-center gap-1">
+        test state <input type="checkbox" />
+      </label>
+    </div>
   );
 }

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/catchall/[...any]/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/catchall/[...any]/page.tsx
@@ -1,0 +1,11 @@
+import type { PageProps } from "@hiogawa/react-server/server";
+import { TestDynamic } from "../../_utils";
+
+export default function Page(props: PageProps) {
+  return (
+    <TestDynamic
+      props={props}
+      file="/test/dynamic/catchall/[...any]/page.tsx"
+    />
+  );
+}

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/catchall/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/catchall/page.tsx
@@ -1,0 +1,6 @@
+import type { PageProps } from "@hiogawa/react-server/server";
+import { TestDynamic } from "../_utils";
+
+export default function Page(props: PageProps) {
+  return <TestDynamic props={props} file="/test/dynamic/catchall/page.tsx" />;
+}

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/catchall/static/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/catchall/static/page.tsx
@@ -1,0 +1,8 @@
+import type { PageProps } from "@hiogawa/react-server/server";
+import { TestDynamic } from "../../_utils";
+
+export default function Page(props: PageProps) {
+  return (
+    <TestDynamic props={props} file="/test/dynamic/catchall/static/page.tsx" />
+  );
+}

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/layout.tsx
@@ -19,6 +19,7 @@ export default function Layout(props: LayoutProps) {
           "/test/dynamic/catchall/x",
           "/test/dynamic/catchall/x/y",
           "/test/dynamic/catchall/x/y/z",
+          "/test/dynamic/catchall/x/y/w",
         ]}
         activeProps={{
           "aria-current": "page",

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/layout.tsx
@@ -15,6 +15,10 @@ export default function Layout(props: LayoutProps) {
           "/test/dynamic/✅",
           "/test/dynamic/" + encodeURI("✅"),
           "/test/dynamic/abc/def",
+          "/test/dynamic/catchall/static",
+          "/test/dynamic/catchall/x",
+          "/test/dynamic/catchall/x/y",
+          "/test/dynamic/catchall/x/y/z",
         ]}
         activeProps={{
           "aria-current": "page",


### PR DESCRIPTION
It looks a little shaky, but this is one way to do it.

## todo

- [x] demo
- [x] test