### PR TITLE
fix: partial support of server-client-mixed package + chore: add react-tweet demo

### DIFF
--- a/packages/react-server/examples/basic/deps/mixed/README.md
+++ b/packages/react-server/examples/basic/deps/mixed/README.md
@@ -1,0 +1,1 @@
+fixture package to test the same package structure as https://github.com/vercel/react-tweet

--- a/packages/react-server/examples/basic/deps/mixed/client.js
+++ b/packages/react-server/examples/basic/deps/mixed/client.js
@@ -1,0 +1,13 @@
+"use client";
+
+import React from "react";
+
+export function TestClient() {
+  const [count, setCount] = React.useState(0);
+
+  return React.createElement(
+    "button",
+    { onClick: () => setCount((v) => v + 1) },
+    "TestDepMixed(Client): " + count,
+  );
+}

--- a/packages/react-server/examples/basic/deps/mixed/index.d.ts
+++ b/packages/react-server/examples/basic/deps/mixed/index.d.ts
@@ -1,0 +1,3 @@
+declare function TestDepMixed(): Promise<JSX.Element>;
+
+export { TestDepMixed };

--- a/packages/react-server/examples/basic/deps/mixed/index.js
+++ b/packages/react-server/examples/basic/deps/mixed/index.js
@@ -1,0 +1,17 @@
+import React from "react";
+import { TestClient } from "./client.js";
+
+export function TestDepMixed() {
+  return React.createElement(
+    React.Fragment,
+    null,
+    React.createElement(TestServer, null),
+    " ",
+    React.createElement(TestClient, null),
+  );
+}
+
+async function TestServer() {
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  return React.createElement("span", null, "TestDepMixed(Server)");
+}

--- a/packages/react-server/examples/basic/deps/mixed/package.json
+++ b/packages/react-server/examples/basic/deps/mixed/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@hiogawa/test-deps-use-client",
+  "name": "@hiogawa/test-deps-mixed",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/react-server/examples/basic/deps/server-component/package.json
+++ b/packages/react-server/examples/basic/deps/server-component/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@hiogawa/test-dep-use-client",
+  "name": "@hiogawa/test-deps-server-component",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -821,6 +821,13 @@ test("server compnoent > fixture", async ({ page }) => {
   await page.getByText("TestDepServerComponent").click();
 });
 
