### PR TITLE
fix(react-server): noramlize client reference with `?t=` query (hmr timestamp)

### DIFF
--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -256,25 +256,23 @@ test("rsc + client + rsc hmr @dev", async ({ page }) => {
 
   // edit client
   await editFile("./src/components/counter.tsx", (s) =>
-    s.replace("test-hmr-div", "test-hmr-edit-div"),
+    s.replace("test-hmr-div", "test-hmr-edit1-div"),
   );
-  await page.getByText("test-hmr-edit-div").click();
+  await page.getByText("test-hmr-edit1-div").click();
   await page.getByText("Count: 1").click();
 
-  // edit server again re-mounts client
+  // edit server again
   await editFile("./src/routes/test/page.tsx", (s) =>
     s.replace("Server (EDIT 1) Time", "Server (EDIT 2) Time"),
   );
   await page.getByText("Server (EDIT 2) Time").click();
-  await page.getByText("Count: 0").click();
-
-  // edit client again should work
-  await page.getByRole("button", { name: "+" }).click();
   await page.getByText("Count: 1").click();
+
+  // edit client again
   await editFile("./src/components/counter.tsx", (s) =>
-    s.replace("test-hmr-edit-div", "test-hmr-edit-edit-div"),
+    s.replace("test-hmr-edit1-div", "test-hmr-edit2-div"),
   );
-  await page.getByText("test-hmr-edit-edit-div").click();
+  await page.getByText("test-hmr-edit2-div").click();
   await page.getByText("Count: 1").click();
 });
 

--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -274,6 +274,10 @@ test("rsc + client + rsc hmr @dev", async ({ page }) => {
   );
   await page.getByText("test-hmr-edit2-div").click();
   await page.getByText("Count: 1").click();
+
+  // check no hydration error after reload
+  await page.reload();
+  await waitForHydration(page);
 });
 
 test("module invalidation @dev", async ({ page }) => {

--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -601,12 +601,9 @@ test("client module used at boundary and non-boundary hmr @dev", async ({
   );
   await page.getByText("Client2Context [okok]").click();
 
-  // TODO: still dual package after HMR due to
-  // `<id>?t=...` imported by client component
-  // `<id>` imported by server component (as client reference)
   await page.reload();
   await waitForHydration(page);
-  await page.getByText("Client2Context [not-ok]").click();
+  await page.getByText("Client2Context [okok]").click();
 });
 
 test("RouteProps.request", async ({ page }) => {

--- a/packages/react-server/src/features/use-client/plugin.ts
+++ b/packages/react-server/src/features/use-client/plugin.ts
@@ -189,7 +189,8 @@ export async function noramlizeClientReferenceId(
   } else {
     id = wrapId(id);
   }
-  // TODO: this is needed only for browser, but not ssr?
+  // this is needed only for browser, so we'll strip it off
+  // during ssr client reference import
   const mod = await parentServer.moduleGraph.getModuleByUrl(id);
   if (mod && mod.lastHMRTimestamp > 0) {
     id += `?t=${mod.lastHMRTimestamp}`;

--- a/packages/react-server/src/features/use-client/plugin.ts
+++ b/packages/react-server/src/features/use-client/plugin.ts
@@ -192,7 +192,7 @@ export async function noramlizeClientReferenceId(
   // TODO: this is needed only for browser, but not ssr?
   const mod = await parentServer.moduleGraph.getModuleByUrl(id);
   if (mod && mod.lastHMRTimestamp > 0) {
-    id += (id.includes("?") ? "&t" : "?t") + `=${mod.lastHMRTimestamp}`;
+    id += `?t=${mod.lastHMRTimestamp}`;
   }
   return id;
 }

--- a/packages/react-server/src/features/use-client/plugin.ts
+++ b/packages/react-server/src/features/use-client/plugin.ts
@@ -32,9 +32,9 @@ export function vitePluginServerUseClient({
   runtimePath: string;
 }): PluginOption {
   // TODO:
-  // during dev, it might be simpler to always wrap all client references (not only node_modules)
-  // with virtual module and let browser environment deal with
-  // precise resolution (e.g. `?v=` deps optimization hash, `?t=` hmr timestamp)
+  // eventually we should try entirely virtual module approach for client reference (not only node_modules)
+  // so that we can delegate precise resolution (e.g. `?v=` deps optimization hash, `?t=` hmr timestamp)
+  // to actual client (browser, ssr) environment instead of faking out things on RSC module graph
 
   // intercept Vite's node resolve to virtualize "use client" in node_modules
   const pluginUseClientNodeModules: Plugin = {

--- a/packages/react-server/src/features/use-client/plugin.ts
+++ b/packages/react-server/src/features/use-client/plugin.ts
@@ -26,6 +26,11 @@ export function vitePluginServerUseClient({
   manager: ReactServerManager;
   runtimePath: string;
 }): PluginOption {
+  // TODO:
+  // during dev, it might be simpler to always wrap all client references (not only node_modules)
+  // with virtual module and let browser environment deal with
+  // precise resolution (e.g. `?v=` deps optimization hash, `?t=` hmr timestamp)
+
   // intercept Vite's node resolve to virtualize "use client" in node_modules
   const pluginUseClientNodeModules: Plugin = {
     name: "server-virtual-use-client-node-modules",

--- a/packages/react-server/src/features/use-client/server.tsx
+++ b/packages/react-server/src/features/use-client/server.tsx
@@ -24,6 +24,8 @@ const ssrWebpackRequire: WebpackRequire = memoize(ssrImport, {
 async function ssrImport(id: string) {
   debug("[__webpack_require__]", { id });
   if (import.meta.env.DEV) {
+    // strip off `?t=` added for browser by noramlizeClientReferenceId
+    id = id.split("?t=")[0]!;
     // transformed to "ssrLoadModule" during dev
     return import(/* @vite-ignore */ id);
   } else {

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -53,6 +53,8 @@ const RUNTIME_REACT_SERVER_PATH = fileURLToPath(
 export type { ReactServerManager };
 
 class ReactServerManager {
+  parentServer?: ViteDevServer;
+
   buildType?: "rsc" | "client" | "ssr";
 
   // expose "use client" node modules to client via virtual modules
@@ -249,6 +251,7 @@ export function vitePluginReactServer(options?: {
     },
     async configureServer(server) {
       parentServer = server;
+      manager.parentServer = server;
     },
     async buildStart(_options) {
       if (parentEnv.command === "serve") {


### PR DESCRIPTION
- follow up to https://github.com/hi-ogawa/vite-plugins/pull/315

Probably we should consider entirely virtual module centered approach (not only `node_modules`), but for now, it might be possible to simply adjust our existing `noramlizeClientReferenceId` to take hmr timestamp into account.

---

However, `?t=...` injection doesn't happen for ssr import analysis (unless we use new module runner `injectInvalidationTimestamp` mode https://github.com/vitejs/vite/pull/16400), so we actually need to strip that out during ssr `importWrapper` again.

---

And good news is that this is going to fix this non-ideal HMR behavior added in:
- https://github.com/hi-ogawa/vite-plugins/pull/265

