### PR TITLE
refactor: encode stream request in pathname

### DIFF
--- a/packages/react-server/examples/prerender/misc/vercel/config.json
+++ b/packages/react-server/examples/prerender/misc/vercel/config.json
@@ -1,5 +1,6 @@
 {
   "version": 3,
+  "trailingSlash": false,
   "routes": [
     {
       "src": "^/assets/(.*)$",

--- a/packages/react-server/examples/prerender/misc/vercel/config.json
+++ b/packages/react-server/examples/prerender/misc/vercel/config.json
@@ -8,22 +8,6 @@
       }
     },
     {
-      "src": "^(.*)",
-      "has": [
-        {
-          "type": "query",
-          "key": "__rsc"
-        }
-      ],
-      "dest": "$1/index.data"
-    },
-    {
-      "src": "^(.*)/index.data$",
-      "headers": {
-        "content-type": "text/x-component;charset=utf-8"
-      }
-    },
-    {
       "handle": "filesystem"
     }
   ]

--- a/packages/react-server/examples/prerender/src/routes/posts/layout.tsx
+++ b/packages/react-server/examples/prerender/src/routes/posts/layout.tsx
@@ -11,7 +11,7 @@ export type PostType = {
 export async function fetchPosts() {
   const res = await fetch("https://jsonplaceholder.typicode.com/posts");
   const posts: PostType[] = await res.json();
-  return posts.slice(0, 10);
+  return posts.slice(0, 5);
 }
 
 export default async function Layout(props: LayoutProps) {
@@ -21,7 +21,7 @@ export default async function Layout(props: LayoutProps) {
     <div>
       <h2>Posts</h2>
       <ul>
-        {posts.slice(0, 10).map((post) => (
+        {posts.map((post) => (
           <li key={post.id}>
             <Link href={`/posts/${post.id}`}>
               {post.title.substring(0, 20)}

--- a/packages/react-server/src/entry/react-server.tsx
+++ b/packages/react-server/src/entry/react-server.tsx
@@ -160,6 +160,7 @@ function createRouter() {
 
 // https://github.com/facebook/react/blob/da69b6af9697b8042834644b14d0e715d4ace18a/fixtures/flight/server/region.js#L105
 async function actionHandler({ request }: { request: Request }) {
+  // TODO: normalize stream request
   const context = new ActionContext(request);
   const streamAction = unwrapStreamActionRequest(request);
   let boundAction: Function;

--- a/packages/react-server/src/features/server-component/utils.tsx
+++ b/packages/react-server/src/features/server-component/utils.tsx
@@ -6,7 +6,7 @@ import {
 import type { ActionResult } from "../server-action/react-server";
 
 // encode flight request as path for the ease of ssg deployment
-export const RSC_PATH = "__f.data";
+export const RSC_PATH = "/__f.data";
 const RSC_PARAM = "__f";
 
 type StreamRequestParam = {
@@ -20,7 +20,7 @@ export function wrapStreamRequestUrl(
   param: StreamRequestParam,
 ): string {
   const newUrl = new URL(url, window.location.href);
-  newUrl.pathname += RSC_PATH;
+  newUrl.pathname = posixJoin(newUrl.pathname, RSC_PATH);
   newUrl.searchParams.set(RSC_PARAM, JSON.stringify(param));
   return newUrl.toString();
 }
@@ -33,7 +33,7 @@ export function unwrapStreamRequest(
   let isStream = false;
   if (url.pathname.endsWith(RSC_PATH)) {
     isStream = true;
-    url.pathname = url.pathname.slice(0, -RSC_PATH.length);
+    url.pathname = url.pathname.slice(0, -RSC_PATH.length) || "/";
   }
   const rscParam = url.searchParams.get(RSC_PARAM);
   url.searchParams.delete(RSC_PARAM);
@@ -57,4 +57,12 @@ export function unwrapStreamRequest(
     layoutRequest,
     isStream,
   };
+}
+
+// posixJoin("/", "new") === "/new"
+// posixJoin("/", "/new") === "/new"
+// posixJoin("/xyz", "new") === "/xyz/new"
+// posixJoin("/xyz", "/new") === "/xyz/new"
+function posixJoin(...args: string[]) {
+  return args.join("/").replace(/\/\/+/g, "/");
 }

--- a/packages/react-server/src/features/server-component/utils.tsx
+++ b/packages/react-server/src/features/server-component/utils.tsx
@@ -5,8 +5,9 @@ import {
 } from "../router/utils";
 import type { ActionResult } from "../server-action/react-server";
 
-// TODO: use accept header x-component?
-const RSC_PARAM = "__rsc";
+// encode flight request as path for the ease of ssg deployment
+const RSC_PATH = "__f.data";
+const RSC_PARAM = "__f";
 
 type StreamRequestParam = {
   lastPathname?: string;
@@ -19,6 +20,7 @@ export function wrapStreamRequestUrl(
   param: StreamRequestParam,
 ): string {
   const newUrl = new URL(url, window.location.href);
+  newUrl.pathname += RSC_PATH;
   newUrl.searchParams.set(RSC_PARAM, JSON.stringify(param));
   return newUrl.toString();
 }
@@ -28,6 +30,11 @@ export function unwrapStreamRequest(
   actionResult?: ActionResult,
 ) {
   const url = new URL(request.url);
+  let isStream = false;
+  if (url.pathname.endsWith(RSC_PATH)) {
+    isStream = true;
+    url.pathname = url.pathname.slice(0, -RSC_PATH.length);
+  }
   const rscParam = url.searchParams.get(RSC_PARAM);
   url.searchParams.delete(RSC_PARAM);
 
@@ -48,6 +55,6 @@ export function unwrapStreamRequest(
       headers: request.headers,
     }),
     layoutRequest,
-    isStream: Boolean(rscParam),
+    isStream,
   };
 }

--- a/packages/react-server/src/features/server-component/utils.tsx
+++ b/packages/react-server/src/features/server-component/utils.tsx
@@ -6,7 +6,7 @@ import {
 import type { ActionResult } from "../server-action/react-server";
 
 // encode flight request as path for the ease of ssg deployment
-const RSC_PATH = "__f.data";
+export const RSC_PATH = "__f.data";
 const RSC_PARAM = "__f";
 
 type StreamRequestParam = {

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -351,7 +351,7 @@ export function vitePluginReactServer(options?: {
             const html = await ssr.text();
             const data = Readable.from(stream as any);
             const htmlFile = path.join("dist/client", route, "index.html");
-            const dataFile = path.join("dist/client", route + RSC_PATH);
+            const dataFile = path.join("dist/client", route, RSC_PATH);
             await fs.promises.mkdir(path.dirname(htmlFile), {
               recursive: true,
             });


### PR DESCRIPTION
This probably makes prerender deployment easier though it might look ugly at a surface.


## todo

- [ ] normalize also action stream request path
- [ ] refactor wrap/unwrap request