+test("server-client-mixed package", async ({ page }) => {
+  await page.goto("/test/deps");
+  await page.getByText("TestDepMixed(Server)").click();
+  await page.getByRole("button", { name: "TestDepMixed(Client): 0" }).click();
+  await page.getByRole("button", { name: "TestDepMixed(Client): 1" }).click();
+});
+
 test("client module used at boundary and non-boundary basic", async ({
   page,
 }) => {

--- a/packages/react-server/examples/basic/package.json
+++ b/packages/react-server/examples/basic/package.json
@@ -24,6 +24,7 @@
     "react": "rc",
     "react-dom": "rc",
     "react-server-dom-webpack": "rc",
+    "react-tweet": "^3.2.1",
     "react-wrap-balancer": "^1.1.0",
     "styled-jsx": "^5.1.6"
   },

--- a/packages/react-server/examples/basic/package.json
+++ b/packages/react-server/examples/basic/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@hiogawa/react-server": "latest",
+    "@hiogawa/test-dep-mixed": "file:deps/mixed",
     "@hiogawa/test-dep-server-component": "file:deps/server-component",
     "@hiogawa/test-dep-use-client": "file:deps/use-client",
     "react": "rc",

--- a/packages/react-server/examples/basic/src/routes/test/deps/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/deps/layout.tsx
@@ -1,0 +1,12 @@
+import type { LayoutProps } from "@hiogawa/react-server/server";
+import { NavMenu } from "../../../components/nav-menu";
+
+export default function Layout(props: LayoutProps) {
+  return (
+    <div className="flex flex-col gap-2 p-2">
+      <h4 className="font-bold">Test Dependencies</h4>
+      <NavMenu links={["/test/deps", "/test/deps/react-tweet"]} />
+      {props.children}
+    </div>
+  );
+}

--- a/packages/react-server/examples/basic/src/routes/test/deps/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/deps/page.tsx
@@ -11,7 +11,6 @@ import { Client2Provider } from "./_client2";
 export default function Page() {
   return (
     <div className="flex flex-col items-start gap-2">
-      <h4 className="font-bold">Test Dependencies</h4>
       <div>
         <TestVirtualUseClient />
       </div>

--- a/packages/react-server/examples/basic/src/routes/test/deps/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/deps/page.tsx
@@ -1,4 +1,5 @@
 import { TestVirtualUseClient } from "virtual:test-use-client";
+import { TestDepMixed } from "@hiogawa/test-dep-mixed";
 import { TestDepServerComponent } from "@hiogawa/test-dep-server-component";
 import { TestDepUseClient } from "@hiogawa/test-dep-use-client";
 import {
@@ -19,6 +20,9 @@ export default function Page() {
       </div>
       <div>
         <TestDepServerComponent />
+      </div>
+      <div>
+        <TestDepMixed />
       </div>
       <div>
         <Client2Provider>

--- a/packages/react-server/examples/basic/src/routes/test/deps/react-tweet/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/deps/react-tweet/page.tsx
@@ -10,7 +10,7 @@ export default function Page() {
       >
         vercel/react-tweet
       </a>
-      <Tweet id="1768090382670463440" />
+      <Tweet id="1725168756454785119" />
     </div>
   );
 }

--- a/packages/react-server/examples/basic/src/routes/test/deps/react-tweet/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/deps/react-tweet/page.tsx
@@ -1,0 +1,16 @@
+import { Tweet } from "react-tweet";
+
+export default function Page() {
+  return (
+    <div className="flex flex-col items-start">
+      <a
+        className="text-lg font-bold antd-link"
+        href="https://github.com/vercel/react-tweet"
+        target="_blank"
+      >
+        vercel/react-tweet
+      </a>
+      <Tweet id="1768090382670463440" />
+    </div>
+  );
+}

--- a/packages/react-server/examples/basic/vite.config.ts
+++ b/packages/react-server/examples/basic/vite.config.ts
@@ -59,11 +59,14 @@ export default defineConfig({
     testVitePluginVirtual(),
   ],
   ssr: {
-    // needs to inline react-wrap-balancer since its default export
-    // is not recognized by NodeJS. See:
-    //   node -e 'import("react-wrap-balancer").then(console.log)'
-    //   https://publint.dev/react-wrap-balancer@1.1.0
-    noExternal: ["react-wrap-balancer"],
+    noExternal: [
+      // bad default export. try
+      //   node -e 'import("react-wrap-balancer").then(console.log)'
+      //   https://publint.dev/react-wrap-balancer@1.1.0
+      "react-wrap-balancer",
+      // css import
+      "react-tweet",
+    ],
   },
 });
 

--- a/packages/react-server/examples/basic/vite.config.ts
+++ b/packages/react-server/examples/basic/vite.config.ts
@@ -60,7 +60,7 @@ export default defineConfig({
   ],
   ssr: {
     noExternal: [
-      // bad default export. try
+      // cjs default export. try
       //   node -e 'import("react-wrap-balancer").then(console.log)'
       //   https://publint.dev/react-wrap-balancer@1.1.0
       "react-wrap-balancer",

--- a/packages/react-server/src/features/client-component/plugin.ts
+++ b/packages/react-server/src/features/client-component/plugin.ts
@@ -131,7 +131,6 @@ export function vitePluginServerUseClient({
       // when using external library's server component includes client reference,
       // it will end up here with deps optimization hash `?v=` resolved by server module graph.
       if (!manager.buildType && id.includes("?v=")) {
-        console.error("[useClientPlugin]", { id });
         id = id.split("?v=")[0]!;
       }
       manager.serverIds.add(id);

--- a/packages/react-server/src/features/client-component/plugin.ts
+++ b/packages/react-server/src/features/client-component/plugin.ts
@@ -128,6 +128,12 @@ export function vitePluginServerUseClient({
   const useClientPlugin: Plugin = {
     name: vitePluginServerUseClient.name,
     async transform(code, id, _options) {
+      // when using external library's server component includes client reference,
+      // it will end up here with deps optimization hash `?v=` resolved by server module graph.
+      if (!manager.buildType && id.includes("?v=")) {
+        console.error("[useClientPlugin]", { id });
+        id = id.split("?v=")[0]!;
+      }
       manager.serverIds.add(id);
       manager.clientReferenceMap.delete(id);
       if (!code.includes(USE_CLIENT)) {

--- a/packages/react-server/src/features/client-component/plugin.ts
+++ b/packages/react-server/src/features/client-component/plugin.ts
@@ -130,6 +130,8 @@ export function vitePluginServerUseClient({
     async transform(code, id, _options) {
       // when using external library's server component includes client reference,
       // it will end up here with deps optimization hash `?v=` resolved by server module graph.
+      // this is not entirely free from double module issue,
+      // but it allows handling simple server-client-mixed package such as react-tweet.
       if (!manager.buildType && id.includes("?v=")) {
         id = id.split("?v=")[0]!;
       }

--- a/packages/react-server/src/features/client-component/plugin.ts
+++ b/packages/react-server/src/features/client-component/plugin.ts
@@ -132,6 +132,7 @@ export function vitePluginServerUseClient({
       // it will end up here with deps optimization hash `?v=` resolved by server module graph.
       // this is not entirely free from double module issue,
       // but it allows handling simple server-client-mixed package such as react-tweet.
+      // cf. https://github.com/hi-ogawa/vite-plugins/issues/379
       if (!manager.buildType && id.includes("?v=")) {
         id = id.split("?v=")[0]!;
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ importers:
         version: 4.3.1(vite@5.3.3(@types/node@20.14.10)(terser@5.31.1))
       '@vitejs/plugin-react-swc':
         specifier: ^3.7.0
-        version: 3.7.0(vite@5.3.3(@types/node@20.14.10)(terser@5.31.1))
+        version: 3.7.0(@swc/helpers@0.5.12)(vite@5.3.3(@types/node@20.14.10)(terser@5.31.1))
       esbuild:
         specifier: ^0.23.0
         version: 0.23.0
@@ -58,10 +58,10 @@ importers:
         version: 19.0.0-rc-df5f2736-20240712
       react-server-dom-webpack:
         specifier: 19.0.0-rc-df5f2736-20240712
-        version: 19.0.0-rc-df5f2736-20240712(react-dom@19.0.0-rc-df5f2736-20240712(react@19.0.0-rc-df5f2736-20240712))(react@19.0.0-rc-df5f2736-20240712)(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.23.0))
+        version: 19.0.0-rc-df5f2736-20240712(react-dom@19.0.0-rc-df5f2736-20240712(react@19.0.0-rc-df5f2736-20240712))(react@19.0.0-rc-df5f2736-20240712)(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.12))(esbuild@0.23.0))
       tsup:
         specifier: ^8.1.0
-        version: 8.1.0(@swc/core@1.6.13)(postcss@8.4.39)(typescript@5.5.3)
+        version: 8.1.0(@swc/core@1.6.13(@swc/helpers@0.5.12))(postcss@8.4.39)(typescript@5.5.3)
       tsx:
         specifier: ^4.16.2
         version: 4.16.2
@@ -118,7 +118,7 @@ importers:
         version: 19.0.0-rc-df5f2736-20240712(react@19.0.0-rc-df5f2736-20240712)
       react-server-dom-webpack:
         specifier: 19.0.0-rc-df5f2736-20240712
-        version: 19.0.0-rc-df5f2736-20240712(react-dom@19.0.0-rc-df5f2736-20240712(react@19.0.0-rc-df5f2736-20240712))(react@19.0.0-rc-df5f2736-20240712)(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.23.0))
+        version: 19.0.0-rc-df5f2736-20240712(react-dom@19.0.0-rc-df5f2736-20240712(react@19.0.0-rc-df5f2736-20240712))(react@19.0.0-rc-df5f2736-20240712)(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.12))(esbuild@0.23.0))
       vite:
         specifier: ^5.3.3
         version: 5.3.3(@types/node@20.14.10)(terser@5.31.1)
@@ -137,7 +137,7 @@ importers:
         version: link:../vite-plugin-ssr-middleware
       '@vitejs/plugin-react-swc':
         specifier: ^3.7.0
-        version: 3.7.0(vite@5.3.3(@types/node@20.14.10)(terser@5.31.1))
+        version: 3.7.0(@swc/helpers@0.5.12)(vite@5.3.3(@types/node@20.14.10)(terser@5.31.1))
       esbuild:
         specifier: ^0.20.2
         version: 0.20.2
@@ -180,7 +180,10 @@ importers:
         version: 19.0.0-rc-df5f2736-20240712(react@19.0.0-rc-df5f2736-20240712)
       react-server-dom-webpack:
         specifier: 19.0.0-rc-df5f2736-20240712
-        version: 19.0.0-rc-df5f2736-20240712(react-dom@19.0.0-rc-df5f2736-20240712(react@19.0.0-rc-df5f2736-20240712))(react@19.0.0-rc-df5f2736-20240712)(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.23.0))
+        version: 19.0.0-rc-df5f2736-20240712(react-dom@19.0.0-rc-df5f2736-20240712(react@19.0.0-rc-df5f2736-20240712))(react@19.0.0-rc-df5f2736-20240712)(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.12))(esbuild@0.23.0))
+      react-tweet:
+        specifier: ^3.2.1
+        version: 3.2.1(react-dom@19.0.0-rc-df5f2736-20240712(react@19.0.0-rc-df5f2736-20240712))(react@19.0.0-rc-df5f2736-20240712)
       react-wrap-balancer:
         specifier: ^1.1.0
         version: 1.1.0(react@19.0.0-rc-df5f2736-20240712)
@@ -244,7 +247,7 @@ importers:
         version: 19.0.0-rc-df5f2736-20240712(react@19.0.0-rc-df5f2736-20240712)
       react-server-dom-webpack:
         specifier: 19.0.0-rc-df5f2736-20240712
-        version: 19.0.0-rc-df5f2736-20240712(react-dom@19.0.0-rc-df5f2736-20240712(react@19.0.0-rc-df5f2736-20240712))(react@19.0.0-rc-df5f2736-20240712)(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.23.0))
+        version: 19.0.0-rc-df5f2736-20240712(react-dom@19.0.0-rc-df5f2736-20240712(react@19.0.0-rc-df5f2736-20240712))(react@19.0.0-rc-df5f2736-20240712)(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.12))(esbuild@0.23.0))
     devDependencies:
       '@types/react':
         specifier: 18.3.3
@@ -272,7 +275,7 @@ importers:
         version: 19.0.0-rc-df5f2736-20240712(react@19.0.0-rc-df5f2736-20240712)
       react-server-dom-webpack:
         specifier: 19.0.0-rc-df5f2736-20240712
-        version: 19.0.0-rc-df5f2736-20240712(react-dom@19.0.0-rc-df5f2736-20240712(react@19.0.0-rc-df5f2736-20240712))(react@19.0.0-rc-df5f2736-20240712)(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.23.0))
+        version: 19.0.0-rc-df5f2736-20240712(react-dom@19.0.0-rc-df5f2736-20240712(react@19.0.0-rc-df5f2736-20240712))(react@19.0.0-rc-df5f2736-20240712)(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.12))(esbuild@0.23.0))
     devDependencies:
       '@playwright/test':
         specifier: ^1.45.1
@@ -300,7 +303,7 @@ importers:
         version: 19.0.0-rc-df5f2736-20240712(react@19.0.0-rc-df5f2736-20240712)
       react-server-dom-webpack:
         specifier: 19.0.0-rc-df5f2736-20240712
-        version: 19.0.0-rc-df5f2736-20240712(react-dom@19.0.0-rc-df5f2736-20240712(react@19.0.0-rc-df5f2736-20240712))(react@19.0.0-rc-df5f2736-20240712)(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.23.0))
+        version: 19.0.0-rc-df5f2736-20240712(react-dom@19.0.0-rc-df5f2736-20240712(react@19.0.0-rc-df5f2736-20240712))(react@19.0.0-rc-df5f2736-20240712)(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.12))(esbuild@0.23.0))
     devDependencies:
       '@hiogawa/utils-node':
         specifier: ^0.0.1
@@ -337,7 +340,7 @@ importers:
         version: 19.0.0-rc-df5f2736-20240712(react@19.0.0-rc-df5f2736-20240712)
       react-server-dom-webpack:
         specifier: 19.0.0-rc-df5f2736-20240712
-        version: 19.0.0-rc-df5f2736-20240712(react-dom@19.0.0-rc-df5f2736-20240712(react@19.0.0-rc-df5f2736-20240712))(react@19.0.0-rc-df5f2736-20240712)(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.23.0))
+        version: 19.0.0-rc-df5f2736-20240712(react-dom@19.0.0-rc-df5f2736-20240712(react@19.0.0-rc-df5f2736-20240712))(react@19.0.0-rc-df5f2736-20240712)(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.12))(esbuild@0.23.0))
     devDependencies:
       '@hiogawa/utils-node':
         specifier: latest
