### PR TITLE
refactor: pass server css to browser via shared build state

### DIFF
--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -418,7 +418,7 @@ test("unocss hmr @dev", async ({ page, browser }) => {
   ).toHaveCSS("font-weight", "300");
 });
 
-test("react-server css @js", async ({ page }) => {
+test("react-server css normal @js", async ({ page }) => {
   checkNoError(page);
 
   await page.goto("/test/css");
@@ -426,18 +426,28 @@ test("react-server css @js", async ({ page }) => {
     "background-color",
     "rgb(250, 250, 200)",
   );
+});
+
+testNoJs("react-server css normal @nojs", async ({ page }) => {
+  await page.goto("/test/css");
+  await expect(page.getByText("css normal")).toHaveCSS(
+    "background-color",
+    "rgb(250, 250, 200)",
+  );
+});
+
+test("react-server css module @js", async ({ page }) => {
+  checkNoError(page);
+
+  await page.goto("/test/css");
   await expect(page.getByText("css module")).toHaveCSS(
     "background-color",
     "rgb(200, 250, 250)",
   );
 });
 
-testNoJs("react-server css @nojs", async ({ page }) => {
+testNoJs("react-server css module @nojs", async ({ page }) => {
   await page.goto("/test/css");
-  await expect(page.getByText("css normal")).toHaveCSS(
-    "background-color",
-    "rgb(250, 250, 200)",
-  );
   await expect(page.getByText("css module")).toHaveCSS(
     "background-color",
     "rgb(200, 250, 250)",

--- a/packages/react-server/src/features/assets/plugin.ts
+++ b/packages/react-server/src/features/assets/plugin.ts
@@ -121,10 +121,11 @@ export function serverAssetsPluginClient({
         return code + `if (import.meta.hot) { import.meta.hot.accept() }`;
       }
       if (manager.buildType === "client") {
+        // shaky way to keep css module import side effect
         const code = manager.serverCssIds
-          .map((url) => `import "${url}";\n`)
+          .map((url) => `export * from "${url}";\n`)
           .join("");
-        return { code, map: null };
+        return { code, map: null, moduleSideEffects: "no-treeshake" };
       }
       tinyassert(false);
     }),

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -14,7 +14,8 @@ import {
 import { CSS_LANGS_RE } from "../features/assets/css";
 import {
   SERVER_CSS_PROXY,
-  vitePluginServerAssets,
+  serverAssertsPluginServer,
+  serverAssetsPluginClient,
 } from "../features/assets/plugin";
 import type { RouteManifest } from "../features/router/manifest";
 import {
@@ -65,6 +66,8 @@ class PluginStateManager {
 
   routeToClientReferences: Record<string, string[]> = {};
   routeManifest?: RouteManifest;
+
+  serverCssIds: string[] = [];
 
   // expose "use client" node modules to client via virtual modules
   // to avoid dual package due to deps optimization hash during dev
@@ -146,6 +149,8 @@ export function vitePluginReactServer(options?: {
       }),
 
       routeManifestPluginServer({ manager }),
+
+      serverAssertsPluginServer({ manager }),
 
       // this virtual is not necessary anymore but has been used in the past
       // to extend user's react-server entry like ENTRY_CLIENT_WRAPPER
@@ -339,7 +344,7 @@ export function vitePluginReactServer(options?: {
       ssrRuntimePath: RUNTIME_SERVER_PATH,
     }),
     ...vitePluginClientUseClient({ manager }),
-    ...vitePluginServerAssets({ manager }),
+    ...serverAssetsPluginClient({ manager }),
     ...routeManifestPluginClient({ manager }),
     createVirtualPlugin(ENTRY_CLIENT_WRAPPER.slice("virtual:".length), () => {
       // dev


### PR DESCRIPTION
Trying to reduce a dependence of `dist` to allow parallel builds of
- https://github.com/hi-ogawa/vite-plugins/pull/350

It looks like css module is dropped for side effect import?