### PR TITLE
fix(react-server): fix client css FOUC

### DIFF
--- a/packages/react-server/examples/basic/src/routes/test/css/_client.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/css/_client.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import "./css-client-normal.css";
+import cssModule from "./css-client-module.module.css";
+
+export function CssClientNormal() {
+  return <div id="css-client-normal">css client normal</div>;
+}
+
+export function CssClientModule() {
+  return <div className={cssModule.test}>css client module</div>;
+}

--- a/packages/react-server/examples/basic/src/routes/test/css/css-client-module.module.css
+++ b/packages/react-server/examples/basic/src/routes/test/css/css-client-module.module.css
@@ -1,0 +1,6 @@
+.test {
+  background: rgb(200, 250, 250);
+  padding: 20px;
+  width: 200px;
+  border: 1px dashed gray;
+}

--- a/packages/react-server/examples/basic/src/routes/test/css/css-client-normal.css
+++ b/packages/react-server/examples/basic/src/routes/test/css/css-client-normal.css
@@ -1,0 +1,6 @@
+#css-client-normal {
+  background: rgb(250, 250, 200);
+  padding: 20px;
+  width: 200px;
+  border: 1px dashed gray;
+}

--- a/packages/react-server/examples/basic/src/routes/test/css/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/css/page.tsx
@@ -1,4 +1,5 @@
 import "./css-normal.css";
+import { CssClientModule, CssClientNormal } from "./_client";
 import cssModule from "./css-module.module.css";
 
 export default function Page() {
@@ -8,6 +9,8 @@ export default function Page() {
       <div className="flex flex-col gap-2">
         <div id="css-normal">css normal</div>
         <div className={cssModule.test}>css module</div>
+        <CssClientNormal />
+        <CssClientModule />
       </div>
     </div>
   );

--- a/packages/react-server/src/entry/browser.tsx
+++ b/packages/react-server/src/entry/browser.tsx
@@ -5,6 +5,7 @@ import {
   LayoutRoot,
   LayoutStateContext,
   ROUTER_REVALIDATE_KEY,
+  RouteAssetLinks,
   RouteManifestContext,
   routerRevalidate,
 } from "../features/router/client";
@@ -160,6 +161,7 @@ export async function start() {
           <RouteManifestContext.Provider
             value={(globalThis as any).__routeManifest}
           >
+            <RouteAssetLinks />
             <LayoutRoot />
           </RouteManifestContext.Provider>
         </LayoutHandler>

--- a/packages/react-server/src/entry/server.tsx
+++ b/packages/react-server/src/entry/server.tsx
@@ -130,6 +130,7 @@ export async function renderHtml(
     head += `<script>globalThis.__DEBUG = "${process.env["DEBUG"]}"</script>\n`;
   }
 
+  // TODO: too huge?
   head += `<script>globalThis.__routeManifest = ${escpaeScriptString(
     JSON.stringify(routeManifest),
   )}</script>\n`;

--- a/packages/react-server/src/entry/server.tsx
+++ b/packages/react-server/src/entry/server.tsx
@@ -6,13 +6,10 @@ import type { SsrAssetsType } from "../features/assets/plugin";
 import {
   LayoutRoot,
   LayoutStateContext,
+  RouteAssetLinks,
   RouteManifestContext,
-  preloadAssetDeps,
 } from "../features/router/client";
-import {
-  type RouteManifest,
-  getRouteAssetDeps,
-} from "../features/router/manifest";
+import type { RouteManifest } from "../features/router/manifest";
 import type { ServerRouterData } from "../features/router/utils";
 import {
   createModuleMap,
@@ -104,19 +101,12 @@ export async function renderHtml(
 
   const routeManifest = await importRouteManifest();
 
-  function ServerPreload() {
-    preloadAssetDeps(getRouteAssetDeps(routeManifest, url.pathname));
-    return null;
-  }
-
   const reactRootEl = (
     <RouterContext.Provider value={router}>
       <LayoutStateContext.Provider value={{ data: layoutPromise }}>
-        <RouteManifestContext.Provider
-          value={(globalThis as any).__routeManifest}
-        >
+        <RouteManifestContext.Provider value={routeManifest}>
+          <RouteAssetLinks />
           <LayoutRoot />
-          <ServerPreload />
         </RouteManifestContext.Provider>
       </LayoutStateContext.Provider>
     </RouterContext.Provider>

--- a/packages/react-server/src/features/assets/plugin.ts
+++ b/packages/react-server/src/features/assets/plugin.ts
@@ -96,7 +96,11 @@ export function vitePluginServerAssets({
         `/******* react-server ********/`,
         collectStyle($__global.dev.reactServer, [ENTRY_REACT_SERVER]),
         `/******* client **************/`,
-        collectStyle($__global.dev.server, [ENTRY_CLIENT]),
+        collectStyle($__global.dev.server, [
+          ENTRY_CLIENT,
+          // TODO: dev should also use RouteManifest to manage client css
+          ...manager.rscUseClientIds,
+        ]),
       ]);
       return styles.join("\n\n");
     }),

--- a/packages/react-server/src/features/router/plugin.ts
+++ b/packages/react-server/src/features/router/plugin.ts
@@ -53,9 +53,6 @@ export function routeManifestPluginClient({
           for (const [k, v] of Object.entries(bundle)) {
             if (v.type === "chunk" && v.facadeModuleId) {
               facadeModuleDeps[v.facadeModuleId] = collectAssetDeps(k, bundle);
-              // TODO: css
-              // https://github.com/vitejs/vite/blob/147e9228bb1c75db153873761eb7a120a2bd09a4/packages/vite/src/node/plugins/manifest.ts#L91-L96
-              v.viteMetadata?.importedCss;
             }
           }
           const routeToAssetDeps = objectMapValues(

--- a/packages/react-server/src/features/router/plugin.ts
+++ b/packages/react-server/src/features/router/plugin.ts
@@ -1,5 +1,10 @@
 import path from "node:path";
-import { objectMapValues, tinyassert, uniq } from "@hiogawa/utils";
+import {
+  objectMapValues,
+  tinyassert,
+  typedBoolean,
+  uniq,
+} from "@hiogawa/utils";
 import FastGlob from "fast-glob";
 import type { Plugin, Rollup } from "vite";
 import type { PluginStateManager } from "../../plugin";
@@ -59,7 +64,9 @@ export function routeManifestPluginClient({
             manager.routeToClientReferences,
             // facade module might not exist when dynamic import is also imported statically
             (ids) =>
-              mergeAssetDeps(ids.flatMap((id) => facadeModuleDeps[id] ?? [])),
+              mergeAssetDeps(
+                ids.map((id) => facadeModuleDeps[id]).filter(typedBoolean),
+              ),
           );
           manager.routeManifest = {
             routeTree: createFsRouteTree(routeToAssetDeps),


### PR DESCRIPTION
It looks like I haven't test this case and it turns out I get FOUC (both dev and build), which needs to be fixed before thinking about preload.

For build, `<link rel="stylesheet" ... />` is injected during `preload`. We need to take control of that probably https://github.com/vitejs/vite/blob/147e9228bb1c75db153873761eb7a120a2bd09a4/packages/vite/src/node/plugins/importAnalysisBuild.ts#L119-L129

## todo

- [x] demo
- [x] manager css link on our own
  - head rendering behavior doesn't allow detaching stylesheet https://react.dev/reference/react-dom/components/link#special-rendering-behavior
    probably this is fine for now and we can follow up later.
- [x] test
  - [x] no FOUC (dev, build)
  - [x] hmr (dev)
    - [ ] css module hmr not working... will follow up later.