@@ -2352,6 +2355,9 @@ packages:
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
+  '@swc/helpers@0.5.12':
+    resolution: {integrity: sha512-KMZNXiGibsW9kvZAO1Pam2JPTDBm+KSHMMHWdsyI/1DbIZjT2A6Gy3hblVXUMEDvUAKq+e0vL0X0o54owWji7g==}
+
   '@swc/types@0.1.9':
     resolution: {integrity: sha512-qKnCno++jzcJ4lM4NTfYifm1EFSCeIfKiAHAfkENZAV5Kl9PjJIyd2yeeVv6c/2CckuLyv2NmRC5pv6pm2WQBg==}
 
@@ -2936,6 +2942,10 @@ packages:
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
@@ -4455,6 +4465,12 @@ packages:
       react-dom: 19.0.0-rc-df5f2736-20240712
       webpack: ^5.59.0
 
+  react-tweet@3.2.1:
+    resolution: {integrity: sha512-dktP3RMuwRB4pnSDocKpSsW5Hq1IXRW6fONkHhxT5EBIXsKZzdQuI70qtub1XN2dtZdkJWWxfBm/Q+kN+vRYFA==}
+    peerDependencies:
+      react: 19.0.0-rc-df5f2736-20240712
+      react-dom: 19.0.0-rc-df5f2736-20240712
+
   react-wrap-balancer@1.1.0:
     resolution: {integrity: sha512-EhF3jOZm5Fjx+Cx41e423qOv2c2aOvXAtym2OHqrGeMUnwERIyNsRBgnfT3plB170JmuYvts8K2KSPEIerKr5A==}
     peerDependencies:
