### PR TITLE
fix: fix initial server css crawling

### DIFF
--- a/packages/react-server/src/features/assets/plugin.ts
+++ b/packages/react-server/src/features/assets/plugin.ts
@@ -96,7 +96,7 @@ export function vitePluginServerAssets({
         `/******* react-server ********/`,
         collectStyle($__global.dev.reactServer, [
           entryServer,
-          "@hiogawa/react-server/entry-react-server",
+          "virtual:server-routes",
         ]),
         `/******* client **************/`,
         collectStyle($__global.dev.server, [
@@ -114,7 +114,7 @@ export function vitePluginServerAssets({
       if (!manager.buildType) {
         const urls = await collectStyleUrls($__global.dev.reactServer, [
           entryServer,
-          "@hiogawa/react-server/entry-react-server",
+          "virtual:server-routes",
         ]);
         const code = urls.map((url) => `import "${url}";\n`).join("");
         // ensure hmr boundary since css module doesn't have `import.meta.hot.accept`

--- a/packages/react-server/src/features/assets/plugin.ts
+++ b/packages/react-server/src/features/assets/plugin.ts
@@ -94,7 +94,10 @@ export function vitePluginServerAssets({
       tinyassert(!manager.buildType);
       const styles = await Promise.all([
         `/******* react-server ********/`,
-        collectStyle($__global.dev.reactServer, [entryServer]),
+        collectStyle($__global.dev.reactServer, [
+          entryServer,
+          "@hiogawa/react-server/entry-react-server",
+        ]),
         `/******* client **************/`,
         collectStyle($__global.dev.server, [
           entryBrowser,
@@ -111,6 +114,7 @@ export function vitePluginServerAssets({
       if (!manager.buildType) {
         const urls = await collectStyleUrls($__global.dev.reactServer, [
           entryServer,
+          "@hiogawa/react-server/entry-react-server",
         ]);
         const code = urls.map((url) => `import "${url}";\n`).join("");
         // ensure hmr boundary since css module doesn't have `import.meta.hot.accept`


### PR DESCRIPTION
When server entry is `react-server-next/vite/entry-server`, initial crawling fails to grab css from user's server routes.
We should revisit the strategy here in general, but for now, ensuring `@hiogawa/react-server/entry-react-server` helps the issue on next tailwind https://github.com/hi-ogawa/reproductions/tree/main/vite-next.

---

Well, it looks like some resolution is broken and it ended up with `@hiogawa/react-server/entry-react-server.js`.
Let's try `virtual:server-routes` instead?

---

Actually, I'm not sure why `examples/next` is working without this. Anyway, let's dig in later...