### PR TITLE
fix: enforce no trailing slash

### DIFF
--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -1077,6 +1077,11 @@ test("preload client @build", async ({ page }) => {
   await expect(page.locator(`link[href="/${file}"]`)).toBeAttached();
 });
 
+test("trailing slash", async ({ request }) => {
+  const res = await request.get("/test/?hello", { maxRedirects: 0 });
+  expect([res.status(), res.headers()["location"]]).toEqual([308, "/test?hello"]);
+});
+
 function getClientManifest(): Manifest {
   return JSON.parse(
     fs.readFileSync("dist/client/.vite/manifest.json", "utf-8"),

--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -1079,7 +1079,10 @@ test("preload client @build", async ({ page }) => {
 
 test("trailing slash", async ({ request }) => {
   const res = await request.get("/test/?hello", { maxRedirects: 0 });
-  expect([res.status(), res.headers()["location"]]).toEqual([308, "/test?hello"]);
+  expect([res.status(), res.headers()["location"]]).toEqual([
+    308,
+    "/test?hello",
+  ]);
 });
 
 function getClientManifest(): Manifest {

--- a/packages/react-server/src/entry/react-server.tsx
+++ b/packages/react-server/src/entry/react-server.tsx
@@ -16,6 +16,7 @@ import {
   type ServerRouterData,
   createLayoutContentRequest,
   getNewLayoutContentKeys,
+  handleTrailingSlash,
 } from "../features/router/utils";
 import { runActionContext } from "../features/server-action/context";
 import {
@@ -61,6 +62,9 @@ export const handler: ReactServerHandler = async (ctx) => {
   if (import.meta.env.DEV) {
     serverReferenceImportPromiseCache.clear();
   }
+
+  const handled = handleTrailingSlash(new URL(ctx.request.url));
+  if (handled) return handled;
 
   // extract stream request details
   const { url, request, isStream, streamParam } = unwrapStreamRequest(

--- a/packages/react-server/src/features/router/__snapshots__/tree.test.ts.snap
+++ b/packages/react-server/src/features/router/__snapshots__/tree.test.ts.snap
@@ -201,41 +201,6 @@ exports[`createFsRouteTree > basic 5`] = `
 
 exports[`createFsRouteTree > basic 6`] = `
 {
-  "__pathname": "/test/",
-  "matches": [
-    {
-      "node": {
-        "layout": "/layout.tsx",
-        "page": "/page.tsx",
-      },
-      "params": {},
-      "prefix": "/",
-      "type": "layout",
-    },
-    {
-      "node": {
-        "layout": "/test/layout.tsx",
-        "page": "/test/page.tsx",
-      },
-      "params": {},
-      "prefix": "/test",
-      "type": "layout",
-    },
-    {
-      "node": {
-        "layout": "/test/layout.tsx",
-        "page": "/test/page.tsx",
-      },
-      "params": {},
-      "prefix": "/test",
-      "type": "page",
-    },
-  ],
-}
-`;
-
-exports[`createFsRouteTree > basic 7`] = `
-{
   "__pathname": "/test/other",
   "matches": [
     {
@@ -276,7 +241,7 @@ exports[`createFsRouteTree > basic 7`] = `
 }
 `;
 
-exports[`createFsRouteTree > basic 8`] = `
+exports[`createFsRouteTree > basic 7`] = `
 {
   "__pathname": "/test/not-found",
   "matches": [
@@ -314,7 +279,7 @@ exports[`createFsRouteTree > basic 8`] = `
 }
 `;
 
-exports[`createFsRouteTree > basic 9`] = `
+exports[`createFsRouteTree > basic 8`] = `
 {
   "__pathname": "/dynamic",
   "matches": [
@@ -349,7 +314,7 @@ exports[`createFsRouteTree > basic 9`] = `
 }
 `;
 
-exports[`createFsRouteTree > basic 10`] = `
+exports[`createFsRouteTree > basic 9`] = `
 {
   "__pathname": "/dynamic/static",
   "matches": [
@@ -391,7 +356,7 @@ exports[`createFsRouteTree > basic 10`] = `
 }
 `;
 
-exports[`createFsRouteTree > basic 11`] = `
+exports[`createFsRouteTree > basic 10`] = `
 {
   "__pathname": "/dynamic/abc",
   "matches": [
@@ -439,7 +404,7 @@ exports[`createFsRouteTree > basic 11`] = `
 }
 `;
 
-exports[`createFsRouteTree > basic 12`] = `
+exports[`createFsRouteTree > basic 11`] = `
 {
   "__pathname": "/dynamic/abc/def",
   "matches": [
@@ -498,7 +463,7 @@ exports[`createFsRouteTree > basic 12`] = `
 }
 `;
 
-exports[`createFsRouteTree > basic 13`] = `
+exports[`createFsRouteTree > basic 12`] = `
 {
   "__pathname": "/dynamic/%E2%9C%85",
   "matches": [
@@ -546,7 +511,7 @@ exports[`createFsRouteTree > basic 13`] = `
 }
 `;
 
-exports[`createFsRouteTree > basic 14`] = `
+exports[`createFsRouteTree > basic 13`] = `
 {
   "__pathname": "/dynamic/catchall",
   "matches": [
@@ -588,7 +553,7 @@ exports[`createFsRouteTree > basic 14`] = `
 }
 `;
 
-exports[`createFsRouteTree > basic 15`] = `
+exports[`createFsRouteTree > basic 14`] = `
 {
   "__pathname": "/dynamic/catchall/static",
   "matches": [
@@ -638,7 +603,7 @@ exports[`createFsRouteTree > basic 15`] = `
 }
 `;
 
-exports[`createFsRouteTree > basic 16`] = `
+exports[`createFsRouteTree > basic 15`] = `
 {
   "__pathname": "/dynamic/catchall/x",
   "matches": [
@@ -692,7 +657,7 @@ exports[`createFsRouteTree > basic 16`] = `
 }
 `;
 
-exports[`createFsRouteTree > basic 17`] = `
+exports[`createFsRouteTree > basic 16`] = `
 {
   "__pathname": "/dynamic/catchall/x/y",
   "matches": [
@@ -754,7 +719,7 @@ exports[`createFsRouteTree > basic 17`] = `
 }
 `;
 
-exports[`createFsRouteTree > basic 18`] = `
+exports[`createFsRouteTree > basic 17`] = `
 {
   "__pathname": "/dynamic/catchall/x/y/z",
   "matches": [

--- a/packages/react-server/src/features/router/tree.test.ts
+++ b/packages/react-server/src/features/router/tree.test.ts
@@ -40,7 +40,6 @@ describe(createFsRouteTree, () => {
       "/other",
       "/not-found",
       "/test",
-      "/test/",
       "/test/other",
       "/test/not-found",
       "/dynamic",

--- a/packages/react-server/src/features/router/tree.ts
+++ b/packages/react-server/src/features/router/tree.ts
@@ -1,5 +1,5 @@
 import { sortBy, tinyassert } from "@hiogawa/utils";
-import { getPathPrefixes, normalizePathname } from "./utils";
+import { getPathPrefixes } from "./utils";
 
 export interface BaseRouteEntry<T> {
   page?: T;
@@ -54,8 +54,6 @@ type MatchResult<T> = {
 };
 
 export function matchRouteTree<T>(tree: TreeNode<T>, pathname: string) {
-  // TODO: more uniform handling of trailing slash
-  pathname = normalizePathname(pathname);
   const prefixes = getPathPrefixes(pathname);
 
   let node = tree;

--- a/packages/react-server/src/features/router/utils.tsx
+++ b/packages/react-server/src/features/router/utils.tsx
@@ -60,7 +60,7 @@ export function getPathPrefixes(pathname: string) {
 }
 
 // strip trailing slash
-export function normalizePathname(pathname: string) {
+function normalizePathname(pathname: string) {
   return pathname.replaceAll(/\/*$/g, "") || "/";
 }
 

--- a/packages/react-server/src/features/router/utils.tsx
+++ b/packages/react-server/src/features/router/utils.tsx
@@ -59,14 +59,9 @@ export function getPathPrefixes(pathname: string) {
   return keys.map((_key, i) => keys.slice(0, i + 1).join("/") || "/");
 }
 
-// strip trailing slash
-function normalizePathname(pathname: string) {
-  return pathname.replaceAll(/\/*$/g, "") || "/";
-}
-
 // enforce no trailing slash for simplicity
 export function handleTrailingSlash(url: URL) {
-  const normalized = normalizePathname(url.pathname);
+  const normalized = url.pathname.replaceAll(/\/*$/g, "") || "/";
   if (normalized !== url.pathname) {
     return new Response(null, {
       status: 308,

--- a/packages/react-server/src/features/router/utils.tsx
+++ b/packages/react-server/src/features/router/utils.tsx
@@ -63,3 +63,18 @@ export function getPathPrefixes(pathname: string) {
 export function normalizePathname(pathname: string) {
   return pathname.replaceAll(/\/*$/g, "") || "/";
 }
+
+// enforce no trailing slash for simplicity
+export function handleTrailingSlash(url: URL) {
+  const normalized = normalizePathname(url.pathname);
+  if (normalized !== url.pathname) {
+    return new Response(null, {
+      status: 308,
+      headers: {
+        "x-handle-trailing-slash": "1",
+        location: normalized + url.search,
+      },
+    });
+  }
+  return;
+}


### PR DESCRIPTION
It doesn't seem worth it to consider trailing slash in down stream logic, so let's just enforce at the top level and assume no trailing slash.