### PR TITLE
perf: set `build.write: false` during scan

### DIFF
--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -11,6 +11,7 @@ import {
   build,
   createLogger,
   createServer,
+  mergeConfig,
 } from "vite";
 import { CSS_LANGS_RE } from "../features/assets/css";
 import { vitePluginServerAssets } from "../features/assets/plugin";
@@ -340,7 +341,11 @@ export function vitePluginReactServer(options?: {
       if (!manager.buildType) {
         console.log("▶▶▶ REACT SERVER BUILD (scan) [1/4]");
         manager.buildType = "scan";
-        await build(reactServerViteConfig);
+        await build(
+          mergeConfig(reactServerViteConfig, {
+            build: { write: false },
+          } satisfies InlineConfig),
+        );
         console.log("▶▶▶ REACT SERVER BUILD (server) [2/4]");
         manager.buildType = "rsc";
         manager.rscUseClientIds.clear();


### PR DESCRIPTION
I just noticed this flag when checking autocomplete. It looks like Waku already make use of it as well https://github.com/dai-shi/waku/blob/aa8b021a2f1ab073abc601129b5d0d6c3bda8ca1/packages/waku/src/lib/builder/build.ts#L126-L127

I don't think this would affect perf much, but build logs get cleaner with this.