### PR TITLE
refactor: simplify `virtual:client-references`

### DIFF
--- a/packages/react-server/src/features/server-action/plugin.tsx
+++ b/packages/react-server/src/features/server-action/plugin.tsx
@@ -114,8 +114,7 @@ export function vitePluginServerUseServer({
     tinyassert(manager.buildType === "rsc");
     let result = `export default {\n`;
     for (const id of manager.rscUseServerIds) {
-      let key = manager.buildType ? hashString(id) : id;
-      result += `"${key}": () => import("${id}"),\n`;
+      result += `"${hashString(id)}": () => import("${id}"),\n`;
     }
     result += "};\n";
     debug("[virtual:server-references]", result);

--- a/packages/react-server/src/features/use-client/plugin.ts
+++ b/packages/react-server/src/features/use-client/plugin.ts
@@ -234,7 +234,7 @@ export function vitePluginClientUseClient({
      * }
      */
     createVirtualPlugin("client-references", () => {
-      tinyassert(manager.buildType && manager.buildType !== "rsc");
+      tinyassert(manager.buildType === "client" || manager.buildType === "ssr");
       let result = `export default {\n`;
       for (let id of manager.rscUseClientIds) {
         // virtual module needs to be mapped back to the original form

--- a/packages/react-server/src/features/use-client/plugin.ts
+++ b/packages/react-server/src/features/use-client/plugin.ts
@@ -162,30 +162,6 @@ export function vitePluginServerUseClient({
         } satisfies CustomModuleMeta,
       };
     },
-
-    /**
-     * emit client-references as dynamic import map
-     * TODO: re-export only used exports via virtual modules?
-     *
-     * export default {
-     *   "some-file1": () => import("some-file1"),
-     * }
-     */
-    closeBundle: {
-      async handler() {
-        let result = `export default {\n`;
-        for (let id of manager.rscUseClientIds) {
-          // virtual module needs to be mapped back to the original form
-          const to = id.startsWith("\0") ? id.slice(1) : id;
-          if (manager.buildType) {
-            id = hashString(id);
-          }
-          result += `"${id}": () => import("${to}"),\n`;
-        }
-        result += "};\n";
-        await fs.promises.writeFile("dist/rsc/client-references.js", result);
-      },
-    },
   };
   return [useClientExternalPlugin, useClientPlugin];
 }
@@ -248,9 +224,25 @@ export function vitePluginClientUseClient({
 
   return [
     devExternalPlugin,
+
+    /**
+     * emit client-references as dynamic import map
+     * TODO: re-export only used exports via virtual modules?
+     *
+     * export default {
+     *   "some-file1": () => import("some-file1"),
+     * }
+     */
     createVirtualPlugin("client-references", () => {
       tinyassert(manager.buildType && manager.buildType !== "rsc");
-      return fs.promises.readFile("dist/rsc/client-references.js", "utf-8");
+      let result = `export default {\n`;
+      for (let id of manager.rscUseClientIds) {
+        // virtual module needs to be mapped back to the original form
+        const to = id.startsWith("\0") ? id.slice(1) : id;
+        result += `"${hashString(id)}": () => import("${to}"),\n`;
+      }
+      result += "};\n";
+      return { code: result, map: null };
     }),
   ];
 }


### PR DESCRIPTION
Cleaning up some old approach, which is already replaced in Vite 6 version https://github.com/hi-ogawa/vite-environment-examples/tree/main/examples/react-server