### PR TITLE
fix: tweak prerender output

### DIFF
--- a/packages/react-server/examples/prerender/README.md
+++ b/packages/react-server/examples/prerender/README.md
@@ -1,5 +1,8 @@
 # react-server prerender
 
+- https://demo-rsc-prerender.vercel.app
+- https://demo-rsc-prerender.pages.dev
+
 ```sh
 pnpm i
 pnpm dev

--- a/packages/react-server/examples/prerender/misc/cf/build.mjs
+++ b/packages/react-server/examples/prerender/misc/cf/build.mjs
@@ -3,31 +3,13 @@ import path from "node:path";
 
 async function main() {
   const distDir = path.join(import.meta.dirname, "dist/client");
-  const files = await fs.promises.readdir(distDir, {
-    recursive: true,
-    withFileTypes: true,
-  });
-  const prerendered = [];
-  for (const f of files) {
-    if (f.isFile() && f.name === "index.html") {
-      const pathname = f.path.slice(distDir.length) || "/";
-      prerendered.push(pathname);
-
-      // rename /hello/index.html -> /hello.html
-      // TODO: probably the default prerender output should follow this
-      if (f.path !== distDir) {
-        await fs.promises.rename(
-          path.join(f.path, "index.html"),
-          f.path + ".html",
-        );
-      }
-    }
-  }
+  const entries = JSON.parse(
+    fs.readFileSync(path.join(distDir, "__prerender.json"), "utf-8"),
+  );
   const exclude = [
     "/favicon.ico",
     "/assets/*",
-    ...prerendered,
-    ...prerendered.map((p) => path.join(p, "__f.data")),
+    ...entries.flatMap((e) => [e.route, e.data]),
   ];
   const routesJson = {
     version: 1,

--- a/packages/react-server/examples/prerender/src/routes/layout.tsx
+++ b/packages/react-server/examples/prerender/src/routes/layout.tsx
@@ -21,13 +21,19 @@ export default function Layout(props: React.PropsWithChildren) {
         <nav>
           <ul>
             <li>
-              <Link href="/">Home</Link>
+              <Link href="/" preload>
+                Home
+              </Link>
             </li>
             <li>
-              <Link href="/counter">Counter</Link>
+              <Link href="/counter" preload>
+                Counter
+              </Link>
             </li>
             <li>
-              <Link href="/posts">Posts</Link>
+              <Link href="/posts" preload>
+                Posts
+              </Link>
             </li>
           </ul>
         </nav>

--- a/packages/react-server/src/features/prerender/plugin.ts
+++ b/packages/react-server/src/features/prerender/plugin.ts
@@ -1,0 +1,72 @@
+import fs from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { Readable } from "node:stream";
+import type { Plugin } from "vite";
+import type { PluginStateManager } from "../../plugin";
+import { RSC_PATH } from "../server-component/utils";
+
+export function prerenderPlugin(options: {
+  manager: PluginStateManager;
+  prerender?: () => Promise<string[]> | string[];
+}): Plugin[] {
+  return [
+    {
+      name: prerenderPlugin + ":build",
+      enforce: "post",
+      async closeBundle() {
+        if (options?.prerender && options.manager.buildType === "ssr") {
+          console.log("▶▶▶ PRERENDER");
+          const routes = await options.prerender();
+          const entry: typeof import("../../entry/server") = await import(
+            path.resolve("dist/server/__entry_prerender.js")
+          );
+          const entries = Array<{
+            route: string;
+            html: string;
+            data: string;
+          }>();
+          for (const route of routes) {
+            console.log(`  • ${route}`);
+            const url = new URL(route, "https://prerender.local");
+            const request = new Request(url);
+            const { stream, html } = await entry.prerender(request);
+            const data = Readable.from(stream as any);
+            const htmlFile =
+              route + (route.endsWith("/") ? "index.html" : ".html");
+            const dataFile = route + RSC_PATH;
+            await mkdir(path.dirname(path.join("dist/client", htmlFile)), {
+              recursive: true,
+            });
+            await writeFile(path.join("dist/client", htmlFile), html);
+            await writeFile(path.join("dist/client", dataFile), data);
+            entries.push({
+              route,
+              html: htmlFile,
+              data: dataFile,
+            });
+          }
+          await writeFile(
+            "dist/client/__prerender.json",
+            JSON.stringify(entries, null, 2),
+          );
+        }
+      },
+    },
+    {
+      name: prerenderPlugin + ":preview",
+      apply: (_config, env) => !!(options?.prerender && env.isPreview),
+      configurePreviewServer(server) {
+        const outDir = server.config.build.outDir;
+        server.middlewares.use((req, _res, next) => {
+          // rewrite `/abc` to `/abc.html` since Vite "mpa" mode doesn't support this
+          const url = new URL(req.url!, "https://test.local");
+          if (fs.existsSync(path.join(outDir, url.pathname + ".html"))) {
+            req.url = path.posix.join(url.pathname + ".html");
+          }
+          next();
+        });
+      },
+    },
+  ];
+}

--- a/packages/react-server/src/features/prerender/plugin.ts
+++ b/packages/react-server/src/features/prerender/plugin.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { Readable } from "node:stream";
+import { tinyassert } from "@hiogawa/utils";
 import type { Plugin } from "vite";
 import type { PluginStateManager } from "../../plugin";
 import { RSC_PATH } from "../server-component/utils";
@@ -14,43 +15,44 @@ export function prerenderPlugin(options: {
     {
       name: prerenderPlugin + ":build",
       enforce: "post",
+      apply: () =>
+        !!(options?.prerender && options.manager.buildType === "ssr"),
       async closeBundle() {
-        if (options?.prerender && options.manager.buildType === "ssr") {
-          console.log("▶▶▶ PRERENDER");
-          const routes = await options.prerender();
-          const entry: typeof import("../../entry/server") = await import(
-            path.resolve("dist/server/__entry_prerender.js")
-          );
-          const entries = Array<{
-            route: string;
-            html: string;
-            data: string;
-          }>();
-          for (const route of routes) {
-            console.log(`  • ${route}`);
-            const url = new URL(route, "https://prerender.local");
-            const request = new Request(url);
-            const { stream, html } = await entry.prerender(request);
-            const data = Readable.from(stream as any);
-            const htmlFile =
-              route + (route.endsWith("/") ? "index.html" : ".html");
-            const dataFile = route + RSC_PATH;
-            await mkdir(path.dirname(path.join("dist/client", htmlFile)), {
-              recursive: true,
-            });
-            await writeFile(path.join("dist/client", htmlFile), html);
-            await writeFile(path.join("dist/client", dataFile), data);
-            entries.push({
-              route,
-              html: htmlFile,
-              data: dataFile,
-            });
-          }
-          await writeFile(
-            "dist/client/__prerender.json",
-            JSON.stringify(entries, null, 2),
-          );
+        console.log("▶▶▶ PRERENDER");
+        tinyassert(options.prerender);
+        const routes = await options.prerender();
+        const entry: typeof import("../../entry/server") = await import(
+          path.resolve("dist/server/__entry_prerender.js")
+        );
+        const entries = Array<{
+          route: string;
+          html: string;
+          data: string;
+        }>();
+        for (const route of routes) {
+          console.log(`  • ${route}`);
+          const url = new URL(route, "https://prerender.local");
+          const request = new Request(url);
+          const { stream, html } = await entry.prerender(request);
+          const data = Readable.from(stream as any);
+          const htmlFile =
+            route + (route.endsWith("/") ? "index.html" : ".html");
+          const dataFile = route + RSC_PATH;
+          await mkdir(path.dirname(path.join("dist/client", htmlFile)), {
+            recursive: true,
+          });
+          await writeFile(path.join("dist/client", htmlFile), html);
+          await writeFile(path.join("dist/client", dataFile), data);
+          entries.push({
+            route,
+            html: htmlFile,
+            data: dataFile,
+          });
         }
+        await writeFile(
+          "dist/client/__prerender.json",
+          JSON.stringify(entries, null, 2),
+        );
       },
     },
     {

--- a/packages/react-server/src/features/server-component/utils.tsx
+++ b/packages/react-server/src/features/server-component/utils.tsx
@@ -11,7 +11,7 @@ type StreamRequestParam = {
 
 export function createStreamRequest(href: string, param: StreamRequestParam) {
   const url = new URL(href, window.location.href);
-  url.pathname = posixJoin(url.pathname, RSC_PATH);
+  url.pathname += RSC_PATH;
   return new Request(url, {
     headers: {
       [RSC_PARAM]: JSON.stringify(param),
@@ -25,7 +25,7 @@ export function unwrapStreamRequest(request: Request) {
   if (!isStream) {
     return { url, request, isStream };
   }
-  url.pathname = url.pathname.slice(0, -RSC_PATH.length) || "/";
+  url.pathname = url.pathname.slice(0, -RSC_PATH.length);
   const headers = new Headers(request.headers);
   const rawParam = headers.get(RSC_PARAM);
   headers.delete(RSC_PARAM);
@@ -44,12 +44,4 @@ export function unwrapStreamRequest(request: Request) {
       ? (JSON.parse(rawParam) as StreamRequestParam)
       : undefined,
   };
-}
-
-// posixJoin("/", "new") === "/new"
-// posixJoin("/", "/new") === "/new"
-// posixJoin("/xyz", "new") === "/xyz/new"
-// posixJoin("/xyz", "/new") === "/xyz/new"
-function posixJoin(...args: string[]) {
-  return args.join("/").replace(/\/\/+/g, "/");
 }

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -349,8 +349,11 @@ export function vitePluginReactServer(options?: {
             const request = new Request(url);
             const { stream, html } = await entry.prerender(request);
             const data = Readable.from(stream as any);
-            const htmlFile = path.join("dist/client", route, "index.html");
-            const dataFile = path.join("dist/client", route, RSC_PATH);
+            const htmlFile = path.join(
+              "dist/client",
+              route.endsWith("/") ? route + "/index.html" : route + ".html",
+            );
+            const dataFile = path.join("dist/client", route + RSC_PATH);
             await fs.promises.mkdir(path.dirname(htmlFile), {
               recursive: true,
             });
@@ -368,10 +371,10 @@ export function vitePluginReactServer(options?: {
     configurePreviewServer(server) {
       const outDir = server.config.build.outDir;
       server.middlewares.use((req, _res, next) => {
-        // rewrite to serve `index.html` in MPA style
+        // rewrite `/abc` to `/abc.html` since Vite "mpa" mode doesn't support this
         const url = new URL(req.url!, "https://test.local");
-        if (fs.existsSync(path.join(outDir, url.pathname, "index.html"))) {
-          req.url = path.posix.join(url.pathname, "index.html");
+        if (fs.existsSync(path.join(outDir, url.pathname + ".html"))) {
+          req.url = path.posix.join(url.pathname + ".html");
         }
         next();
       });


### PR DESCRIPTION
Tweaking this again since Cloudflare Pages only matches `/abc` to `/abc/index.html` (cf. https://github.com/hi-ogawa/vite-plugins/pull/375).

```
# before
/posts/index.html
/posts/__f.data

# after
/posts.html
/posts__f.data
```