### PR TITLE
test(react-server): test SSR after HMR

### DIFF
--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -177,8 +177,9 @@ test("rsc hmr @dev", async ({ page }) => {
 
   await checkClientState();
 
-  const res = await page.request.get("/test");
-  const resText = await res.text();
+  const res = await page.reload();
+  await waitForHydration(page);
+  const resText = await res?.text();
   expect(resText).toContain("RSC (EDIT) Experiment");
 });
 
@@ -201,8 +202,9 @@ test("common hmr @dev", async ({ page }) => {
 
   await checkClientState();
 
-  const res = await page.request.get("/test");
-  const resText = await res.text();
+  const res = await page.reload();
+  await waitForHydration(page);
+  const resText = await res?.text();
   expect(resText).toContain(
     "Common (EDIT) component (<!-- -->from server<!-- -->)",
   );
@@ -229,8 +231,10 @@ test("client hmr @dev", async ({ page }) => {
   await checkClientState();
 
   // SSR should also use a fresh module
-  const res = await page.request.get("/test");
-  expect(await res.text()).toContain("<div>test-hmr-edit-div</div>");
+  const res = await page.reload();
+  await waitForHydration(page);
+  const resText = await res?.text();
+  expect(resText).toContain("<div>test-hmr-edit-div</div>");
 });
 
 test("rsc + client + rsc hmr @dev", async ({ page }) => {

--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -203,8 +203,12 @@ test("common hmr @dev", async ({ page }) => {
 
   const res = await page.request.get("/test");
   const resText = await res.text();
-  expect(resText).toContain("Common (EDIT) component (from server)");
-  expect(resText).toContain("Common (EDIT) component (from client)");
+  expect(resText).toContain(
+    "Common (EDIT) component (<!-- -->from server<!-- -->)",
+  );
+  expect(resText).toContain(
+    "Common (EDIT) component (<!-- -->from client<!-- -->)",
+  );
 });
 
 test("client hmr @dev", async ({ page }) => {

--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -176,6 +176,10 @@ test("rsc hmr @dev", async ({ page }) => {
   await waitForHydration(page);
 
   await checkClientState();
+
+  const res = await page.request.get("/test");
+  const resText = await res.text();
+  expect(resText).toContain("RSC (EDIT) Experiment");
 });
 
 test("common hmr @dev", async ({ page }) => {
@@ -196,6 +200,11 @@ test("common hmr @dev", async ({ page }) => {
   await waitForHydration(page);
 
   await checkClientState();
+
+  const res = await page.request.get("/test");
+  const resText = await res.text();
+  expect(resText).toContain("Common (EDIT) component (from server)");
+  expect(resText).toContain("Common (EDIT) component (from client)");
 });
 
 test("client hmr @dev", async ({ page }) => {


### PR DESCRIPTION
We already check the most important case to catch stale server module hydration error, but why not add more:

https://github.com/hi-ogawa/vite-plugins/blob/48f1844d62aba59f9a17cb58ec73c9c5286cd6c4/packages/react-server/examples/basic/e2e/basic.test.ts#L231-L233