@@ -4780,6 +4796,11 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  swr@2.2.5:
+    resolution: {integrity: sha512-QtxqyclFeAsxEUeZIYmsaQ0UjimSq1RZ9Un7I68/0ClKK/U3LoyQunwkQfJZr2fc22DfIXLNDc2wFyTEikCUpg==}
+    peerDependencies:
+      react: 19.0.0-rc-df5f2736-20240712
+
   tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
@@ -5027,6 +5048,11 @@ packages:
 
   urlpattern-polyfill@10.0.0:
     resolution: {integrity: sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==}
+
+  use-sync-external-store@1.2.2:
+    resolution: {integrity: sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==}
+    peerDependencies:
+      react: 19.0.0-rc-df5f2736-20240712
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -6571,7 +6597,7 @@ snapshots:
   '@swc/core-win32-x64-msvc@1.6.13':
     optional: true
 
-  '@swc/core@1.6.13':
+  '@swc/core@1.6.13(@swc/helpers@0.5.12)':
     dependencies:
       '@swc/counter': 0.1.3
       '@swc/types': 0.1.9
@@ -6586,8 +6612,13 @@ snapshots:
       '@swc/core-win32-arm64-msvc': 1.6.13
       '@swc/core-win32-ia32-msvc': 1.6.13
       '@swc/core-win32-x64-msvc': 1.6.13
