### PR TITLE
chore: optional ssr entry by using virtual module on userland

### DIFF
--- a/packages/react-server/examples/next/src/adapters/node.ts
+++ b/packages/react-server/examples/next/src/adapters/node.ts
@@ -1,4 +1,0 @@
-import { webToNodeHandler } from "@hiogawa/utils-node";
-import { handler } from "../entry-server";
-
-export default webToNodeHandler(handler);

--- a/packages/react-server/examples/next/src/entry-server.tsx
+++ b/packages/react-server/examples/next/src/entry-server.tsx
@@ -1,1 +1,0 @@
-export { handler } from "@hiogawa/react-server/entry-server";

--- a/packages/react-server/examples/next/vite.config.ts
+++ b/packages/react-server/examples/next/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     vitePluginReactServer({
       routeDir: "app",
     }),
+    // for now, ssr entry setup is not done by vitePluginReactServer
     vitePluginLogger(),
     vitePluginSsrMiddleware({
       entry: "virtual:entry-ssr-node",

--- a/packages/react-server/examples/next/vite.config.ts
+++ b/packages/react-server/examples/next/vite.config.ts
@@ -16,8 +16,25 @@ export default defineConfig({
     }),
     vitePluginLogger(),
     vitePluginSsrMiddleware({
-      entry: process.env["SSR_ENTRY"] || "/src/adapters/node.ts",
+      entry: "virtual:entry-ssr-node",
       preview: path.resolve("./dist/server/index.js"),
     }),
+    {
+      name: "virtual-entry-ssr-node",
+      resolveId(source, _importer, _options) {
+        if (source === "virtual:entry-ssr-node") {
+          return "\0" + source;
+        }
+      },
+      load(id, _options) {
+        if (id === "\0virtual:entry-ssr-node") {
+          return `
+            import { handler } from "@hiogawa/react-server/entry-server";
+            import { webToNodeHandler } from "@hiogawa/utils-node";
+            export default webToNodeHandler(handler);
+          `;
+        }
+      },
+    },
   ],
 });

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -99,8 +99,6 @@ export function vitePluginReactServer(options?: {
   prerender?: () => Promise<string[]> | string[];
   entryBrowser?: string;
   entryServer?: string;
-  // entrySsr?: string,
-  /** @default "src/routes" */
   routeDir?: string;
 }): Plugin[] {
   const entryBrowser = options?.entryBrowser ?? "virtual:entry-browser-default";


### PR DESCRIPTION
Okay, probably this looks okay without actually supporting `entrySsr` on core plugin side.

Maybe, it's better to have a separate package (e.g. `@hiogawa/react-server-next`), then put all next-compat wrangling there?