### PR TITLE
fix: robust server reference build scan

### DIFF
--- a/packages/react-server-next/src/vite/index.ts
+++ b/packages/react-server-next/src/vite/index.ts
@@ -16,7 +16,6 @@ export default function vitePluginReactServerNext(options?: {
       routeDir: "app",
       entryBrowser: `next/vite/entry-browser`,
       entryServer: "next/vite/entry-server",
-      buildScanMode: "server",
       plugins: [nextEsbuildJsx, ...(options?.plugins ?? [])],
     }),
     vitePluginLogger(),

--- a/packages/react-server/examples/next/app/actions/client/layout.tsx
+++ b/packages/react-server/examples/next/app/actions/client/layout.tsx
@@ -1,6 +1,6 @@
 // TODO: this is a workaround for server action discovery
 // see https://github.com/hi-ogawa/vite-plugins/pull/420
-import "./actions";
+// import "./actions";
 
 export default function Layout(props: any) {
   return <>{props.children}</>;

--- a/packages/react-server/examples/next/app/actions/client/layout.tsx
+++ b/packages/react-server/examples/next/app/actions/client/layout.tsx
@@ -1,7 +1,0 @@
-// TODO: this is a workaround for server action discovery
-// see https://github.com/hi-ogawa/vite-plugins/pull/420
-// import "./actions";
-
-export default function Layout(props: any) {
-  return <>{props.children}</>;
-}

--- a/packages/react-server/examples/next/app/test/page.tsx
+++ b/packages/react-server/examples/next/app/test/page.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+
+export default function Page() {
+  return (
+    <div>
+      <h2>Test</h2>
+      <ul>
+        {links.map((href) => (
+          <li key={href}>
+            <Link href={href}>{href}</Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+const links = [
+  "/actions/client",
+  "/actions/server",
+  "/navigation",
+  "/navigation/router",
+  "/navigation/redirect/servercomponent",
+  "/navigation/redirect/servercomponent2",
+  "/navigation/not-found/servercomponent",
+];

--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -67,6 +67,7 @@
     "@hiogawa/transforms": "workspace:*",
     "@hiogawa/vite-plugin-ssr-middleware": "workspace:*",
     "@tanstack/history": "^1.15.13",
+    "es-module-lexer": "^1.4.1",
     "fast-glob": "^3.3.2",
     "use-sync-external-store": "^1.2.0"
   },

--- a/packages/react-server/src/features/use-client/plugin.ts
+++ b/packages/react-server/src/features/use-client/plugin.ts
@@ -147,6 +147,11 @@ export function vitePluginServerUseClient({
         `import { registerClientReference as $$proxy } from "${runtimePath}";\n`,
       );
       manager.rscUseClientIds.add(id);
+      // if (manager.buildType === "scan") {
+      //   // to discover server references imported only by client
+      //   // we keep code as is and continue crawling
+      //   return;
+      // }
       if (manager.buildType === "scan" && manager.buildScanMode === "full") {
         // to discover server references imported only by client
         // we keep code as is and continue crawling

--- a/packages/react-server/src/features/use-client/plugin.ts
+++ b/packages/react-server/src/features/use-client/plugin.ts
@@ -147,12 +147,7 @@ export function vitePluginServerUseClient({
         `import { registerClientReference as $$proxy } from "${runtimePath}";\n`,
       );
       manager.rscUseClientIds.add(id);
-      // if (manager.buildType === "scan") {
-      //   // to discover server references imported only by client
-      //   // we keep code as is and continue crawling
-      //   return;
-      // }
-      if (manager.buildType === "scan" && manager.buildScanMode === "full") {
+      if (manager.buildType === "scan") {
         // to discover server references imported only by client
         // we keep code as is and continue crawling
         return;

--- a/packages/react-server/src/features/use-client/plugin.ts
+++ b/packages/react-server/src/features/use-client/plugin.ts
@@ -163,7 +163,45 @@ export function vitePluginServerUseClient({
       };
     },
   };
-  return [useClientExternalPlugin, useClientPlugin];
+
+  let esModuleLexer: typeof import("es-module-lexer");
+  const scanStripPlugin: Plugin = {
+    name: vitePluginServerUseClient + ":strip-strip",
+    apply: "build",
+    enforce: "post",
+    async buildStart() {
+      if (manager.buildType !== "scan") return;
+
+      esModuleLexer = await import("es-module-lexer");
+      await esModuleLexer.init;
+    },
+    transform(code, _id, _options) {
+      if (manager.buildType !== "scan") return;
+
+      // During server scan, we strip every modules to only keep imports/exports
+      //   import "x"
+      //   import "y"
+      //   export const f = undefined;
+      //   export const g = undefined;
+
+      // emptify all exports while keeping import statements as side effects
+      const [imports, exports] = esModuleLexer.parse(code);
+      const output = [
+        imports.map((e) => e.n && `import ${JSON.stringify(e.n)};\n`),
+        exports.map((e) =>
+          e.n === "default"
+            ? `export default undefined;\n`
+            : `export const ${e.n} = undefined;\n`,
+        ),
+      ]
+        .flat()
+        .filter(Boolean)
+        .join("");
+      return { code: output, map: null };
+    },
+  };
+
+  return [useClientExternalPlugin, useClientPlugin, scanStripPlugin];
 }
 
 // Apply same noramlizaion as Vite's dev import analysis

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -60,8 +60,6 @@ class PluginStateManager {
   configEnv!: ConfigEnv;
 
   buildType?: "scan" | "rsc" | "client" | "ssr";
-  // TODO: remove
-  buildScanMode?: "full" | "server";
 
   routeToClientReferences: Record<string, string[]> = {};
   routeManifest?: RouteManifest;
@@ -103,7 +101,6 @@ export function vitePluginReactServer(options?: {
   entryBrowser?: string;
   entryServer?: string;
   routeDir?: string;
-  buildScanMode?: PluginStateManager["buildScanMode"];
 }): Plugin[] {
   const entryBrowser = options?.entryBrowser ?? "/src/entry-client";
   const entryServer = options?.entryServer ?? "/src/entry-react-server";
@@ -338,7 +335,6 @@ export function vitePluginReactServer(options?: {
       if (!manager.buildType) {
         console.log("▶▶▶ REACT SERVER BUILD (scan) [1/4]");
         manager.buildType = "scan";
-        manager.buildScanMode = options?.buildScanMode ?? "full";
         await build(reactServerViteConfig);
         console.log("▶▶▶ REACT SERVER BUILD (server) [2/4]");
         manager.buildType = "rsc";

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -336,11 +336,6 @@ export function vitePluginReactServer(options?: {
     apply: "build",
     async buildStart(_options) {
       if (!manager.buildType) {
-        // TODO: during scan, we can strip every modules to all skelton?
-        //   import "x"
-        //   import "y"
-        //   export const f = undefined;
-        //   export const g = undefined;
         console.log("▶▶▶ REACT SERVER BUILD (scan) [1/4]");
         manager.buildType = "scan";
         manager.buildScanMode = options?.buildScanMode ?? "full";

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -170,6 +170,27 @@ export function vitePluginReactServer(options?: {
         `;
       }),
 
+      // {
+      //   name: "server-scan-transform",
+      //   apply: "build",
+      //   transform(code, id, _options) {
+      //     // leave glob import as is
+      //     if (code.includes("import.meta.glob")) {
+      //       return;
+      //     }
+      //     // otherwise emptify all modules
+      //     // emptify modules to avoid invalid import error
+      //     if (manager.buildType === "scan") {
+      //       if (code.includes("import.meta.glob")) {
+      //         console.log("import.meta.glob", { id });
+      //       }
+      //     }
+      //     if (id.includes("virtual:server-routes")) {
+      //       console.log({ code });
+      //     }
+      //   },
+      // },
+
       // this virtual is not necessary anymore but has been used in the past
       // to extend user's react-server entry like ENTRY_CLIENT_WRAPPER
       createVirtualPlugin(
@@ -335,6 +356,11 @@ export function vitePluginReactServer(options?: {
     apply: "build",
     async buildStart(_options) {
       if (!manager.buildType) {
+        // TODO: during scan, we can strip every modules to all skelton?
+        //   import "x"
+        //   import "y"
+        //   export const f = undefined;
+        //   export const g = undefined;
         console.log("▶▶▶ REACT SERVER BUILD (scan) [1/4]");
         manager.buildType = "scan";
         manager.buildScanMode = options?.buildScanMode ?? "full";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,9 @@ importers:
       '@tanstack/history':
         specifier: ^1.15.13
         version: 1.15.13
+      es-module-lexer:
+        specifier: ^1.4.1
+        version: 1.4.1
       fast-glob:
         specifier: ^3.3.2
         version: 3.3.2


### PR DESCRIPTION
- close https://github.com/hi-ogawa/vite-plugins/issues/428

The previous issue was that when some package changes exports based on condition e.g.

```ts
// some-lib package.json
{
  exports: {
    ".": {
      "react-server": "./some-lib.react-server.js",
      "default": "./some-lib.js",
    }
  }
}

// some-lib.js
export const clientLib = ...;

// some-lib.react-server.js
export const serverLib = ...
```

then scanning of a following user code fails since scanning happens with `"react-server"` condition:

```ts
// some-user-code.js
"use client"

import { clientLib } from "some-lib";
// => Rollup error for missing export

export const thing = ...
```

This PR fixes this issue by import as side effects and all exports to `undefined`, which still allows scanning module graph and discover server/client references as before:

```ts
// some-user-code.js (transformed)
import "some-lib"
export const thing = undefined;
```