### PR TITLE
refactor(react-server): organize plugins

### DIFF
--- a/packages/react-server/src/entry/server.tsx
+++ b/packages/react-server/src/entry/server.tsx
@@ -2,6 +2,7 @@ import { createDebug, splitFirst, tinyassert } from "@hiogawa/utils";
 import { createMemoryHistory } from "@tanstack/history";
 import reactDomServer from "react-dom/server.edge";
 import type { ModuleNode, ViteDevServer } from "vite";
+import type { SsrAssetsType } from "../features/assets/plugin";
 import { LayoutRoot, LayoutStateContext } from "../features/router/client";
 import type { ServerRouterData } from "../features/router/utils";
 import {
@@ -17,11 +18,7 @@ import {
   isRedirectError,
 } from "../lib/error";
 import { $__global } from "../lib/global";
-import {
-  ENTRY_REACT_SERVER_WRAPPER,
-  type SsrAssetsType,
-  invalidateModule,
-} from "../plugin/utils";
+import { ENTRY_REACT_SERVER_WRAPPER, invalidateModule } from "../plugin/utils";
 import { jsonStringifyTransform } from "../utils/stream";
 import { injectStreamScript } from "../utils/stream-script";
 import type { ReactServerHandlerStreamResult } from "./react-server";

--- a/packages/react-server/src/features/assets/plugin.ts
+++ b/packages/react-server/src/features/assets/plugin.ts
@@ -1,0 +1,140 @@
+import fs from "node:fs";
+import path from "node:path";
+import { tinyassert, typedBoolean } from "@hiogawa/utils";
+import type { Manifest, Plugin, ViteDevServer } from "vite";
+import { $__global } from "../../lib/global";
+import type { ReactServerManager } from "../../plugin";
+import { collectStyle, collectStyleUrls } from "../../plugin/css";
+import {
+  ENTRY_CLIENT,
+  ENTRY_CLIENT_WRAPPER,
+  ENTRY_REACT_SERVER,
+  createVirtualPlugin,
+} from "../../plugin/utils";
+
+export interface SsrAssetsType {
+  bootstrapModules: string[];
+  head: string;
+}
+
+export const SERVER_CSS_PROXY = "virtual:server-css-proxy.js";
+
+export function vitePluginServerAssets({
+  manager,
+}: { manager: ReactServerManager }): Plugin[] {
+  return [
+    createVirtualPlugin("ssr-assets", async () => {
+      // dev
+      if (!manager.buildType) {
+        // extract <head> injected by plugins
+        let { head } = await getIndexHtmlTransform($__global.dev.server);
+
+        // expose raw dynamic `import` which doesn't go through vite's transform
+        // since it would inject `<id>?import` and cause dual packages when
+        // client code is both imported at the boundary (as `<id>?import`)
+        // and not at the boundary (as `<id>`).
+        head += `<script>globalThis.__raw_import = (id) => import(id)</script>\n`;
+
+        // serve dev css as ?direct so that ssr html won't get too huge.
+        // also remove style on first hot update.
+        head += `\
+          <link
+            data-ssr-dev-css
+            rel="stylesheet"
+            href="/@id/__x00__virtual:dev-ssr-css.css?direct"
+          />
+          <script type="module">
+            import { createHotContext } from "/@vite/client";
+            const hot = createHotContext("hot-data-ssr-dev-css");
+            hot.on("vite:afterUpdate", () => {
+              document
+                .querySelectorAll("[data-ssr-dev-css]")
+                .forEach(node => node.remove());
+            });
+          </script>
+        `;
+        const result: SsrAssetsType = {
+          bootstrapModules: [`/@id/__x00__${ENTRY_CLIENT_WRAPPER}`],
+          head,
+        };
+        return `export default ${JSON.stringify(result)}`;
+      }
+
+      // build
+      if (manager.buildType === "ssr") {
+        const manifest: Manifest = JSON.parse(
+          await fs.promises.readFile(
+            "dist/client/.vite/manifest.json",
+            "utf-8",
+          ),
+        );
+        const entry = manifest[ENTRY_CLIENT_WRAPPER];
+        tinyassert(entry);
+        const css = entry.css ?? [];
+        const js =
+          entry.dynamicImports
+            ?.map((k) => manifest[k]?.file)
+            .filter(typedBoolean) ?? [];
+        const head = [
+          ...css.map((href) => `<link rel="stylesheet" href="/${href}" />`),
+          ...js.map((href) => `<link rel="modulepreload" href="/${href}" />`),
+        ].join("\n");
+        const result: SsrAssetsType = {
+          bootstrapModules: [`/${entry.file}`],
+          head,
+        };
+        return `export default ${JSON.stringify(result)}`;
+      }
+
+      tinyassert(false);
+    }),
+
+    createVirtualPlugin("dev-ssr-css.css", async () => {
+      tinyassert(!manager.buildType);
+      const styles = await Promise.all([
+        `/******* react-server ********/`,
+        collectStyle($__global.dev.reactServer, [ENTRY_REACT_SERVER]),
+        `/******* client **************/`,
+        collectStyle($__global.dev.server, [ENTRY_CLIENT]),
+      ]);
+      return styles.join("\n\n");
+    }),
+
+    createVirtualPlugin(SERVER_CSS_PROXY.slice("virtual:".length), async () => {
+      // virtual module to proxy css imports from react server to client
+      // TODO: invalidate + full reload when add/remove css file?
+      if (!manager.buildType) {
+        const urls = await collectStyleUrls($__global.dev.reactServer, [
+          ENTRY_REACT_SERVER,
+        ]);
+        const code = urls.map((url) => `import "${url}";\n`).join("");
+        // ensure hmr boundary since css module doesn't have `import.meta.hot.accept`
+        return code + `if (import.meta.hot) { import.meta.hot.accept() }`;
+      }
+      if (manager.buildType === "client") {
+        // TODO: probe manifest to collect css?
+        const files = await fs.promises.readdir("./dist/rsc/assets", {
+          withFileTypes: true,
+        });
+        const code = files
+          .filter((f) => f.isFile() && f.name.endsWith(".css"))
+          .map((f) => path.join(f.path, f.name))
+          .map((f) => `import "/${f}";\n`)
+          .join("");
+        return code;
+      }
+      tinyassert(false);
+    }),
+  ];
+}
+
+async function getIndexHtmlTransform(server: ViteDevServer) {
+  const html = await server.transformIndexHtml(
+    "/",
+    "<html><head></head></html>",
+  );
+  const match = html.match(/<head>(.*)<\/head>/s);
+  tinyassert(match && 1 in match);
+  const head = match[1];
+  return { head };
+}

--- a/packages/react-server/src/features/assets/plugin.ts
+++ b/packages/react-server/src/features/assets/plugin.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { tinyassert, typedBoolean } from "@hiogawa/utils";
 import type { Manifest, Plugin, ViteDevServer } from "vite";
 import { $__global } from "../../lib/global";
-import type { ReactServerManager } from "../../plugin";
+import type { PluginStateManager } from "../../plugin";
 import { collectStyle, collectStyleUrls } from "../../plugin/css";
 import {
   ENTRY_CLIENT,
@@ -21,7 +21,7 @@ export const SERVER_CSS_PROXY = "virtual:server-css-proxy.js";
 
 export function vitePluginServerAssets({
   manager,
-}: { manager: ReactServerManager }): Plugin[] {
+}: { manager: PluginStateManager }): Plugin[] {
   return [
     createVirtualPlugin("ssr-assets", async () => {
       // dev

--- a/packages/react-server/src/features/assets/plugin.ts
+++ b/packages/react-server/src/features/assets/plugin.ts
@@ -36,7 +36,7 @@ export function vitePluginServerAssets({
         head += `<script>globalThis.__raw_import = (id) => import(id)</script>\n`;
 
         // serve dev css as ?direct so that ssr html won't get too huge.
-        // also remove style on first hot update.
+        // then remove this injected style on first hot update.
         head += `\
           <link
             data-ssr-dev-css

--- a/packages/react-server/src/features/server-action/plugin.tsx
+++ b/packages/react-server/src/features/server-action/plugin.tsx
@@ -4,7 +4,7 @@ import {
 } from "@hiogawa/transforms";
 import { createDebug, tinyassert } from "@hiogawa/utils";
 import { type Plugin, type PluginOption, parseAstAsync } from "vite";
-import type { ReactServerManager } from "../../plugin";
+import type { PluginStateManager } from "../../plugin";
 import { createVirtualPlugin, hashString } from "../../plugin/utils";
 
 const debug = createDebug("react-server:plugin:server-action");
@@ -24,7 +24,7 @@ export function vitePluginClientUseServer({
   runtimePath,
   ssrRuntimePath,
 }: {
-  manager: ReactServerManager;
+  manager: PluginStateManager;
   runtimePath: string;
   ssrRuntimePath: string;
 }): Plugin {
@@ -72,7 +72,7 @@ export function vitePluginServerUseServer({
   manager,
   runtimePath,
 }: {
-  manager: ReactServerManager;
+  manager: PluginStateManager;
   runtimePath: string;
 }): PluginOption {
   const transformPlugin: Plugin = {

--- a/packages/react-server/src/features/use-client/plugin.ts
+++ b/packages/react-server/src/features/use-client/plugin.ts
@@ -113,8 +113,8 @@ export function vitePluginServerUseClient({
     if (!manager.buildType) {
       // normalize client reference during dev
       // to align with Vite's import analysis
-      tinyassert(manager.parentServer);
-      return await noramlizeClientReferenceId(id, manager.parentServer);
+      tinyassert(manager.server);
+      return await noramlizeClientReferenceId(id, manager.server);
     } else {
       // obfuscate reference
       return hashString(id);

--- a/packages/react-server/src/features/use-client/plugin.ts
+++ b/packages/react-server/src/features/use-client/plugin.ts
@@ -11,7 +11,7 @@ import {
   type ViteDevServer,
   parseAstAsync,
 } from "vite";
-import type { ReactServerManager } from "../../plugin";
+import type { PluginStateManager } from "../../plugin";
 import { USE_CLIENT_RE } from "../../plugin/ast-utils";
 import { createVirtualPlugin, hashString } from "../../plugin/utils";
 
@@ -32,7 +32,7 @@ export function vitePluginServerUseClient({
   manager,
   runtimePath,
 }: {
-  manager: ReactServerManager;
+  manager: PluginStateManager;
   runtimePath: string;
 }): PluginOption {
   // TODO:
@@ -209,7 +209,7 @@ const VIRTUAL_PREFIX = "virtual:use-client-node-module/";
 export function vitePluginClientUseClient({
   manager,
 }: {
-  manager: ReactServerManager;
+  manager: PluginStateManager;
 }): Plugin[] {
   const devExternalPlugin: Plugin = {
     name: vitePluginClientUseClient.name + ":dev-external",

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -1,11 +1,8 @@
-import fs from "node:fs";
-import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { createDebug, tinyassert, typedBoolean } from "@hiogawa/utils";
+import { createDebug, tinyassert } from "@hiogawa/utils";
 import {
   type ConfigEnv,
   type InlineConfig,
-  type Manifest,
   type Plugin,
   type PluginOption,
   type ViteDevServer,
@@ -13,6 +10,10 @@ import {
   createLogger,
   createServer,
 } from "vite";
+import {
+  SERVER_CSS_PROXY,
+  vitePluginServerAssets,
+} from "../features/assets/plugin";
 import {
   vitePluginClientUseServer,
   vitePluginServerUseServer,
@@ -22,13 +23,11 @@ import {
   vitePluginServerUseClient,
 } from "../features/use-client/plugin";
 import { $__global } from "../lib/global";
-import { collectStyle, collectStyleUrls } from "./css";
 import {
   ENTRY_CLIENT,
   ENTRY_CLIENT_WRAPPER,
   ENTRY_REACT_SERVER,
   ENTRY_REACT_SERVER_WRAPPER,
-  type SsrAssetsType,
   createVirtualPlugin,
   vitePluginSilenceDirectiveBuildWarning,
 } from "./utils";
@@ -50,6 +49,7 @@ const RUNTIME_REACT_SERVER_PATH = fileURLToPath(
 // convenient singleton to share states
 export type { ReactServerManager };
 
+// TODO: rename to PluginStateManager
 class ReactServerManager {
   parentServer?: ViteDevServer;
 
@@ -318,77 +318,13 @@ export function vitePluginReactServer(options?: {
       ssrRuntimePath: RUNTIME_SERVER_PATH,
     }),
     ...vitePluginClientUseClient({ manager }),
-    createVirtualPlugin("ssr-assets", async () => {
-      // dev
-      if (!manager.buildType) {
-        // extract <head> injected by plugins
-        let { head } = await getIndexHtmlTransform($__global.dev.server);
-
-        // expose raw dynamic `import` which doesn't go through vite's transform
-        // since it would inject `<id>?import` and cause dual packages when
-        // client code is both imported at the boundary (as `<id>?import`)
-        // and not at the boundary (as `<id>`).
-        head += `<script>globalThis.__raw_import = (id) => import(id)</script>\n`;
-
-        // serve dev css as ?direct so that ssr html won't get too huge.
-        // also remove style on first hot update.
-        head += `\
-          <link
-            data-ssr-dev-css
-            rel="stylesheet"
-            href="/@id/__x00__virtual:dev-ssr-css.css?direct"
-          />
-          <script type="module">
-            import { createHotContext } from "/@vite/client";
-            const hot = createHotContext("hot-data-ssr-dev-css");
-            hot.on("vite:afterUpdate", () => {
-              document
-                .querySelectorAll("[data-ssr-dev-css]")
-                .forEach(node => node.remove());
-            });
-          </script>
-        `;
-        const result: SsrAssetsType = {
-          bootstrapModules: [`/@id/__x00__${ENTRY_CLIENT_WRAPPER}`],
-          head,
-        };
-        return `export default ${JSON.stringify(result)}`;
-      }
-
-      // build
-      if (manager.buildType === "ssr") {
-        const manifest: Manifest = JSON.parse(
-          await fs.promises.readFile(
-            "dist/client/.vite/manifest.json",
-            "utf-8",
-          ),
-        );
-        const entry = manifest[ENTRY_CLIENT_WRAPPER];
-        tinyassert(entry);
-        const css = entry.css ?? [];
-        const js =
-          entry.dynamicImports
-            ?.map((k) => manifest[k]?.file)
-            .filter(typedBoolean) ?? [];
-        const head = [
-          ...css.map((href) => `<link rel="stylesheet" href="/${href}" />`),
-          ...js.map((href) => `<link rel="modulepreload" href="/${href}" />`),
-        ].join("\n");
-        const result: SsrAssetsType = {
-          bootstrapModules: [`/${entry.file}`],
-          head,
-        };
-        return `export default ${JSON.stringify(result)}`;
-      }
-
-      tinyassert(false);
-    }),
+    ...vitePluginServerAssets({ manager }),
     createVirtualPlugin(ENTRY_CLIENT_WRAPPER.slice("virtual:".length), () => {
       // dev
       if (!manager.buildType) {
         // wrapper entry to ensure client entry runs after vite/react inititialization
         return /* js */ `
-          import "virtual:react-server-css.js";
+          import "${SERVER_CSS_PROXY}";
           for (let i = 0; !window.__vite_plugin_react_preamble_installed__; i++) {
             await new Promise(resolve => setTimeout(resolve, 10 * (2 ** i)));
           }
@@ -399,58 +335,12 @@ export function vitePluginReactServer(options?: {
       if (manager.buildType === "client") {
         // import "runtime-client" for preload
         return /* js */ `
-          import "virtual:react-server-css.js";
+          import "${SERVER_CSS_PROXY}";
           import("@hiogawa/react-server/runtime-client");
           import "${ENTRY_CLIENT}";
         `;
       }
       tinyassert(false);
     }),
-    createVirtualPlugin("dev-ssr-css.css?direct", async () => {
-      tinyassert(!manager.buildType);
-      const styles = await Promise.all([
-        `/******* react-server ********/`,
-        collectStyle($__global.dev.reactServer, [ENTRY_REACT_SERVER]),
-        `/******* client **************/`,
-        collectStyle($__global.dev.server, [ENTRY_CLIENT]),
-      ]);
-      return styles.join("\n\n");
-    }),
-    createVirtualPlugin("react-server-css.js", async () => {
-      // virtual module proxy css imports from react server to client
-      // TODO: invalidate + full reload when add/remove css file?
-      if (!manager.buildType) {
-        const urls = await collectStyleUrls($__global.dev.reactServer, [
-          ENTRY_REACT_SERVER,
-        ]);
-        const code = urls.map((url) => `import "${url}";\n`).join("");
-        // ensure hmr boundary since css module doesn't have `import.meta.hot.accept`
-        return code + `if (import.meta.hot) { import.meta.hot.accept() }`;
-      }
-      if (manager.buildType === "client") {
-        // TODO: probe manifest to collect css?
-        const files = await fs.promises.readdir("./dist/rsc/assets", {
-          withFileTypes: true,
-        });
-        const code = files
-          .filter((f) => f.isFile() && f.name.endsWith(".css"))
-          .map((f) => path.join(f.path, f.name))
-          .map((f) => `import "/${f}";\n`)
-          .join("");
-        return code;
-      }
-      tinyassert(false);
-    }),
   ];
-}
-
-async function getIndexHtmlTransform(server: ViteDevServer) {
-  const html = await server.transformIndexHtml(
-    "/",
-    "<html><head></head></html>",
-  );
-  const match = html.match(/<head>(.*)<\/head>/s);
-  tinyassert(match && 1 in match);
-  const head = match[1];
-  return { head };
 }

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -47,10 +47,9 @@ const RUNTIME_REACT_SERVER_PATH = fileURLToPath(
 );
 
 // convenient singleton to share states
-export type { ReactServerManager };
+export type { PluginStateManager };
 
-// TODO: rename to PluginStateManager
-class ReactServerManager {
+class PluginStateManager {
   parentServer?: ViteDevServer;
 
   buildType?: "scan" | "rsc" | "client" | "ssr";
@@ -81,9 +80,9 @@ class ReactServerManager {
 if (!process.argv.includes("build")) {
   delete (globalThis as any).__VITE_REACT_SERVER_MANAGER;
 }
-const manager: ReactServerManager = ((
+const manager: PluginStateManager = ((
   globalThis as any
-).__VITE_REACT_SERVER_MANAGER ??= new ReactServerManager());
+).__VITE_REACT_SERVER_MANAGER ??= new PluginStateManager());
 
 export function vitePluginReactServer(options?: {
   plugins?: PluginOption[];

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -30,7 +30,6 @@ import {
   ENTRY_REACT_SERVER_WRAPPER,
   type SsrAssetsType,
   createVirtualPlugin,
-  hashString,
   vitePluginSilenceDirectiveBuildWarning,
 } from "./utils";
 
@@ -138,31 +137,11 @@ export function vitePluginReactServer(options?: {
         runtimePath: RUNTIME_REACT_SERVER_PATH,
       }),
 
-      // expose server references for RSC build via virtual module
-      createVirtualPlugin("server-references", async () => {
-        if (manager.buildType === "scan") {
-          return `export default {}`;
-        }
-        tinyassert(manager.buildType === "rsc");
-        let result = `export default {\n`;
-        for (const id of manager.rscUseServerIds) {
-          let key = manager.buildType ? hashString(id) : id;
-          result += `"${key}": () => import("${id}"),\n`;
-        }
-        result += "};\n";
-        debug("[virtual:server-references]", result);
-        return result;
-      }),
-
+      // this virtual is not necessary anymore but has been used in the past
+      // to extend user's react-server entry like ENTRY_CLIENT_WRAPPER
       createVirtualPlugin(
         ENTRY_REACT_SERVER_WRAPPER.slice("virtual:".length),
-        () => {
-          // this virtual is not necessary anymore but has been used in the past
-          // to extend user's react-server entry like ENTRY_CLIENT_WRAPPER
-          return /* js */ `
-            export * from "${ENTRY_REACT_SERVER}";
-          `;
-        },
+        () => `export * from "${ENTRY_REACT_SERVER}";\n`,
       ),
 
       {

--- a/packages/react-server/src/plugin/utils.tsx
+++ b/packages/react-server/src/plugin/utils.tsx
@@ -8,6 +8,7 @@ export function invalidateModule(server: ViteDevServer, id: string) {
   }
 }
 
+// TODO: move to features/assets/ssr.ts
 export interface SsrAssetsType {
   bootstrapModules: string[];
   head: string;
@@ -32,11 +33,14 @@ export function createVirtualPlugin(name: string, load: Plugin["load"]) {
   return {
     name: `virtual-${name}`,
     resolveId(source, _importer, _options) {
-      return source === name ? "\0" + name : undefined;
+      if (source === name || source.startsWith(`${name}?`)) {
+        return `\0${source}`;
+      }
+      return;
     },
     load(id, options) {
-      if (id === "\0" + name) {
-        return (load as any)(id, options);
+      if (id === `\0${name}` || id.startsWith(`\0${name}?`)) {
+        return (load as any).apply(this, [id, options]);
       }
     },
   } satisfies Plugin;

--- a/packages/react-server/src/plugin/utils.tsx
+++ b/packages/react-server/src/plugin/utils.tsx
@@ -8,12 +8,6 @@ export function invalidateModule(server: ViteDevServer, id: string) {
   }
 }
 
-// TODO: move to features/assets/ssr.ts
-export interface SsrAssetsType {
-  bootstrapModules: string[];
-  head: string;
-}
-
 // TODO: configurable?
 export const ENTRY_CLIENT = "/src/entry-client";
 export const ENTRY_REACT_SERVER = "/src/entry-react-server";


### PR DESCRIPTION
Moving out some code from `plugin/index.ts` to corresponding `features/plugin.ts` when possible.