### PR TITLE
feat: validate server-only and client-only

### DIFF
--- a/packages/react-server/examples/next/app/actions/client/actions.ts
+++ b/packages/react-server/examples/next/app/actions/client/actions.ts
@@ -1,7 +1,6 @@
 "use server";
 
-// import 'server-only'
-
+import "server-only";
 import { redirect } from "next/navigation";
 // import { headers, cookies } from 'next/headers'
 

--- a/packages/react-server/examples/next/app/actions/client/page.tsx
+++ b/packages/react-server/examples/next/app/actions/client/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import "client-only";
 import { useState } from "react";
 
 import double, {

--- a/packages/react-server/examples/next/vite.config.ts
+++ b/packages/react-server/examples/next/vite.config.ts
@@ -1,6 +1,52 @@
 import next from "next/vite";
-import { defineConfig } from "vite";
+import { type Plugin, defineConfig } from "vite";
 
 export default defineConfig({
-  plugins: [next()],
+  plugins: [
+    validateImportPlugin({
+      "client-only": { ok: true },
+      "server-only": {
+        ok: false,
+        message: `'server-only' is included in client build`,
+      },
+    }),
+    next({
+      plugins: [
+        validateImportPlugin({
+          "client-only": {
+            ok: false,
+            message: `'client-only' is included in client build`,
+          },
+          "server-only": { ok: true },
+        }),
+      ],
+    }),
+  ],
 });
+
+function validateImportPlugin(
+  entries: Record<string, { ok: true } | { ok: false; message: string }>,
+): Plugin {
+  return {
+    name: validateImportPlugin.name,
+    enforce: "pre",
+    resolveId(source, importer, options) {
+      const entry = entries[source];
+      if (entry) {
+        // skip validation during optimizeDeps scan since for now
+        // we want to allow going through server/client boundary loosely.
+        if (entry.ok || ("scan" in options && options.scan)) {
+          return "\0virtual:validate-import";
+        }
+        throw new Error(
+          entry.message + ` (importer: ${importer ?? "unknown"})`,
+        );
+      }
+    },
+    load(id, _options) {
+      if (id === "\0virtual:validate-import") {
+        return "export {}";
+      }
+    },
+  };
+}

--- a/packages/react-server/examples/next/vite.config.ts
+++ b/packages/react-server/examples/next/vite.config.ts
@@ -1,52 +1,6 @@
 import next from "next/vite";
-import { type Plugin, defineConfig } from "vite";
+import { defineConfig } from "vite";
 
 export default defineConfig({
-  plugins: [
-    validateImportPlugin({
-      "client-only": { ok: true },
-      "server-only": {
-        ok: false,
-        message: `'server-only' is included in client build`,
-      },
-    }),
-    next({
-      plugins: [
-        validateImportPlugin({
-          "client-only": {
-            ok: false,
-            message: `'client-only' is included in client build`,
-          },
-          "server-only": { ok: true },
-        }),
-      ],
-    }),
-  ],
+  plugins: [next()],
 });
-
-function validateImportPlugin(
-  entries: Record<string, { ok: true } | { ok: false; message: string }>,
-): Plugin {
-  return {
-    name: validateImportPlugin.name,
-    enforce: "pre",
-    resolveId(source, importer, options) {
-      const entry = entries[source];
-      if (entry) {
-        // skip validation during optimizeDeps scan since for now
-        // we want to allow going through server/client boundary loosely.
-        if (entry.ok || ("scan" in options && options.scan)) {
-          return "\0virtual:validate-import";
-        }
-        throw new Error(
-          entry.message + ` (importer: ${importer ?? "unknown"})`,
-        );
-      }
-    },
-    load(id, _options) {
-      if (id === "\0virtual:validate-import") {
-        return "export {}";
-      }
-    },
-  };
-}

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -422,7 +422,11 @@ function validateImportPlugin(entries: Record<string, string | true>): Plugin {
       if (entry) {
         // skip validation during optimizeDeps scan since for now
         // we want to allow going through server/client boundary loosely
-        if (entry || ("scan" in options && options.scan)) {
+        if (
+          entry ||
+          manager.buildType === "scan" ||
+          ("scan" in options && options.scan)
+        ) {
           return "\0virtual:validate-import";
         }
         throw new Error(entry + ` (importer: ${importer ?? "unknown"})`);


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/vite-plugins/issues/427

Not an essential feature (i.e. easily implemented on userland), but next.js code base includes this in a random place, so let's not break on that.