### PR TITLE
fix: avoid ssr build on browser build failure

### DIFF
--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -347,17 +347,20 @@ export function vitePluginReactServer(options?: {
         manager.buildType = "client";
       }
     },
-    async closeBundle() {
-      // TODO: build ssr only when client build succeeds
-      if (manager.buildType === "client") {
-        console.log("▶▶▶ REACT SERVER BUILD (ssr) [4/4]");
-        manager.buildType = "ssr";
-        await build({
-          build: {
-            ssr: true,
-          },
-        });
-      }
+    writeBundle: {
+      order: "post",
+      sequential: true,
+      async handler(_options, _bundle) {
+        if (manager.buildType === "client") {
+          console.log("▶▶▶ REACT SERVER BUILD (ssr) [4/4]");
+          manager.buildType = "ssr";
+          await build({
+            build: {
+              ssr: true,
+            },
+          });
+        }
+      },
     },
   };
 


### PR DESCRIPTION
`closeBundle` is called regardless of build error, so moving it `writeBundle` (like Sveltekit and Remix do) helps stopping a build properly when first build is broken.

Currently, ssr build continues (and is destined to fail) even if browser build fails and the error message in that case is very cryptic like:

```
▶▶▶ REACT SERVER BUILD (browser) [3/4]
✓ 38 modules transformed.
▶▶▶ REACT SERVER BUILD (ssr) [4/4]
vite v5.2.3 building SSR bundle for production...
✓ 2 modules transformed.
x Build failed in 9ms
x Build failed in 881ms
error during build:
Error: [vitePluginReactServer:build] [virtual-virtual:route-manifest] Could not load virtual:route-manifest (imported by ../../dist/entry/server.js): TinyAssertionError
```

