### PR TITLE
chore: cf pages without bundle

### DIFF
--- a/packages/react-server/examples/prerender/misc/cf/build.js
+++ b/packages/react-server/examples/prerender/misc/cf/build.js
@@ -50,23 +50,28 @@ async function main() {
 `,
   );
 
-  // function
+  // worker
   // https://developers.cloudflare.com/pages/functions/advanced-mode/
-  await esbuild.build({
-    entryPoints: [join(buildDir, "server/index.js")],
-    outfile: join(outDir, "_worker.js"),
-    metafile: true,
-    bundle: true,
-    minify: true,
-    format: "esm",
-    platform: "browser",
-    define: {
-      "process.env.NODE_ENV": `"production"`,
-    },
-    logOverride: {
-      "ignored-bare-import": "silent",
-    },
+  await mkdir(join(outDir, "_worker.js"), { recursive: true });
+  await cp(join(buildDir, "server"), join(outDir, "_worker.js"), {
+    recursive: true,
   });
+
+  // await esbuild.build({
+  //   entryPoints: [join(buildDir, "server/index.js")],
+  //   outfile: join(outDir, "_worker.js"),
+  //   metafile: true,
+  //   bundle: true,
+  //   minify: true,
+  //   format: "esm",
+  //   platform: "browser",
+  //   define: {
+  //     "process.env.NODE_ENV": `"production"`,
+  //   },
+  //   logOverride: {
+  //     "ignored-bare-import": "silent",
+  //   },
+  // });
 }
 
 main();


### PR DESCRIPTION
- a part of https://github.com/hi-ogawa/vite-plugins/issues/401

As I expected, exactly the issue is that cloudflare's esbuild doesn't set certain flags we've been using (namely, `NODE_ENV`, `logOverride`, etc...), so this is probably a non starter...