### PR TITLE
feat(react-server): remount subtree on dynamic segment change

### DIFF
--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -840,6 +840,15 @@ test("dynamic routes", async ({ page }) => {
   ).toHaveAttribute("aria-current", "page");
 });
 
+test("remount on dynamic segment change", async ({ page }) => {
+  await page.goto("/test/dynamic/abc");
+  await waitForHydration(page);
+  await page.getByPlaceholder("dynamic-input").fill("hello");
+  await page.getByRole("link", { name: "• /test/dynamic/✅" }).click();
+  await page.waitForURL("/test/dynamic/✅");
+  await expect(page.getByPlaceholder("dynamic-input")).toHaveValue("");
+});
+
 test("catch-all routes @js", async ({ page }) => {
   checkNoError(page);
   await page.goto("/test/dynamic/catchall");

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/[id]/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/[id]/page.tsx
@@ -2,5 +2,10 @@ import type { PageProps } from "@hiogawa/react-server/server";
 import { TestDynamic } from "../_utils";
 
 export default function Page(props: PageProps) {
-  return <TestDynamic props={props} file="/test/dynamic/[id]/page.tsx" />;
+  return (
+    <div>
+      <input className="antd-input px-2 mb-2" placeholder="dynamic-input" />
+      <TestDynamic props={props} file="/test/dynamic/[id]/page.tsx" />
+    </div>
+  );
 }

--- a/packages/react-server/examples/basic/src/routes/test/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/layout.tsx
@@ -23,6 +23,7 @@ export default async function Layout(props: LayoutProps) {
           "/test/session",
           "/test/client",
           "/test/revalidate",
+          "/test/loading",
         ]}
       />
       <div className="flex items-center gap-2 text-sm">

--- a/packages/react-server/examples/basic/src/routes/test/loading/[id]/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/loading/[id]/page.tsx
@@ -1,0 +1,21 @@
+import type { PageProps } from "@hiogawa/react-server/server";
+import { sleep } from "@hiogawa/utils";
+import React from "react";
+
+// TODO: userland implementation?
+export default function PageWrapper(props: PageProps) {
+  return (
+    <React.Suspense fallback={"loading...."} key={props.params.id}>
+      <Page {...props} />
+    </React.Suspense>
+  );
+}
+
+async function Page(props: PageProps) {
+  await sleep(1000);
+  return (
+    <div>
+      <pre>{JSON.stringify(props.params, null, 2)}</pre>
+    </div>
+  );
+}

--- a/packages/react-server/examples/basic/src/routes/test/loading/[id]/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/loading/[id]/page.tsx
@@ -2,20 +2,24 @@ import type { PageProps } from "@hiogawa/react-server/server";
 import { sleep } from "@hiogawa/utils";
 import React from "react";
 
-// TODO: userland implementation?
-export default function PageWrapper(props: PageProps) {
+// TODO: userland `loading` implementation?
+export default function PageWithLoading(props: PageProps) {
   return (
-    <React.Suspense fallback={"loading...."} key={props.params.id}>
+    <React.Suspense fallback={<Loading />}>
       <Page {...props} />
     </React.Suspense>
   );
+}
+
+function Loading() {
+  return <div className="antd-spin size-10" />;
 }
 
 async function Page(props: PageProps) {
   await sleep(1000);
   return (
     <div>
-      <pre>{JSON.stringify(props.params, null, 2)}</pre>
+      <pre>params {JSON.stringify(props.params)}</pre>
     </div>
   );
 }

--- a/packages/react-server/examples/basic/src/routes/test/loading/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/loading/layout.tsx
@@ -1,0 +1,14 @@
+import type { LayoutProps } from "@hiogawa/react-server/server";
+import { NavMenu } from "../../../components/nav-menu";
+
+export default function Layout(props: LayoutProps) {
+  return (
+    <div className="flex flex-col gap-2 p-2">
+      <h4 className="font-bold">Loading</h4>
+      <NavMenu
+        links={["/test/loading", "/test/loading/1", "/test/loading/2"]}
+      />
+      {props.children}
+    </div>
+  );
+}

--- a/packages/react-server/examples/basic/src/routes/test/loading/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/loading/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Choose a page from above</div>;
+}

--- a/packages/react-server/src/lib/__snapshots__/router.test.ts.snap
+++ b/packages/react-server/src/lib/__snapshots__/router.test.ts.snap
@@ -96,11 +96,13 @@ exports[`generateRouteTree > basic > (1) "/other" 1`] = `
         />
       </RedirectBoundary>
     <//layout.tsx>,
-    "/other": <RedirectBoundary>
-      <LayoutContent
-        name="/other"
-      />
-    </RedirectBoundary>,
+    "/other": <React.Fragment>
+      <RedirectBoundary>
+        <LayoutContent
+          name="/other"
+        />
+      </RedirectBoundary>
+    </React.Fragment>,
   },
   "pages": {
     "/other": </other/page.tsx
@@ -164,11 +166,13 @@ exports[`generateRouteTree > basic > (2) "/not-found" 1`] = `
         />
       </RedirectBoundary>
     <//layout.tsx>,
-    "/not-found": <RedirectBoundary>
-      <LayoutContent
-        name="/not-found"
-      />
-    </RedirectBoundary>,
+    "/not-found": <React.Fragment>
+      <RedirectBoundary>
+        <LayoutContent
+          name="/not-found"
+        />
+      </RedirectBoundary>
+    </React.Fragment>,
   },
   "pages": {
     "/not-found": <ThrowNotFound
@@ -355,11 +359,13 @@ exports[`generateRouteTree > basic > (4) "/test/other" 1`] = `
         />
       </RedirectBoundary>
     <//test/layout.tsx>,
-    "/test/other": <RedirectBoundary>
-      <LayoutContent
-        name="/test/other"
-      />
-    </RedirectBoundary>,
+    "/test/other": <React.Fragment>
+      <RedirectBoundary>
+        <LayoutContent
+          name="/test/other"
+        />
+      </RedirectBoundary>
+    </React.Fragment>,
   },
   "pages": {
     "/test/other": </test/other/page.tsx
@@ -453,11 +459,13 @@ exports[`generateRouteTree > basic > (5) "/test/not-found" 1`] = `
         />
       </RedirectBoundary>
     <//test/layout.tsx>,
-    "/test/not-found": <RedirectBoundary>
-      <LayoutContent
-        name="/test/not-found"
-      />
-    </RedirectBoundary>,
+    "/test/not-found": <React.Fragment>
+      <RedirectBoundary>
+        <LayoutContent
+          name="/test/not-found"
+        />
+      </RedirectBoundary>
+    </React.Fragment>,
   },
   "pages": {
     "/test/not-found": </test/[dynamic]/page.tsx

--- a/packages/react-server/src/lib/router.tsx
+++ b/packages/react-server/src/lib/router.tsx
@@ -69,6 +69,7 @@ async function renderLayout(
   node: RouteTreeNode,
   props: PageProps,
   name: string,
+  key?: string,
 ) {
   const { ErrorBoundary, RedirectBoundary, LayoutContent } =
     await importRuntimeClient();
@@ -82,7 +83,13 @@ async function renderLayout(
   }
   const Layout = node.value?.layout?.default;
   if (Layout) {
-    return <Layout {...props}>{acc}</Layout>;
+    acc = (
+      <Layout key={key} {...props}>
+        {acc}
+      </Layout>
+    );
+  } else {
+    acc = <React.Fragment key={key}>{acc}</React.Fragment>;
   }
   return acc;
 }
@@ -129,7 +136,9 @@ export async function renderRouteMap(
       node = initNode();
     }
     const props: BaseProps = { ...baseProps, params };
-    layouts[prefix] = await renderLayout(node, props, prefix);
+    // re-mount subtree when dynamic segment changes
+    const cacheKey = [i, next?.param ?? "", key].join("");
+    layouts[prefix] = await renderLayout(node, props, prefix, cacheKey);
     if (prefix === pathname) {
       pages[prefix] = renderPage(node, props);
     }


### PR DESCRIPTION
I think this is what's more important so that other convention (e.g. `loading` https://github.com/hi-ogawa/vite-plugins/pull/327) should work or userland implement is easier.

## todo

- [x] check Next.js (it does re-mount)
- [x] check Remix (it doesn't re-mount)
- [x] test