### PR TITLE
refactor(next): move vite to peer deps

### DIFF
--- a/packages/react-server-next/package.json
+++ b/packages/react-server-next/package.json
@@ -40,18 +40,19 @@
   },
   "dependencies": {
     "@hiogawa/vite-plugin-ssr-middleware": "workspace:*",
-    "@vitejs/plugin-react": "^4.2.1",
-    "vite": "^5.2.3"
+    "@vitejs/plugin-react": "^4.2.1"
   },
   "devDependencies": {
     "@hiogawa/react-server": "workspace:*",
     "@hiogawa/utils-node": "^0.0.1",
     "@types/react": "18.3.1",
     "@types/react-dom": "18.3.0",
-    "react": "$react"
+    "react": "$react",
+    "vite": "$vite"
   },
   "peerDependencies": {
     "@hiogawa/react-server": "*",
-    "react": "*"
+    "react": "*",
+    "vite": "*"
   }
 }

--- a/packages/react-server/examples/next/package.json
+++ b/packages/react-server/examples/next/package.json
@@ -21,7 +21,8 @@
   "devDependencies": {
     "@playwright/test": "^1.42.1",
     "@types/react": "18.3.1",
-    "@types/react-dom": "18.3.0"
+    "@types/react-dom": "18.3.0",
+    "vite": "latest"
   },
   "packageManager": "pnpm@9.3.0+sha512.ee7b93e0c2bd11409c6424f92b866f31d3ea1bef5fbe47d3c7500cdc3c9668833d2e55681ad66df5b640c61fa9dc25d546efa54d76d7f8bf54b13614ac293631"
 }

--- a/packages/react-server/examples/next/vite.config.ts
+++ b/packages/react-server/examples/next/vite.config.ts
@@ -1,5 +1,6 @@
 import next from "next/vite";
+import { defineConfig } from "vite";
 
-export default {
+export default defineConfig({
   plugins: [next()],
-};
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,9 +146,6 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.2.1
         version: 4.2.1(vite@5.2.3(@types/node@20.11.28)(terser@5.29.2))
-      vite:
-        specifier: ^5.2.3
-        version: 5.2.3(@types/node@20.11.28)(terser@5.29.2)
     devDependencies:
       '@hiogawa/react-server':
         specifier: workspace:*
@@ -165,6 +162,9 @@ importers:
       react:
         specifier: 19.0.0-rc-c21bcd627b-20240624
         version: 19.0.0-rc-c21bcd627b-20240624
+      vite:
+        specifier: ^5.2.3
+        version: 5.2.3(@types/node@20.11.28)(terser@5.29.2)
 
   packages/react-server/examples/basic:
     dependencies:
@@ -260,6 +260,9 @@ importers:
       '@types/react-dom':
         specifier: 18.3.0
         version: 18.3.0
+      vite:
+        specifier: ^5.2.3
+        version: 5.2.3(@types/node@20.11.28)(terser@5.29.2)
 
   packages/react-server/examples/prerender:
     dependencies:


### PR DESCRIPTION
Having `vite` in `dependencies` was for trying to have some zero config magic, but striving for that can be later. Let's just go with simpler one for now.

This would also help providing types from `"types": ["vite/client"]`.