### PR TITLE
fix: workaround scan build error with conditioned exports

### DIFF
--- a/packages/react-server/examples/next/app/navigation/README.md
+++ b/packages/react-server/examples/next/app/navigation/README.md
@@ -1,1 +1,1 @@
-based on https://github.com/vercel/next.js/tree/canary/test/e2e/app-dir/navigation
+based on https://github.com/vercel/next.js/tree/ea8020158e7f7f75242ac4dad03136b6a170b63c/test/e2e/app-dir/navigation

--- a/packages/react-server/examples/next/app/navigation/not-found/error.tsx
+++ b/packages/react-server/examples/next/app/navigation/not-found/error.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import type { ErrorPageProps } from "@hiogawa/react-server/server";
+import styles from "./style.module.css";
+
+export default function ErrorPage(props: ErrorPageProps) {
+  return (
+    <h1 id="not-found-component" className={styles.red}>
+      Error: {props.serverError?.status}
+    </h1>
+  );
+}

--- a/packages/react-server/examples/next/app/navigation/not-found/servercomponent/page.tsx
+++ b/packages/react-server/examples/next/app/navigation/not-found/servercomponent/page.tsx
@@ -1,0 +1,6 @@
+import { notFound } from "next/navigation";
+
+export default function Page() {
+  notFound();
+  return <></>;
+}

--- a/packages/react-server/examples/next/app/navigation/not-found/style.module.css
+++ b/packages/react-server/examples/next/app/navigation/not-found/style.module.css
@@ -1,0 +1,3 @@
+.red {
+  color: red;
+}

--- a/packages/react-server/examples/next/app/navigation/redirect/result/page.tsx
+++ b/packages/react-server/examples/next/app/navigation/redirect/result/page.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <div>
+      <h1 id="result-page">Result Page</h1>
+      <div id="timestamp">{Date.now()}</div>
+    </div>
+  );
+}

--- a/packages/react-server/examples/next/app/navigation/redirect/servercomponent-2/page.tsx
+++ b/packages/react-server/examples/next/app/navigation/redirect/servercomponent-2/page.tsx
@@ -1,0 +1,6 @@
+import { RedirectType, permanentRedirect } from "next/navigation";
+
+export default function Page() {
+  permanentRedirect("/navigation/redirect/result", RedirectType.push);
+  return <></>;
+}

--- a/packages/react-server/examples/next/app/navigation/redirect/servercomponent/page.tsx
+++ b/packages/react-server/examples/next/app/navigation/redirect/servercomponent/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from "next/navigation";
+
+export default function Page() {
+  redirect("/navigation/redirect/result");
+  return <></>;
+}

--- a/packages/react-server/examples/next/app/navigation/router/dynamic-gsp/[slug]/page.tsx
+++ b/packages/react-server/examples/next/app/navigation/router/dynamic-gsp/[slug]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page({ params }: any) {
+  return <div id="dynamic-gsp-content">{"slug:" + params.slug}</div>;
+}

--- a/packages/react-server/examples/next/app/navigation/router/page.tsx
+++ b/packages/react-server/examples/next/app/navigation/router/page.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+export default function Page() {
+  const router = useRouter();
+  return (
+    <div>
+      <button
+        id="dynamic-link"
+        onClick={() => router.push("/navigation/router/dynamic-gsp/1")}
+      >
+        Test routing
+      </button>
+    </div>
+  );
+}

--- a/packages/react-server/examples/next/e2e/basic.test.ts
+++ b/packages/react-server/examples/next/e2e/basic.test.ts
@@ -34,6 +34,12 @@ test("navigation permanentRedirect", async ({ page }) => {
   await page.getByText("Result Page").click();
 });
 
