### PR TITLE
fix(react-server/css): fix client css module hmr

### DIFF
--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -552,15 +552,13 @@ test("client css hmr @dev", async ({ page, browser }) => {
   }
 });
 
-// TODO: is this vite's default behavior?
-test("client css module no hmr @dev", async ({ page, browser }) => {
+test("client css module hmr @dev", async ({ page, browser }) => {
   checkNoError(page);
 
   await page.goto("/test/css");
   await waitForHydration(page);
 
-  // check client state is reset (i.e. no hmr)
-  await page.getByPlaceholder("test-input").fill("hello");
+  const checkClientState = await setupCheckClientState(page);
 
   await expect(page.getByText("css client module")).toHaveCSS(
     "background-color",
@@ -574,7 +572,7 @@ test("client css module no hmr @dev", async ({ page, browser }) => {
     "rgb(123, 250, 250)",
   );
 
-  await expect(page.getByPlaceholder("test-input")).toHaveValue("");
+  await checkClientState();
 
   // verify new style is applied without js
   {

--- a/packages/react-server/src/features/assets/css.ts
+++ b/packages/react-server/src/features/assets/css.ts
@@ -46,5 +46,5 @@ export async function collectStyleUrls(
 }
 
 // cf. https://github.com/vitejs/vite/blob/d6bde8b03d433778aaed62afc2be0630c8131908/packages/vite/src/node/constants.ts#L49C23-L50
-const CSS_LANGS_RE =
+export const CSS_LANGS_RE =
   /\.(css|less|sass|scss|styl|stylus|pcss|postcss|sss)(?:$|\?)/;

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -11,6 +11,7 @@ import {
   createLogger,
   createServer,
 } from "vite";
+import { CSS_LANGS_RE } from "../features/assets/css";
 import {
   SERVER_CSS_PROXY,
   vitePluginServerAssets,
@@ -285,7 +286,14 @@ export function vitePluginReactServer(options?: {
           return [];
         }
       }
-      return ctx.modules;
+
+      // css module is not self-accepting, so we filter out
+      // `?direct` module (used for SSR CSS) to avoid browser full reload.
+      // (see packages/react-server/src/features/assets/css.ts)
+      if (CSS_LANGS_RE.test(ctx.file)) {
+        return ctx.modules.filter((m) => !m.id?.includes("?direct"));
+      }
+      return;
     },
   };
 


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/vite-plugins/issues/345

We should maybe replace `transformRequret("...css?direct")` with `ssrLoadModule("...css")`, so there won't be `?direct` module. I can follow up with this approach later.