### PR TITLE
fix: fix react-dom/server conditions in workerd

### DIFF
--- a/packages/vite-node-miniflare/examples/react-router/vite.config.ts
+++ b/packages/vite-node-miniflare/examples/react-router/vite.config.ts
@@ -7,6 +7,9 @@ import { defineConfig } from "vite";
 export default defineConfig({
   clearScreen: false,
   ssr: {
+    resolve: {
+      conditions: ["workerd"],
+    },
     optimizeDeps: {
       include: [
         "react",

--- a/packages/vite-node-miniflare/examples/react/vite.config.ts
+++ b/packages/vite-node-miniflare/examples/react/vite.config.ts
@@ -11,6 +11,9 @@ export default defineConfig({
     // force: true,
   },
   ssr: {
+    resolve: {
+      conditions: ["workerd"],
+    },
     optimizeDeps: {
       include: ["react", "react/jsx-dev-runtime", "react-dom/server"],
     },

--- a/packages/vite-node-miniflare/examples/remix/app/entry.server.tsx
+++ b/packages/vite-node-miniflare/examples/remix/app/entry.server.tsx
@@ -3,9 +3,7 @@
 import { RemixServer } from "@remix-run/react";
 import type { EntryContext } from "@remix-run/server-runtime";
 import { isbot } from "isbot";
-
-// force "browser" export on nodejs with manual typing override (see env.d.ts)
-import { renderToReadableStream } from "react-dom/server.browser";
+import { renderToReadableStream } from "react-dom/server";
 
 export default async function handleRequest(
   request: Request,

--- a/packages/vite-node-miniflare/examples/remix/vite.config.ts
+++ b/packages/vite-node-miniflare/examples/remix/vite.config.ts
@@ -6,6 +6,9 @@ import { defineConfig } from "vite";
 export default defineConfig({
   clearScreen: false,
   ssr: {
+    resolve: {
+      conditions: ["workerd"],
+    },
     optimizeDeps: {
       include: [
         "react",

--- a/packages/vite-node-miniflare/examples/remix/vite.config.ts
+++ b/packages/vite-node-miniflare/examples/remix/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
         "react",
         "react/jsx-dev-runtime",
         "react-dom",
-        "react-dom/server.browser",
+        "react-dom/server",
         "@remix-run/server-runtime",
       ],
     },


### PR DESCRIPTION
Cherry-picking change from https://github.com/hi-ogawa/vite-plugins/pull/396
Currently `react-dom/server.browser` is resolved and it looks like it's going to break by the latest experimental react.