### PR TITLE
refactor: encode stream request metadata in http header

### DIFF
--- a/packages/react-server/src/features/server-component/utils.tsx
+++ b/packages/react-server/src/features/server-component/utils.tsx
@@ -16,6 +16,7 @@ export function wrapStreamRequestUrl(
   const newUrl = new URL(url, window.location.href);
   newUrl.pathname = posixJoin(newUrl.pathname, RSC_PATH);
   // TODO: remove params on prerendered paths for better caching
+  // TODO: move it to request headers and ssr can return no-cache?
   newUrl.searchParams.set(RSC_PARAM, JSON.stringify(param));
   return newUrl.toString();
 }
@@ -24,7 +25,7 @@ export function unwrapStreamRequest(request: Request) {
   const url = new URL(request.url);
   const isStream = url.pathname.endsWith(RSC_PATH);
   if (!isStream) {
-    return { url, request };
+    return { url, request, isStream };
   }
   url.pathname = url.pathname.slice(0, -RSC_PATH.length) || "/";
   const rawParam = url.searchParams.get(RSC_PARAM);

--- a/packages/react-server/src/features/server-component/utils.tsx
+++ b/packages/react-server/src/features/server-component/utils.tsx
@@ -1,8 +1,6 @@
 // encode flight request as path for the ease of ssg deployment
 export const RSC_PATH = "__f.data";
-const RSC_PARAM = "__f";
-
-const FLIGHT_META = "x-flight-meta";
+const RSC_PARAM = "x-flight-meta";
 
 type StreamRequestParam = {
   actionId?: string;
@@ -11,24 +9,12 @@ type StreamRequestParam = {
   revalidate?: boolean;
 };
 
-export function wrapStreamRequestUrl(
-  url: string,
-  param: StreamRequestParam,
-): string {
-  const newUrl = new URL(url, window.location.href);
-  newUrl.pathname = posixJoin(newUrl.pathname, RSC_PATH);
-  // TODO: remove params on prerendered paths for better caching
-  // TODO: move it to request headers and ssr can return no-cache?
-  newUrl.searchParams.set(RSC_PARAM, JSON.stringify(param));
-  return newUrl.toString();
-}
-
 export function createStreamRequest(href: string, param: StreamRequestParam) {
   const url = new URL(href, window.location.href);
   url.pathname = posixJoin(url.pathname, RSC_PATH);
   return new Request(url, {
     headers: {
-      [FLIGHT_META]: JSON.stringify(param),
+      [RSC_PARAM]: JSON.stringify(param),
     },
   });
 }
@@ -41,7 +27,7 @@ export function unwrapStreamRequest(request: Request) {
   }
   url.pathname = url.pathname.slice(0, -RSC_PATH.length) || "/";
   const headers = new Headers(request.headers);
-  const rawParam = headers.get(FLIGHT_META);
+  const rawParam = headers.get(RSC_PARAM);
   headers.delete(RSC_PARAM);
 
   return {


### PR DESCRIPTION
This prevents unnecessary cache miss for prerendered flight response.