### PR TITLE
refactor: rename react imports

### DIFF
--- a/packages/react-server/src/entry/browser.tsx
+++ b/packages/react-server/src/entry/browser.tsx
@@ -29,7 +29,7 @@ const debug = createDebug("react-server:browser");
 export async function start() {
   initializeReactClientBrowser();
 
-  const { default: reactServerDomClient } = await import(
+  const { default: ReactClient } = await import(
     "react-server-dom-webpack/client.browser"
   );
 
@@ -50,11 +50,11 @@ export async function start() {
       }),
       {
         method: "POST",
-        body: await reactServerDomClient.encodeReply(args),
+        body: await ReactClient.encodeReply(args),
         headers: wrapStreamActionRequest(id),
       },
     );
-    const result = reactServerDomClient.createFromFetch<ServerRouterData>(
+    const result = ReactClient.createFromFetch<ServerRouterData>(
       fetch(request),
       { callServer },
     );
@@ -68,7 +68,7 @@ export async function start() {
   // prepare initial layout data from inline <script>
   // TODO: needs to await for hydration formState. does it affect startup perf?
   const initialLayout =
-    await reactServerDomClient.createFromReadableStream<ServerRouterData>(
+    await ReactClient.createFromReadableStream<ServerRouterData>(
       readStreamScript<string>().pipeThrough(new TextEncoderStream()),
       { callServer },
     );
@@ -137,12 +137,9 @@ export async function start() {
       );
       startTransition(() => {
         $__setLayout(
-          reactServerDomClient.createFromFetch<ServerRouterData>(
-            fetch(request),
-            {
-              callServer,
-            },
-          ),
+          ReactClient.createFromFetch<ServerRouterData>(fetch(request), {
+            callServer,
+          }),
         );
       });
     }, [location]);

--- a/packages/react-server/src/entry/browser.tsx
+++ b/packages/react-server/src/entry/browser.tsx
@@ -1,6 +1,6 @@
 import { createDebug, memoize } from "@hiogawa/utils";
 import React from "react";
-import reactDomClient from "react-dom/client";
+import ReactDOMClient from "react-dom/client";
 import {
   LayoutRoot,
   LayoutStateContext,
@@ -12,7 +12,7 @@ import {
 import type { ServerRouterData } from "../features/router/utils";
 import { wrapStreamActionRequest } from "../features/server-action/utils";
 import { wrapStreamRequestUrl } from "../features/server-component/utils";
-import { initializeWebpackBrowser } from "../features/use-client/browser";
+import { initializeReactClientBrowser } from "../features/use-client/browser";
 import { RootErrorBoundary } from "../lib/client/error-boundary";
 import {
   Router,
@@ -27,7 +27,7 @@ import { readStreamScript } from "../utils/stream-script";
 const debug = createDebug("react-server:browser");
 
 export async function start() {
-  initializeWebpackBrowser();
+  initializeReactClientBrowser();
 
   const { default: reactServerDomClient } = await import(
     "react-server-dom-webpack/client.browser"
@@ -178,9 +178,9 @@ export async function start() {
 
   // full client render on SSR error
   if (document.documentElement.dataset["noHydrate"]) {
-    reactDomClient.createRoot(document).render(reactRootEl);
+    ReactDOMClient.createRoot(document).render(reactRootEl);
   } else {
-    reactDomClient.hydrateRoot(document, reactRootEl, {
+    ReactDOMClient.hydrateRoot(document, reactRootEl, {
       formState: initialLayout.action?.data,
     });
   }

--- a/packages/react-server/src/entry/server.tsx
+++ b/packages/react-server/src/entry/server.tsx
@@ -71,7 +71,7 @@ export async function renderHtml(
 ) {
   initializeReactClientSsr();
 
-  const { default: reactServerDomClient } = await import(
+  const { default: ReactClient } = await import(
     "react-server-dom-webpack/client.edge"
   );
 
@@ -85,13 +85,15 @@ export async function renderHtml(
 
   const [stream1, stream2] = result.stream.tee();
 
-  const layoutPromise =
-    reactServerDomClient.createFromReadableStream<ServerRouterData>(stream1, {
+  const layoutPromise = ReactClient.createFromReadableStream<ServerRouterData>(
+    stream1,
+    {
       ssrManifest: {
         moduleMap: createModuleMap(),
         moduleLoading: null,
       },
-    });
+    },
+  );
 
   const url = new URL(request.url);
   const history = createMemoryHistory({

--- a/packages/react-server/src/entry/server.tsx
+++ b/packages/react-server/src/entry/server.tsx
@@ -1,6 +1,6 @@
 import { createDebug, splitFirst, tinyassert } from "@hiogawa/utils";
 import { createMemoryHistory } from "@tanstack/history";
-import reactDomServer from "react-dom/server.edge";
+import ReactDOMServer from "react-dom/server.edge";
 import type { ModuleNode, ViteDevServer } from "vite";
 import type { SsrAssetsType } from "../features/assets/plugin";
 import {
@@ -13,7 +13,7 @@ import type { RouteManifest } from "../features/router/manifest";
 import type { ServerRouterData } from "../features/router/utils";
 import {
   createModuleMap,
-  initializeWebpackSsr,
+  initializeReactClientSsr,
   ssrImportPromiseCache,
 } from "../features/use-client/server";
 import { Router, RouterContext } from "../lib/client/router";
@@ -69,7 +69,7 @@ export async function renderHtml(
   request: Request,
   result: ReactServerHandlerStreamResult,
 ) {
-  initializeWebpackSsr();
+  initializeReactClientSsr();
 
   const { default: reactServerDomClient } = await import(
     "react-server-dom-webpack/client.edge"
@@ -139,7 +139,7 @@ export async function renderHtml(
   let ssrStream: ReadableStream<Uint8Array>;
   let status = 200;
   try {
-    ssrStream = await reactDomServer.renderToReadableStream(reactRootEl, {
+    ssrStream = await ReactDOMServer.renderToReadableStream(reactRootEl, {
       formState: result.actionResult?.data,
       bootstrapModules: url.search.includes("__nojs")
         ? []
@@ -174,7 +174,7 @@ export async function renderHtml(
         </body>
       </html>
     );
-    ssrStream = await reactDomServer.renderToReadableStream(errorRoot, {
+    ssrStream = await ReactDOMServer.renderToReadableStream(errorRoot, {
       bootstrapModules: assets.bootstrapModules,
     });
   }

--- a/packages/react-server/src/features/server-action/browser.tsx
+++ b/packages/react-server/src/features/server-action/browser.tsx
@@ -1,11 +1,11 @@
-import reactServerDomClient from "react-server-dom-webpack/client.browser";
+import ReactClient from "react-server-dom-webpack/client.browser";
 import { $__global } from "../../lib/global";
 
 // https://github.com/facebook/react/blob/c8a035036d0f257c514b3628e927dd9dd26e5a09/packages/react-client/src/ReactFlightReplyClient.js#L758
 
 /* @__NO_SIDE_EFFECTS__ */
 export function createServerReference(id: string) {
-  return reactServerDomClient.createServerReference(id, (...args) =>
+  return ReactClient.createServerReference(id, (...args) =>
     $__global.callServer(...args),
   );
 }

--- a/packages/react-server/src/features/server-action/react-server.tsx
+++ b/packages/react-server/src/features/server-action/react-server.tsx
@@ -1,5 +1,5 @@
 import { memoize, tinyassert } from "@hiogawa/utils";
-import reactServerDomWebpack from "react-server-dom-webpack/server.edge";
+import ReactServer from "react-server-dom-webpack/server.edge";
 import type { BundlerConfig, ImportManifestEntry } from "../../lib/types";
 import type { ReactServerErrorContext } from "../../server";
 
@@ -14,7 +14,7 @@ export function registerServerReference(
   if (typeof action !== "function") {
     return action;
   }
-  return reactServerDomWebpack.registerServerReference(action, id, name);
+  return ReactServer.registerServerReference(action, id, name);
 }
 
 export type ActionResult = {
@@ -64,7 +64,7 @@ const serverReferenceWebpackRequire = memoize(importServerReference, {
   cache: serverReferenceImportPromiseCache,
 });
 
-export function initializeWebpackReactServer() {
+export function initializeReactServer() {
   Object.assign(globalThis, {
     __vite_react_server_webpack_require__: serverReferenceWebpackRequire,
     __vite_react_server_webpack_chunk_load__: () => {

--- a/packages/react-server/src/features/server-action/server.tsx
+++ b/packages/react-server/src/features/server-action/server.tsx
@@ -1,8 +1,8 @@
-import reactServerDomClient from "react-server-dom-webpack/client.edge";
+import ReactClient from "react-server-dom-webpack/client.edge";
 
 /* @__NO_SIDE_EFFECTS__ */
 export function createServerReference(id: string) {
-  return reactServerDomClient.createServerReference(id, (...args) => {
+  return ReactClient.createServerReference(id, (...args) => {
     console.error(args);
     throw new Error("unexpected callServer during SSR");
   });

--- a/packages/react-server/src/features/use-client/browser.tsx
+++ b/packages/react-server/src/features/use-client/browser.tsx
@@ -20,7 +20,7 @@ async function importWrapper(id: string) {
   }
 }
 
-export function initializeWebpackBrowser() {
+export function initializeReactClientBrowser() {
   Object.assign(globalThis, {
     __webpack_require__: memoize(importWrapper),
     __webpack_chunk_load__: () => {

--- a/packages/react-server/src/features/use-client/react-server.tsx
+++ b/packages/react-server/src/features/use-client/react-server.tsx
@@ -1,5 +1,5 @@
 import { tinyassert } from "@hiogawa/utils";
-import reactServerDomWebpack from "react-server-dom-webpack/server.edge";
+import ReactServer from "react-server-dom-webpack/server.edge";
 import type { BundlerConfig, ImportManifestEntry } from "../../lib/types";
 
 // https://github.com/facebook/react/blob/c8a035036d0f257c514b3628e927dd9dd26e5a09/packages/react-server-dom-webpack/src/ReactFlightWebpackReferences.js#L43
@@ -14,7 +14,7 @@ export function registerClientReference(id: string, name: string) {
   // reuse everything but { $$async: true }.
   // `$$async` is not strictly necessary if we use `__webpack_chunk_load__` trick
   // but for now, we go with async `__webpack_require__` for simplicity.
-  const reference = reactServerDomWebpack.registerClientReference({}, id, name);
+  const reference = ReactServer.registerClientReference({}, id, name);
   return Object.defineProperties(
     {},
     {

--- a/packages/react-server/src/features/use-client/server.tsx
+++ b/packages/react-server/src/features/use-client/server.tsx
@@ -38,7 +38,7 @@ async function ssrImport(id: string) {
   }
 }
 
-export function initializeWebpackSsr() {
+export function initializeReactClientSsr() {
   Object.assign(globalThis, {
     __webpack_require__: ssrWebpackRequire,
     __webpack_chunk_load__: () => {


### PR DESCRIPTION
Adopting the same naming from
- https://github.com/hi-ogawa/vite-environment-examples/pull/88