+      '@swc/helpers': 0.5.12
 
   '@swc/counter@0.1.3': {}
+
+  '@swc/helpers@0.5.12':
+    dependencies:
+      tslib: 2.6.2
 
   '@swc/types@0.1.9':
     dependencies:
@@ -6942,9 +6973,9 @@ snapshots:
 
   '@vanilla-extract/private@1.0.3': {}
 
-  '@vitejs/plugin-react-swc@3.7.0(vite@5.3.3(@types/node@20.14.10)(terser@5.31.1))':
+  '@vitejs/plugin-react-swc@3.7.0(@swc/helpers@0.5.12)(vite@5.3.3(@types/node@20.14.10)(terser@5.31.1))':
     dependencies:
-      '@swc/core': 1.6.13
+      '@swc/core': 1.6.13(@swc/helpers@0.5.12)
       vite: 5.3.3(@types/node@20.14.10)(terser@5.31.1)
     transitivePeerDependencies:
       - '@swc/helpers'
@@ -7355,6 +7386,8 @@ snapshots:
   client-only@0.0.1: {}
 
   clone@1.0.4: {}
+
+  clsx@2.1.1: {}
 
   color-convert@1.9.3:
     dependencies:
@@ -9101,13 +9134,21 @@ snapshots:
       '@remix-run/router': 1.15.3
       react: 19.0.0-rc-df5f2736-20240712
 
