### PR TITLE
feat(next): ambient type via `next-env.d.ts`

### DIFF
--- a/packages/react-server-next/index.d.ts
+++ b/packages/react-server-next/index.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="vite/client" />
+/// <reference types="react" />
+/// <reference types="react/experimental" />
+/// <reference types="react-dom" />
+/// <reference types="react-dom/experimental" />
+
+export * from "./dist/compat";

--- a/packages/react-server-next/package.json
+++ b/packages/react-server-next/package.json
@@ -20,8 +20,7 @@
     },
     "./vite/*": "./dist/vite/*.js",
     ".": {
-      "types": "./dist/compat/index.d.ts",
-      "default": "./dist/compat/index.js"
+      "types": "./index.d.ts"
     },
     "./navigation": {
       "types": "./dist/compat/navigation.d.ts",

--- a/packages/react-server/examples/next/next-env.d.ts
+++ b/packages/react-server/examples/next/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/packages/react-server/examples/next/tsconfig.json
+++ b/packages/react-server/examples/next/tsconfig.json
@@ -1,18 +1,27 @@
 {
-  "include": ["**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"],
   "compilerOptions": {
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
     "skipLibCheck": true,
-    "verbatimModuleSyntax": true,
+    "strict": true,
     "noEmit": true,
-    "moduleResolution": "Bundler",
-    "module": "ESNext",
-    "target": "ESNext",
-    "lib": ["ESNext", "DOM"],
-    "types": ["vite/client", "react/experimental"],
-    "jsx": "preserve"
-  }
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
By providing an ambient type from the root `index.d.ts`, that will be picked up automatically via `next-env.d.ts`.