### PR TITLE
feat: refine route data revalidation

### DIFF
--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -929,6 +929,48 @@ test("revalidate on navigation", async ({ page }) => {
   await checkClientState();
 });
 
+test("revalidate by path on action", async ({ page }) => {
+  checkNoError(page);
+
+  await page.goto("/test/revalidate/x");
+  await waitForHydration(page);
+  await page.pause();
+
+  const checkClientState = await setupCheckClientState(page);
+
+  const count = process.env.E2E_PREVIEW ? 1 : 1;
+  await page.getByText(`[effect: ${count}]`).click();
+  await page.getByText(`[effect-revalidate: ${count}]`).click();
+  await page
+    .getByRole("button", { name: 'action revalidate "/test/revalidate"' })
+    .click();
+  await page.getByText(`[effect: ${count}]`).click();
+  await page.getByText(`[effect-revalidate: ${count + 1}]`).click();
+
+  await checkClientState();
+});
+
+test("revalidate by path on navigation", async ({ page }) => {
+  checkNoError(page);
+
+  await page.goto("/test/revalidate/x");
+  await waitForHydration(page);
+  await page.pause();
+
+  const checkClientState = await setupCheckClientState(page);
+
+  const count = process.env.E2E_PREVIEW ? 1 : 1;
+  await page.getByText(`[effect: ${count}]`).click();
+  await page.getByText(`[effect-revalidate: ${count}]`).click();
+  await page
+    .getByRole("link", { name: 'link revalidate "/test/revalidate"' })
+    .click();
+  await page.getByText(`[effect: ${count}]`).click();
+  await page.getByText(`[effect-revalidate: ${count + 1}]`).click();
+
+  await checkClientState();
+});
+
 test("dynamic routes", async ({ page }) => {
   checkNoError(page);
 

--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -934,7 +934,6 @@ test("revalidate by path on action", async ({ page }) => {
 
   await page.goto("/test/revalidate/x");
   await waitForHydration(page);
-  await page.pause();
 
   const checkClientState = await setupCheckClientState(page);
 
@@ -955,7 +954,6 @@ test("revalidate by path on navigation", async ({ page }) => {
 
   await page.goto("/test/revalidate/x");
   await waitForHydration(page);
-  await page.pause();
 
   const checkClientState = await setupCheckClientState(page);
 

--- a/packages/react-server/examples/basic/src/routes/test/_client.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/_client.tsx
@@ -9,7 +9,7 @@ export function Hydrated() {
 
 // test client re-rendering
 // https://github.com/pmndrs/jotai/blob/419ab5cda3503e70463dc340076e21e438db89b6/tests/react/basic.test.tsx#L27-L33
-export function EffectCount() {
+export function EffectCount({ label = "effect" }: { label?: string }) {
   const elRef = React.useRef<HTMLElement>(null);
   const countRef = React.useRef(0);
 
@@ -21,7 +21,7 @@ export function EffectCount() {
 
   return (
     <div>
-      [effect: <span ref={elRef}>0</span>]
+      [{label}: <span ref={elRef}>0</span>]
     </div>
   );
 }

--- a/packages/react-server/examples/basic/src/routes/test/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/layout.tsx
@@ -30,6 +30,7 @@ export default async function Layout(props: LayoutProps) {
         <input className="antd-input px-2" placeholder="test-input" />
         <Hydrated />
         <EffectCount />
+        <div>[now: {Date.now()}]</div>
       </div>
       {props.children}
     </div>

--- a/packages/react-server/examples/basic/src/routes/test/revalidate/[id]/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/revalidate/[id]/page.tsx
@@ -1,0 +1,9 @@
+import type { PageProps } from "@hiogawa/react-server/server";
+
+export default function Page(props: PageProps) {
+  return (
+    <div>
+      <pre>params = {JSON.stringify(props.params)}</pre>
+    </div>
+  );
+}

--- a/packages/react-server/examples/basic/src/routes/test/revalidate/[id]/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/revalidate/[id]/page.tsx
@@ -1,6 +1,8 @@
+import { Link } from "@hiogawa/react-server/client";
 import { type PageProps, useActionContext } from "@hiogawa/react-server/server";
 
 export default function Page(props: PageProps) {
+  props.params.id === "x" ? "y" : "x";
   return (
     <div className="flex flex-col gap-2">
       <pre>params = {JSON.stringify(props.params)}</pre>
@@ -12,9 +14,18 @@ export default function Page(props: PageProps) {
         className="flex flex-col gap-2"
       >
         <button className="antd-btn antd-btn-default px-2 self-start">
-          revalidate "/test/revalidate"
+          action revalidate "/test/revalidate"
         </button>
       </form>
+      <div className="flex flex-col gap-2">
+        <Link
+          className="antd-btn antd-btn-default px-2 self-start"
+          href={`/test/revalidate/${props.params.id === "x" ? "y" : "x"}`}
+          revalidate="/test/revalidate"
+        >
+          link revalidate "/test/revalidate"
+        </Link>
+      </div>
     </div>
   );
 }

--- a/packages/react-server/examples/basic/src/routes/test/revalidate/[id]/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/revalidate/[id]/page.tsx
@@ -1,9 +1,20 @@
-import type { PageProps } from "@hiogawa/react-server/server";
+import { type PageProps, useActionContext } from "@hiogawa/react-server/server";
 
 export default function Page(props: PageProps) {
   return (
-    <div>
+    <div className="flex flex-col gap-2">
       <pre>params = {JSON.stringify(props.params)}</pre>
+      <form
+        action={() => {
+          "use server";
+          useActionContext().revalidate = "/test/revalidate";
+        }}
+        className="flex flex-col gap-2"
+      >
+        <button className="antd-btn antd-btn-default px-2 self-start">
+          revalidate "/test/revalidate"
+        </button>
+      </form>
     </div>
   );
 }

--- a/packages/react-server/examples/basic/src/routes/test/revalidate/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/revalidate/layout.tsx
@@ -9,7 +9,7 @@ export default function Layout(props: LayoutProps) {
       <NavMenu
         links={["/test/revalidate", "/test/revalidate/x", "/test/revalidate/y"]}
       />
-      <EffectCount />
+      <EffectCount label="effect-revalidate" />
       {props.children}
     </div>
   );

--- a/packages/react-server/examples/basic/src/routes/test/revalidate/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/revalidate/layout.tsx
@@ -9,7 +9,10 @@ export default function Layout(props: LayoutProps) {
       <NavMenu
         links={["/test/revalidate", "/test/revalidate/x", "/test/revalidate/y"]}
       />
-      <EffectCount label="effect-revalidate" />
+      <div className="flex items-center gap-2 text-sm">
+        <EffectCount label="effect-revalidate" />
+        <div>[now: {Date.now()}]</div>
+      </div>
       {props.children}
     </div>
   );

--- a/packages/react-server/examples/basic/src/routes/test/revalidate/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/revalidate/layout.tsx
@@ -1,0 +1,16 @@
+import type { LayoutProps } from "@hiogawa/react-server/server";
+import { NavMenu } from "../../../components/nav-menu";
+import { EffectCount } from "../_client";
+
+export default function Layout(props: LayoutProps) {
+  return (
+    <div className="flex flex-col gap-3 p-2">
+      <h3 className="font-bold">Revalidate Test</h3>
+      <NavMenu
+        links={["/test/revalidate", "/test/revalidate/x", "/test/revalidate/y"]}
+      />
+      <EffectCount />
+      {props.children}
+    </div>
+  );
+}

--- a/packages/react-server/examples/basic/src/routes/test/revalidate/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/revalidate/page.tsx
@@ -4,8 +4,7 @@ import { actionTestRevalidate } from "./_action";
 
 export default function Layout(_props: LayoutProps) {
   return (
-    <div className="flex flex-col gap-3 p-2">
-      <h3 className="font-bold">Revalidate Test</h3>
+    <div className="flex flex-col gap-3">
       <form action={actionTestRevalidate} className="flex flex-col gap-2">
         <button className="antd-btn antd-btn-default px-2 self-start">
           Action

--- a/packages/react-server/src/entry/browser.tsx
+++ b/packages/react-server/src/entry/browser.tsx
@@ -129,7 +129,7 @@ export async function start() {
       });
       const request = createStreamRequest(location.href, {
         lastPathname,
-        revalidate: ROUTER_REVALIDATE_KEY in location.state,
+        revalidate: location.state[ROUTER_REVALIDATE_KEY],
       });
       startTransition(() => {
         $__setLayout(

--- a/packages/react-server/src/features/router/client.tsx
+++ b/packages/react-server/src/features/router/client.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import ReactDom from "react-dom";
 import { useRouter } from "../../client";
 import { ActionRedirectHandler } from "../server-action/client";
+import type { RevalidationType } from "../server-component/utils";
 import {
   type AssetDeps,
   type RouteManifest,
@@ -37,7 +38,7 @@ export const ROUTER_REVALIDATE_KEY = "__REVALIDATE";
 
 declare module "@tanstack/history" {
   interface HistoryState {
-    [ROUTER_REVALIDATE_KEY]?: boolean | string;
+    [ROUTER_REVALIDATE_KEY]?: RevalidationType;
   }
 }
 

--- a/packages/react-server/src/features/router/client.tsx
+++ b/packages/react-server/src/features/router/client.tsx
@@ -1,3 +1,4 @@
+import type { HistoryState } from "@tanstack/history";
 import React from "react";
 import ReactDom from "react-dom";
 import { useRouter } from "../../client";
@@ -34,8 +35,14 @@ export function LayoutRoot() {
 
 export const ROUTER_REVALIDATE_KEY = "__REVALIDATE";
 
-export function routerRevalidate() {
-  return { [ROUTER_REVALIDATE_KEY]: true };
+declare module "@tanstack/history" {
+  interface HistoryState {
+    [ROUTER_REVALIDATE_KEY]?: boolean | string;
+  }
+}
+
+export function routerRevalidate(v: string | boolean = true): HistoryState {
+  return { [ROUTER_REVALIDATE_KEY]: v };
 }
 
 function preloadAssetDeps(deps: AssetDeps) {

--- a/packages/react-server/src/features/router/utils.test.ts
+++ b/packages/react-server/src/features/router/utils.test.ts
@@ -4,6 +4,7 @@ import {
   getNewLayoutContentKeys,
   getPathPrefixes,
   isAncestorPath,
+  revalidateLayoutContentRequest,
 } from "./utils";
 
 describe(createLayoutContentRequest, () => {
@@ -53,6 +54,43 @@ describe(createLayoutContentRequest, () => {
         "__root": {
           "name": "/",
           "type": "layout",
+        },
+      }
+    `);
+  });
+});
+
+describe(revalidateLayoutContentRequest, () => {
+  it("basic", () => {
+    expect(
+      revalidateLayoutContentRequest("/dir/x", "/dir/y", []),
+    ).toMatchInlineSnapshot(`
+      {
+        "/dir": {
+          "name": "/dir/x",
+          "type": "layout",
+        },
+        "/dir/x": {
+          "name": "/dir/x",
+          "type": "page",
+        },
+      }
+    `);
+    expect(
+      revalidateLayoutContentRequest("/dir/x", "/dir/y", ["/dir"]),
+    ).toMatchInlineSnapshot(`
+      {
+        "/": {
+          "name": "/dir",
+          "type": "layout",
+        },
+        "/dir": {
+          "name": "/dir/x",
+          "type": "layout",
+        },
+        "/dir/x": {
+          "name": "/dir/x",
+          "type": "page",
         },
       }
     `);

--- a/packages/react-server/src/features/router/utils.test.ts
+++ b/packages/react-server/src/features/router/utils.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
   createLayoutContentRequest,
-  getNewLayoutContentKeys,
   getPathPrefixes,
   isAncestorPath,
   revalidateLayoutContentRequest,
@@ -93,57 +92,6 @@ describe(revalidateLayoutContentRequest, () => {
           "type": "page",
         },
       }
-    `);
-  });
-});
-
-describe(getNewLayoutContentKeys, () => {
-  it("basic", () => {
-    expect(getNewLayoutContentKeys("/", "/")).toMatchInlineSnapshot(`
-      [
-        "/",
-      ]
-    `);
-    expect(getNewLayoutContentKeys("/", "/a")).toMatchInlineSnapshot(`
-      [
-        "/",
-        "/a",
-      ]
-    `);
-    expect(getNewLayoutContentKeys("/a", "/")).toMatchInlineSnapshot(`
-      [
-        "/",
-      ]
-    `);
-    expect(getNewLayoutContentKeys("/a", "/b")).toMatchInlineSnapshot(`
-      [
-        "/",
-        "/b",
-      ]
-    `);
-    expect(getNewLayoutContentKeys("/a/b", "/a/b")).toMatchInlineSnapshot(`
-      [
-        "/a/b",
-      ]
-    `);
-    expect(getNewLayoutContentKeys("/a/b", "/a/c")).toMatchInlineSnapshot(`
-      [
-        "/a",
-        "/a/c",
-      ]
-    `);
-    expect(getNewLayoutContentKeys("/a", "/a/b")).toMatchInlineSnapshot(`
-      [
-        "/a",
-        "/a/b",
-      ]
-    `);
-    expect(getNewLayoutContentKeys("/", "/a/b")).toMatchInlineSnapshot(`
-      [
-        "/",
-        "/a",
-        "/a/b",
-      ]
     `);
   });
 });

--- a/packages/react-server/src/features/router/utils.test.ts
+++ b/packages/react-server/src/features/router/utils.test.ts
@@ -3,6 +3,7 @@ import {
   createLayoutContentRequest,
   getNewLayoutContentKeys,
   getPathPrefixes,
+  isAncestorPath,
 } from "./utils";
 
 describe(createLayoutContentRequest, () => {
@@ -129,5 +130,13 @@ describe(getPathPrefixes, () => {
         "/hello/world",
       ]
     `);
+  });
+});
+
+describe(isAncestorPath, () => {
+  it("basic", () => {
+    expect(isAncestorPath("/x", "/x")).toMatchInlineSnapshot(`true`);
+    expect(isAncestorPath("/x", "/x/y")).toMatchInlineSnapshot(`true`);
+    expect(isAncestorPath("/x", "/xx/y")).toMatchInlineSnapshot(`false`);
   });
 });

--- a/packages/react-server/src/features/router/utils.tsx
+++ b/packages/react-server/src/features/router/utils.tsx
@@ -80,17 +80,6 @@ export function revalidateLayoutContentRequest(
   return layoutRequest;
 }
 
-// TODO: remove
-export function getNewLayoutContentKeys(prev: string, next: string): string[] {
-  const prevMap = createLayoutContentRequest(prev);
-  const nextMap = createLayoutContentRequest(next);
-  return Object.keys(nextMap).filter(
-    (k) =>
-      nextMap[k]?.type === "page" ||
-      JSON.stringify(nextMap[k]) !== JSON.stringify(prevMap[k]),
-  );
-}
-
 /**
  * @example
  * "/" => ["/"]

--- a/packages/react-server/src/features/router/utils.tsx
+++ b/packages/react-server/src/features/router/utils.tsx
@@ -37,6 +37,7 @@ export function createLayoutContentRequest(pathname: string) {
   return map;
 }
 
+// TODO: remove
 export function getNewLayoutContentKeys(prev: string, next: string): string[] {
   const prevMap = createLayoutContentRequest(prev);
   const nextMap = createLayoutContentRequest(next);
@@ -72,4 +73,15 @@ export function handleTrailingSlash(url: URL) {
     });
   }
   return;
+}
+
+/**
+ * @example
+ * isAncestorPath("/x", "/x") === true
+ * isAncestorPath("/x", "/x/y") === true
+ * isAncestorPath("/x", "/xx/y") === false
+ */
+export function isAncestorPath(p1: string, p2: string) {
+  // check prefix after trailing slash
+  return p2.replace(/\/*$/, "/").startsWith(p1.replace(/\/*$/, "/"));
 }

--- a/packages/react-server/src/features/router/utils.tsx
+++ b/packages/react-server/src/features/router/utils.tsx
@@ -72,8 +72,9 @@ export function revalidateLayoutContentRequest(
       lastPathname,
       revalidations?.filter(typedBoolean) ?? [],
     );
-    layoutRequest = objectPickBy(layoutRequest, (v) =>
-      cached.some((c) => c.name === v.name && c.type === v.type),
+    layoutRequest = objectPickBy(
+      layoutRequest,
+      (v) => !cached.some((c) => c.name === v.name && c.type === v.type),
     );
   }
   return layoutRequest;

--- a/packages/react-server/src/features/server-action/react-server.tsx
+++ b/packages/react-server/src/features/server-action/react-server.tsx
@@ -2,6 +2,7 @@ import { memoize, tinyassert } from "@hiogawa/utils";
 import ReactServer from "react-server-dom-webpack/server.edge";
 import type { BundlerConfig, ImportManifestEntry } from "../../lib/types";
 import type { ReactServerErrorContext } from "../../server";
+import type { RevalidationType } from "../server-component/utils";
 
 // https://github.com/facebook/react/blob/c8a035036d0f257c514b3628e927dd9dd26e5a09/packages/react-server-dom-webpack/src/ReactFlightWebpackReferences.js#L87
 
@@ -27,7 +28,7 @@ export type ActionResult = {
 export class ActionContext {
   responseHeaders: Record<string, string> = {};
 
-  revalidate: boolean | string = false;
+  revalidate?: RevalidationType;
 
   constructor(public request: Request) {}
 }

--- a/packages/react-server/src/features/server-action/react-server.tsx
+++ b/packages/react-server/src/features/server-action/react-server.tsx
@@ -27,7 +27,6 @@ export type ActionResult = {
 export class ActionContext {
   responseHeaders: Record<string, string> = {};
 
-  // TODO: refine revalidation by layout key
   revalidate: boolean | string = false;
 
   constructor(public request: Request) {}

--- a/packages/react-server/src/features/server-action/react-server.tsx
+++ b/packages/react-server/src/features/server-action/react-server.tsx
@@ -28,7 +28,7 @@ export class ActionContext {
   responseHeaders: Record<string, string> = {};
 
   // TODO: refine revalidation by layout key
-  revalidate = false;
+  revalidate: boolean | string = false;
 
   constructor(public request: Request) {}
 }

--- a/packages/react-server/src/features/server-component/utils.tsx
+++ b/packages/react-server/src/features/server-component/utils.tsx
@@ -2,7 +2,7 @@
 export const RSC_PATH = "__f.data";
 const RSC_PARAM = "x-flight-meta";
 
-// TODO!: remove boolean `true` in favor of string "/"
+// TODO: (breaking) remove boolean `true` in favor of string "/"
 export type RevalidationType = boolean | string;
 
 export type StreamRequestParam = {

--- a/packages/react-server/src/features/server-component/utils.tsx
+++ b/packages/react-server/src/features/server-component/utils.tsx
@@ -5,8 +5,7 @@ const RSC_PARAM = "x-flight-meta";
 type StreamRequestParam = {
   actionId?: string;
   lastPathname?: string;
-  // TODO: refine revalitating each layout layer
-  revalidate?: boolean;
+  revalidate?: boolean | string;
 };
 
 export function createStreamRequest(href: string, param: StreamRequestParam) {

--- a/packages/react-server/src/features/server-component/utils.tsx
+++ b/packages/react-server/src/features/server-component/utils.tsx
@@ -2,10 +2,14 @@
 export const RSC_PATH = "__f.data";
 const RSC_PARAM = "x-flight-meta";
 
-type StreamRequestParam = {
+// TODO!: remove boolean `true` in favor of string "/"
+export type RevalidationType = boolean | string;
+
+export type StreamRequestParam = {
   actionId?: string;
+  // TODO: browser can send all cached route ids?
   lastPathname?: string;
-  revalidate?: boolean | string;
+  revalidate?: RevalidationType;
 };
 
 export function createStreamRequest(href: string, param: StreamRequestParam) {

--- a/packages/react-server/src/lib/client/link.tsx
+++ b/packages/react-server/src/lib/client/link.tsx
@@ -10,7 +10,7 @@ import { useRouter } from "./router";
 // https://github.com/remix-run/remix/blob/6ad886145bd35298accf04d43bd6ef69833567e2/packages/remix-react/components.tsx#L121
 
 interface LinkProps {
-  revalidate?: boolean;
+  revalidate?: boolean | string;
   activeProps?: JSX.IntrinsicElements["a"];
   preload?: boolean;
 }

--- a/packages/react-server/src/lib/client/link.tsx
+++ b/packages/react-server/src/lib/client/link.tsx
@@ -53,7 +53,10 @@ export function Link({
               (!target || target === "_self")
             ) {
               e.preventDefault();
-              history.push(href, revalidate ? routerRevalidate() : {});
+              history.push(
+                href,
+                revalidate ? routerRevalidate(revalidate) : {},
+              );
             }
           },
         } satisfies JSX.IntrinsicElements["a"],
@@ -87,7 +90,7 @@ export function LinkForm({
           });
           history.push(
             url.href.slice(url.origin.length),
-            revalidate ? routerRevalidate() : {},
+            revalidate ? routerRevalidate(revalidate) : {},
           );
         },
       } satisfies JSX.IntrinsicElements["form"])}

--- a/packages/react-server/src/lib/client/link.tsx
+++ b/packages/react-server/src/lib/client/link.tsx
@@ -2,6 +2,7 @@ import { objectMapValues } from "@hiogawa/utils";
 import React from "react";
 import { routerRevalidate } from "../../client";
 import { usePreloadHandlers } from "../../features/router/client";
+import type { RevalidationType } from "../../features/server-component/utils";
 import { useRouter } from "./router";
 
 // TODO: study prior art
@@ -10,7 +11,7 @@ import { useRouter } from "./router";
 // https://github.com/remix-run/remix/blob/6ad886145bd35298accf04d43bd6ef69833567e2/packages/remix-react/components.tsx#L121
 
 interface LinkProps {
-  revalidate?: boolean | string;
+  revalidate?: RevalidationType;
   activeProps?: JSX.IntrinsicElements["a"];
   preload?: boolean;
 }


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/vite-plugins/issues/390

I thought I should refactor route data handling first, but it's probably fine to go with this one now.

## todo

- [x] from server action
- [x] from browser
- [x] demo, test