### PR TITLE
fix(react-server): tree shake unused references by `__NO_SIDE_EFFECTS__`

### DIFF
--- a/packages/react-server/src/features/server-action/browser.tsx
+++ b/packages/react-server/src/features/server-action/browser.tsx
@@ -3,6 +3,7 @@ import { $__global } from "../../lib/global";
 
 // https://github.com/facebook/react/blob/c8a035036d0f257c514b3628e927dd9dd26e5a09/packages/react-client/src/ReactFlightReplyClient.js#L758
 
+/* @__NO_SIDE_EFFECT */
 export function createServerReference(id: string) {
   return reactServerDomClient.createServerReference(id, (...args) =>
     $__global.callServer(...args),

--- a/packages/react-server/src/features/server-action/browser.tsx
+++ b/packages/react-server/src/features/server-action/browser.tsx
@@ -3,7 +3,7 @@ import { $__global } from "../../lib/global";
 
 // https://github.com/facebook/react/blob/c8a035036d0f257c514b3628e927dd9dd26e5a09/packages/react-client/src/ReactFlightReplyClient.js#L758
 
-/* @__NO_SIDE_EFFECT */
+/* @__NO_SIDE_EFFECTS__ */
 export function createServerReference(id: string) {
   return reactServerDomClient.createServerReference(id, (...args) =>
     $__global.callServer(...args),

--- a/packages/react-server/src/features/server-action/react-server.tsx
+++ b/packages/react-server/src/features/server-action/react-server.tsx
@@ -5,6 +5,7 @@ import type { ReactServerErrorContext } from "../../server";
 
 // https://github.com/facebook/react/blob/c8a035036d0f257c514b3628e927dd9dd26e5a09/packages/react-server-dom-webpack/src/ReactFlightWebpackReferences.js#L87
 
+/* @__NO_SIDE_EFFECT */
 export function registerServerReference(
   action: Function,
   id: string,

--- a/packages/react-server/src/features/server-action/react-server.tsx
+++ b/packages/react-server/src/features/server-action/react-server.tsx
@@ -5,7 +5,7 @@ import type { ReactServerErrorContext } from "../../server";
 
 // https://github.com/facebook/react/blob/c8a035036d0f257c514b3628e927dd9dd26e5a09/packages/react-server-dom-webpack/src/ReactFlightWebpackReferences.js#L87
 
-/* @__NO_SIDE_EFFECT */
+/* @__NO_SIDE_EFFECTS__ */
 export function registerServerReference(
   action: Function,
   id: string,

--- a/packages/react-server/src/features/server-action/server.tsx
+++ b/packages/react-server/src/features/server-action/server.tsx
@@ -1,5 +1,6 @@
 import reactServerDomClient from "react-server-dom-webpack/client.edge";
 
+/* @__NO_SIDE_EFFECT */
 export function createServerReference(id: string) {
   return reactServerDomClient.createServerReference(id, (...args) => {
     console.error(args);

--- a/packages/react-server/src/features/server-action/server.tsx
+++ b/packages/react-server/src/features/server-action/server.tsx
@@ -1,6 +1,6 @@
 import reactServerDomClient from "react-server-dom-webpack/client.edge";
 
-/* @__NO_SIDE_EFFECT */
+/* @__NO_SIDE_EFFECTS__ */
 export function createServerReference(id: string) {
   return reactServerDomClient.createServerReference(id, (...args) => {
     console.error(args);

--- a/packages/react-server/src/features/use-client/react-server.tsx
+++ b/packages/react-server/src/features/use-client/react-server.tsx
@@ -9,6 +9,7 @@ import type { BundlerConfig, ImportManifestEntry } from "../../lib/types";
 // id: /src/components/counter.tsx
 // name: Counter
 
+/* @__NO_SIDE_EFFECTS__ */
 export function registerClientReference(id: string, name: string) {
   // reuse everything but { $$async: true }.
   // `$$async` is not strictly necessary if we use `__webpack_chunk_load__` trick


### PR DESCRIPTION
Picking up diff from https://github.com/hi-ogawa/vite-plugins/pull/331

We could probably add `/* @__PURE__ */ $$proxy(...)` from transform plugin side, but `__NO_SIDE_EFFECTS__` should be also fine for now.

## example: 

Source https://github.com/hi-ogawa/vite-plugins/blob/1b276422a7fe68c908e1c279528b8a3d8fbb29e3/packages/react-server/examples/starter/src/routes/layout.tsx#L1-L3

Build output in `packages/react-server/examples/starter/dist/rsc/index.js`

- before

```ts
...
const Link = registerClientReference("SGjedgC19ilj85OGI0xm9X7OjaT_pYP5IBJLJN739tk", "Link");
registerClientReference("SGjedgC19ilj85OGI0xm9X7OjaT_pYP5IBJLJN739tk", "LinkForm");
registerClientReference("SGjedgC19ilj85OGI0xm9X7OjaT_pYP5IBJLJN739tk", "routerRevalidate");
registerClientReference("SGjedgC19ilj85OGI0xm9X7OjaT_pYP5IBJLJN739tk", "useRouter");
function Layout(props) { ... }
```

- after

```ts
...
const Link = /* @__PURE__ */ registerClientReference("SGjedgC19ilj85OGI0xm9X7OjaT_pYP5IBJLJN739tk", "Link");
function Layout(props) { ... }
```