-  react-server-dom-webpack@19.0.0-rc-df5f2736-20240712(react-dom@19.0.0-rc-df5f2736-20240712(react@19.0.0-rc-df5f2736-20240712))(react@19.0.0-rc-df5f2736-20240712)(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.23.0)):
+  react-server-dom-webpack@19.0.0-rc-df5f2736-20240712(react-dom@19.0.0-rc-df5f2736-20240712(react@19.0.0-rc-df5f2736-20240712))(react@19.0.0-rc-df5f2736-20240712)(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.12))(esbuild@0.23.0)):
     dependencies:
       acorn-loose: 8.4.0
       neo-async: 2.6.2
       react: 19.0.0-rc-df5f2736-20240712
       react-dom: 19.0.0-rc-df5f2736-20240712(react@19.0.0-rc-df5f2736-20240712)
-      webpack: 5.92.1(@swc/core@1.6.13)(esbuild@0.23.0)
+      webpack: 5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.12))(esbuild@0.23.0)
+
+  react-tweet@3.2.1(react-dom@19.0.0-rc-df5f2736-20240712(react@19.0.0-rc-df5f2736-20240712))(react@19.0.0-rc-df5f2736-20240712):
+    dependencies:
+      '@swc/helpers': 0.5.12
+      clsx: 2.1.1
+      react: 19.0.0-rc-df5f2736-20240712
+      react-dom: 19.0.0-rc-df5f2736-20240712(react@19.0.0-rc-df5f2736-20240712)
+      swr: 2.2.5(react@19.0.0-rc-df5f2736-20240712)
 
   react-wrap-balancer@1.1.0(react@19.0.0-rc-df5f2736-20240712):
     dependencies:
@@ -9472,6 +9513,12 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  swr@2.2.5(react@19.0.0-rc-df5f2736-20240712):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.0.0-rc-df5f2736-20240712
+      use-sync-external-store: 1.2.2(react@19.0.0-rc-df5f2736-20240712)
+
   tapable@2.2.1: {}
 
   tar-fs@2.1.1:
@@ -9498,16 +9545,16 @@ snapshots:
       mkdirp: 1.0.4
       yallist: 4.0.0
 
-  terser-webpack-plugin@5.3.10(@swc/core@1.6.13)(esbuild@0.23.0)(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.23.0)):
+  terser-webpack-plugin@5.3.10(@swc/core@1.6.13(@swc/helpers@0.5.12))(esbuild@0.23.0)(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.12))(esbuild@0.23.0)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
       terser: 5.31.1
-      webpack: 5.92.1(@swc/core@1.6.13)(esbuild@0.23.0)
+      webpack: 5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.12))(esbuild@0.23.0)
     optionalDependencies:
-      '@swc/core': 1.6.13
+      '@swc/core': 1.6.13(@swc/helpers@0.5.12)
       esbuild: 0.23.0
 
   terser@5.31.1:
@@ -9582,7 +9629,7 @@ snapshots:
 
   tslib@2.6.2: {}
 
-  tsup@8.1.0(@swc/core@1.6.13)(postcss@8.4.39)(typescript@5.5.3):
+  tsup@8.1.0(@swc/core@1.6.13(@swc/helpers@0.5.12))(postcss@8.4.39)(typescript@5.5.3):
     dependencies:
       bundle-require: 4.2.1(esbuild@0.21.5)
       cac: 6.7.14
@@ -9599,7 +9646,7 @@ snapshots:
       sucrase: 3.35.0
       tree-kill: 1.2.2
     optionalDependencies:
-      '@swc/core': 1.6.13
+      '@swc/core': 1.6.13(@swc/helpers@0.5.12)
       postcss: 8.4.39
       typescript: 5.5.3
     transitivePeerDependencies:
@@ -9756,6 +9803,10 @@ snapshots:
 
   urlpattern-polyfill@10.0.0: {}
 
+  use-sync-external-store@1.2.2(react@19.0.0-rc-df5f2736-20240712):
+    dependencies:
+      react: 19.0.0-rc-df5f2736-20240712
+
   util-deprecate@1.0.2: {}
 
   util@0.12.5:
@@ -9909,7 +9960,7 @@ snapshots:
 
   webpack-sources@3.2.3: {}
 
