### PR TITLE
feat(react-server): support `loading` convention

### DIFF
--- a/packages/react-server/examples/basic/src/routes/test/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/layout.tsx
@@ -23,6 +23,7 @@ export default async function Layout(props: LayoutProps) {
           "/test/session",
           "/test/client",
           "/test/revalidate",
+          "/test/loading",
         ]}
       />
       <div className="flex items-center gap-2 text-sm">

--- a/packages/react-server/examples/basic/src/routes/test/loading/[id]/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/loading/[id]/page.tsx
@@ -1,0 +1,21 @@
+import type { PageProps } from "@hiogawa/react-server/server";
+import { sleep } from "@hiogawa/utils";
+import React from "react";
+
+// TODO: userland implementation?
+export default function PageWrapper(props: PageProps) {
+  return (
+    <React.Suspense fallback={"loading...."} key={props.params.id}>
+      <Page {...props} />
+    </React.Suspense>
+  );
+}
+
+async function Page(props: PageProps) {
+  await sleep(1000);
+  return (
+    <div>
+      <pre>{JSON.stringify(props.params, null, 2)}</pre>
+    </div>
+  );
+}

--- a/packages/react-server/examples/basic/src/routes/test/loading/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/loading/layout.tsx
@@ -1,0 +1,14 @@
+import type { LayoutProps } from "@hiogawa/react-server/server";
+import { NavMenu } from "../../../components/nav-menu";
+
+export default function Layout(props: LayoutProps) {
+  return (
+    <div className="flex flex-col gap-2 p-2">
+      <h4 className="font-bold">Loading</h4>
+      <NavMenu
+        links={["/test/loading", "/test/loading/1", "/test/loading/2"]}
+      />
+      {props.children}
+    </div>
+  );
+}

--- a/packages/react-server/examples/basic/src/routes/test/loading/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/loading/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Choose a page from above</div>;
+}


### PR DESCRIPTION
- For https://github.com/hi-ogawa/rsc-on-vite/issues/5

I think leaving it as userland implementation is fine (Remix also suggests manually putting `<Suspense key>`?), but it's still nice to have a way for each `page.tsx` to know own part of `params` (aka segment) so they can differentiate whether ancestors `params` are changing or not.
