### PR TITLE
feat!: support optional `entryBrowser`

### DIFF
--- a/packages/react-server/examples/basic/vite.config.ts
+++ b/packages/react-server/examples/basic/vite.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
         patchConsoleError: true,
       }),
     vitePluginReactServer({
+      entryBrowser: "/src/entry-client",
       plugins: [
         testVitePluginVirtual(),
         {

--- a/packages/react-server/examples/next/src/entry-client.tsx
+++ b/packages/react-server/examples/next/src/entry-client.tsx
@@ -1,3 +1,0 @@
-import { start } from "@hiogawa/react-server/entry-browser";
-
-start();

--- a/packages/react-server/examples/prerender/vite.config.ts
+++ b/packages/react-server/examples/prerender/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
   plugins: [
     react(),
     vitePluginReactServer({
+      entryBrowser: "/src/entry-client",
       prerender: async () => {
         process.env["REACT_SERVER_PRERENDER"] = "1";
         const posts = await fetchPosts();

--- a/packages/react-server/examples/starter/vite.config.ts
+++ b/packages/react-server/examples/starter/vite.config.ts
@@ -11,7 +11,9 @@ export default defineConfig({
   clearScreen: false,
   plugins: [
     react(),
-    vitePluginReactServer(),
+    vitePluginReactServer({
+      entryBrowser: "/src/entry-client",
+    }),
     vitePluginLogger(),
     vitePluginSsrMiddleware({
       entry: process.env["SSR_ENTRY"] || "/src/adapters/node.ts",

--- a/packages/react-server/src/features/assets/plugin.ts
+++ b/packages/react-server/src/features/assets/plugin.ts
@@ -5,7 +5,6 @@ import type { Manifest, Plugin, ViteDevServer } from "vite";
 import { $__global } from "../../lib/global";
 import type { PluginStateManager } from "../../plugin";
 import {
-  ENTRY_CLIENT,
   ENTRY_CLIENT_WRAPPER,
   ENTRY_REACT_SERVER,
   createVirtualPlugin,
@@ -20,7 +19,8 @@ export interface SsrAssetsType {
 
 export function vitePluginServerAssets({
   manager,
-}: { manager: PluginStateManager }): Plugin[] {
+  entryBrowser,
+}: { manager: PluginStateManager; entryBrowser: string }): Plugin[] {
   return [
     createVirtualPlugin("ssr-assets", async () => {
       // dev
@@ -96,7 +96,7 @@ export function vitePluginServerAssets({
         collectStyle($__global.dev.reactServer, [ENTRY_REACT_SERVER]),
         `/******* client **************/`,
         collectStyle($__global.dev.server, [
-          ENTRY_CLIENT,
+          entryBrowser,
           // TODO: dev should also use RouteManifest to manage client css
           ...manager.rscUseClientIds,
         ]),

--- a/packages/react-server/src/plugin/utils.tsx
+++ b/packages/react-server/src/plugin/utils.tsx
@@ -16,7 +16,6 @@ export type CustomModuleMeta = {
 };
 
 // TODO: configurable?
-export const ENTRY_CLIENT = "/src/entry-client";
 export const ENTRY_REACT_SERVER = "/src/entry-react-server";
 export const ENTRY_CLIENT_WRAPPER = "virtual:entry-client-wrapper";
 export const ENTRY_REACT_SERVER_WRAPPER = "virtual:entry-react-server-wrapper";


### PR DESCRIPTION
This is a little inconvenient since Vite is usually happier when css is loaded on client side directly, but it's not possible to do that with the default entry.