### PR TITLE
fix: set html response as charset=utf-8

### DIFF
--- a/packages/react-server/src/entry/server.tsx
+++ b/packages/react-server/src/entry/server.tsx
@@ -213,7 +213,7 @@ export async function renderHtml(
     status,
     headers: {
       ...result.actionResult?.responseHeaders,
-      "content-type": "text/html",
+      "content-type": "text/html;charset=utf-8",
     },
   });
 }


### PR DESCRIPTION
Somehow this was causing `&nbsp;` to be rendered as `Â` when `<meta charSet="UTF-8" />` is not included like in https://github.com/hi-ogawa/vite-plugins/pull/409.
Probably forcing charset in the response should be fine.