-  webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.23.0):
+  webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.12))(esbuild@0.23.0):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.5
@@ -9932,7 +9983,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(@swc/core@1.6.13)(esbuild@0.23.0)(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.23.0))
+      terser-webpack-plugin: 5.3.10(@swc/core@1.6.13(@swc/helpers@0.5.12))(esbuild@0.23.0)(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.12))(esbuild@0.23.0))
       watchpack: 2.4.1
       webpack-sources: 3.2.3
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,12 +166,15 @@ importers:
       '@hiogawa/react-server':
         specifier: latest
         version: link:../..
+      '@hiogawa/test-dep-mixed':
+        specifier: file:deps/mixed
+        version: '@hiogawa/test-deps-mixed@file:packages/react-server/examples/basic/deps/mixed(react@19.0.0-rc-df5f2736-20240712)'
       '@hiogawa/test-dep-server-component':
         specifier: file:deps/server-component
-        version: '@hiogawa/test-dep-use-client@file:packages/react-server/examples/basic/deps/server-component(react@19.0.0-rc-df5f2736-20240712)'
+        version: '@hiogawa/test-deps-server-component@file:packages/react-server/examples/basic/deps/server-component(react@19.0.0-rc-df5f2736-20240712)'
       '@hiogawa/test-dep-use-client':
         specifier: file:deps/use-client
-        version: file:packages/react-server/examples/basic/deps/use-client(react@19.0.0-rc-df5f2736-20240712)
+        version: '@hiogawa/test-deps-use-client@file:packages/react-server/examples/basic/deps/use-client(react@19.0.0-rc-df5f2736-20240712)'
       react:
         specifier: 19.0.0-rc-df5f2736-20240712
         version: 19.0.0-rc-df5f2736-20240712
@@ -1958,12 +1961,17 @@ packages:
       '@trpc/server':
         optional: true
 
-  '@hiogawa/test-dep-use-client@file:packages/react-server/examples/basic/deps/server-component':
+  '@hiogawa/test-deps-mixed@file:packages/react-server/examples/basic/deps/mixed':
+    resolution: {directory: packages/react-server/examples/basic/deps/mixed, type: directory}
+    peerDependencies:
+      react: 19.0.0-rc-df5f2736-20240712
+
+  '@hiogawa/test-deps-server-component@file:packages/react-server/examples/basic/deps/server-component':
     resolution: {directory: packages/react-server/examples/basic/deps/server-component, type: directory}
     peerDependencies:
       react: 19.0.0-rc-df5f2736-20240712
 
-  '@hiogawa/test-dep-use-client@file:packages/react-server/examples/basic/deps/use-client':
+  '@hiogawa/test-deps-use-client@file:packages/react-server/examples/basic/deps/use-client':
     resolution: {directory: packages/react-server/examples/basic/deps/use-client, type: directory}
     peerDependencies:
       react: 19.0.0-rc-df5f2736-20240712
@@ -6189,11 +6197,15 @@ snapshots:
 
   '@hiogawa/query-proxy@0.1.1-pre.3': {}
 
-  '@hiogawa/test-dep-use-client@file:packages/react-server/examples/basic/deps/server-component(react@19.0.0-rc-df5f2736-20240712)':
+  '@hiogawa/test-deps-mixed@file:packages/react-server/examples/basic/deps/mixed(react@19.0.0-rc-df5f2736-20240712)':
     dependencies:
       react: 19.0.0-rc-df5f2736-20240712
 
-  '@hiogawa/test-dep-use-client@file:packages/react-server/examples/basic/deps/use-client(react@19.0.0-rc-df5f2736-20240712)':
+  '@hiogawa/test-deps-server-component@file:packages/react-server/examples/basic/deps/server-component(react@19.0.0-rc-df5f2736-20240712)':
+    dependencies:
+      react: 19.0.0-rc-df5f2736-20240712
+
+  '@hiogawa/test-deps-use-client@file:packages/react-server/examples/basic/deps/use-client(react@19.0.0-rc-df5f2736-20240712)':
     dependencies:
       react: 19.0.0-rc-df5f2736-20240712
 


### PR DESCRIPTION
- related https://github.com/hi-ogawa/vite-plugins/issues/379

## todo

- [x] create a patch to make it an ideal external package
  - https://github.com/hi-ogawa/vite-plugins/pull/385
- [x] explore plugin level workaround
  - strip-off `?v=` (this still causes dual modules when client is imported from both server (no `?v=`) and client (with `?v=`)
  - pre-bundling?
- [ ] explore userland workaround
  - vendoring...?
  - package manager level workaround?
- [x] test
  - probably flaky to test react-tweet, so let's add fixture package to simulate the same.