### PR TITLE
fix(next): force esbuild jsx transform

### DIFF
--- a/packages/react-server/examples/next/tsconfig.json
+++ b/packages/react-server/examples/next/tsconfig.json
@@ -17,6 +17,6 @@
     "target": "ESNext",
     "lib": ["ESNext", "DOM"],
     "types": ["vite/client", "react/experimental"],
-    "jsx": "react-jsx"
+    "jsx": "preserve"
   }
 }

--- a/packages/react-server/src/next/plugin.ts
+++ b/packages/react-server/src/next/plugin.ts
@@ -18,7 +18,7 @@ export function vitePluginReactServerNext(options?: {
       routeDir: "app",
       entryBrowser: "@hiogawa/react-server/next/entry-browser",
       entryServer: "@hiogawa/react-server/entry-react-server",
-      plugins: [nextAliasPlugin, ...(options?.plugins ?? [])],
+      plugins: [nextAliasPlugin, nextEsbuildJsx, ...(options?.plugins ?? [])],
     }),
     vitePluginLogger(),
     vitePluginSsrMiddleware({
@@ -39,5 +39,16 @@ const nextAliasPlugin: Plugin = {
         },
       ],
     },
+  }),
+};
+
+// overrdied next.js's default `jsx: preserve`
+const nextEsbuildJsx: Plugin = {
+  name: "next-esbuild-jsx",
+  config: () => ({
+    esbuild: {
+      jsx: "automatic",
+    },
+    optimizeDeps: { esbuildOptions: { jsx: "automatic" } },
   }),
 };


### PR DESCRIPTION
Next.js's default `jsx: preserve` breaks, but we can workaround this on esbuild config side.
Not really a big deal, but this will reduce one patch needed for codemod.