+test("navigation notFound", async ({ page }) => {
+  const res = await page.goto("/navigation/not-found/servercomponent");
+  expect(res?.status()).toBe(404);
+  await page.getByText("Error: 404").click();
+});
+
 async function waitForHydration(page: Page) {
   await expect(page.locator("html")).toHaveAttribute(
     "data-test-state",

--- a/packages/react-server/examples/next/e2e/basic.test.ts
+++ b/packages/react-server/examples/next/e2e/basic.test.ts
@@ -9,5 +9,6 @@ test("basic", async ({ page }) => {
 test("navigation", async ({ page }) => {
   await page.goto("/navigation");
   await page.getByRole("link", { name: "set Query" }).click();
-  await page.getByTestId("a=b&c=d").click();
+  await page.getByText("a=b&c=d").click();
+  await page.waitForURL("/navigation?a=b&c=d");
 });

--- a/packages/react-server/examples/next/e2e/basic.test.ts
+++ b/packages/react-server/examples/next/e2e/basic.test.ts
@@ -6,7 +6,7 @@ test("basic", async ({ page }) => {
   await page.getByRole("img", { name: "Next.js logo" }).click();
 });
 
-test("navigation link", async ({ page }) => {
+test("navigation Link", async ({ page }) => {
   await page.goto("/navigation");
   await waitForHydration(page);
   await page.getByRole("link", { name: "set Query" }).click();
@@ -14,12 +14,24 @@ test("navigation link", async ({ page }) => {
   await page.waitForURL("/navigation?a=b&c=d");
 });
 
-test("navigation router", async ({ page }) => {
+test("navigation useRouter", async ({ page }) => {
   await page.goto("/navigation/router");
   await waitForHydration(page);
   await page.getByRole("button", { name: "Test routing" }).click();
   await page.getByText("slug:1").click();
   await page.waitForURL("/navigation/router/dynamic-gsp/1");
+});
+
+test("navigation redirect", async ({ page }) => {
+  await page.goto("/navigation/redirect/servercomponent");
+  await page.waitForURL("/navigation/redirect/result");
+  await page.getByText("Result Page").click();
+});
+
+test("navigation permanentRedirect", async ({ page }) => {
+  await page.goto("/navigation/redirect/servercomponent-2");
+  await page.waitForURL("/navigation/redirect/result");
+  await page.getByText("Result Page").click();
 });
 
 async function waitForHydration(page: Page) {

--- a/packages/react-server/examples/next/e2e/basic.test.ts
+++ b/packages/react-server/examples/next/e2e/basic.test.ts
@@ -5,3 +5,9 @@ test("basic", async ({ page }) => {
   expect(res?.status()).toBe(200);
   await page.getByRole("img", { name: "Next.js logo" }).click();
 });
+
+test("navigation", async ({ page }) => {
+  await page.goto("/navigation");
+  await page.getByRole("link", { name: "set Query" }).click();
+  await page.getByTestId("a=b&c=d").click();
+});

--- a/packages/react-server/examples/next/e2e/basic.test.ts
+++ b/packages/react-server/examples/next/e2e/basic.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { type Page, expect, test } from "@playwright/test";
 
 test("basic", async ({ page }) => {
   const res = await page.goto("/");
@@ -6,9 +6,25 @@ test("basic", async ({ page }) => {
   await page.getByRole("img", { name: "Next.js logo" }).click();
 });
 
-test("navigation", async ({ page }) => {
+test("navigation link", async ({ page }) => {
   await page.goto("/navigation");
+  await waitForHydration(page);
   await page.getByRole("link", { name: "set Query" }).click();
   await page.getByText("a=b&c=d").click();
   await page.waitForURL("/navigation?a=b&c=d");
 });
+
+test("navigation router", async ({ page }) => {
+  await page.goto("/navigation/router");
+  await waitForHydration(page);
+  await page.getByRole("button", { name: "Test routing" }).click();
+  await page.getByText("slug:1").click();
+  await page.waitForURL("/navigation/router/dynamic-gsp/1");
+});
+
+async function waitForHydration(page: Page) {
+  await expect(page.locator("html")).toHaveAttribute(
+    "data-test-state",
+    "hydrated",
+  );
+}

--- a/packages/react-server/src/entry/browser.tsx
+++ b/packages/react-server/src/entry/browser.tsx
@@ -102,6 +102,9 @@ export async function start() {
     $__startActionTransition = startActionTransition;
 
     React.useEffect(() => router.setup(), []);
+    React.useEffect(() => {
+      document.firstElementChild?.setAttribute("data-test-state", "hydrated");
+    }, []);
 
     React.useEffect(() => {
       debug("[isPending]", isPending);

--- a/packages/react-server/src/features/use-client/plugin.ts
+++ b/packages/react-server/src/features/use-client/plugin.ts
@@ -147,7 +147,7 @@ export function vitePluginServerUseClient({
         `import { registerClientReference as $$proxy } from "${runtimePath}";\n`,
       );
       manager.rscUseClientIds.add(id);
-      if (manager.buildType === "scan") {
+      if (manager.buildType === "scan" && manager.buildScanMode === "full") {
         // to discover server references imported only by client
         // we keep code as is and continue crawling
         return;

--- a/packages/react-server/src/next/compat/navigation.react-server.tsx
+++ b/packages/react-server/src/next/compat/navigation.react-server.tsx
@@ -1,9 +1,19 @@
-/** @todo */
-export function notFound(..._args: unknown[]): never {
-  throw new Error("todo");
+import { createError, redirect as redirect_ } from "../../server";
+
+export function notFound(): never {
+  throw createError({ status: 404 });
 }
 
 /** @todo */
-export function redirect(..._args: unknown[]): never {
-  throw new Error("todo");
+export enum RedirectType {
+  push = "push",
+  replace = "replace",
+}
+
+export function redirect(url: string, ..._args: unknown[]): never {
+  throw redirect_(url);
+}
+
+export function permanentRedirect(url: string, ..._args: unknown[]): never {
+  throw redirect_(url, { status: 308 });
 }

--- a/packages/react-server/src/next/compat/navigation.tsx
+++ b/packages/react-server/src/next/compat/navigation.tsx
@@ -1,13 +1,13 @@
 import React from "react";
-import { useRouter } from "../../client";
+import { useRouter as useRouter_ } from "../../client";
 
 export function useSearchParams() {
-  const search = useRouter((s) => s.location.search);
+  const search = useRouter_((s) => s.location.search);
   return React.useMemo(() => new URLSearchParams(search), [search]);
 }
 
 export function usePathname() {
-  return useRouter((s) => s.location.pathname);
+  return useRouter_((s) => s.location.pathname);
 }
 
 /** @todo */
@@ -16,11 +16,9 @@ export function useParams() {}
 /** @todo */
 export function useSelectedLayoutSegments() {}
 
-function useNextRouter() {
-  const history = useRouter((s) => s.history);
+export function useRouter() {
+  const history = useRouter_((s) => s.history);
   return history;
 }
-
-export { useNextRouter as useRouter };
 
 export type * from "./navigation.react-server";

--- a/packages/react-server/src/next/plugin.ts
+++ b/packages/react-server/src/next/plugin.ts
@@ -18,6 +18,7 @@ export function vitePluginReactServerNext(options?: {
       routeDir: "app",
       entryBrowser: "@hiogawa/react-server/next/entry-browser",
       entryServer: "@hiogawa/react-server/entry-react-server",
+      buildScanMode: "server",
       plugins: [nextAliasPlugin, nextEsbuildJsx, ...(options?.plugins ?? [])],
     }),
     vitePluginLogger(),

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -60,6 +60,7 @@ class PluginStateManager {
   configEnv!: ConfigEnv;
 
   buildType?: "scan" | "rsc" | "client" | "ssr";
+  buildScanMode?: "full" | "server";
 
   routeToClientReferences: Record<string, string[]> = {};
   routeManifest?: RouteManifest;
@@ -101,6 +102,7 @@ export function vitePluginReactServer(options?: {
   entryBrowser?: string;
   entryServer?: string;
   routeDir?: string;
+  buildScanMode?: PluginStateManager["buildScanMode"];
 }): Plugin[] {
   const entryBrowser = options?.entryBrowser ?? "/src/entry-client";
   const entryServer = options?.entryServer ?? "/src/entry-react-server";
@@ -335,6 +337,7 @@ export function vitePluginReactServer(options?: {
       if (!manager.buildType) {
         console.log("▶▶▶ REACT SERVER BUILD (scan) [1/4]");
         manager.buildType = "scan";
+        manager.buildScanMode = options?.buildScanMode ?? "full";
         await build(reactServerViteConfig);
         console.log("▶▶▶ REACT SERVER BUILD (server) [2/4]");
         manager.buildType = "rsc";


### PR DESCRIPTION
As seen in https://github.com/hi-ogawa/vite-plugins/pull/420, `"scan"` phase sees `navigation.react-server.js`, so it breaks build.
This is a workaround to give up scanning of `"use server"` imported from client, but this is somewhat edge case, so let's go with this for now for next compat.