### PR TITLE
fix(next): shim `cookies` using `@edge-runtime/cookies`

### DIFF
--- a/packages/react-server-next/package.json
+++ b/packages/react-server-next/package.json
@@ -38,6 +38,7 @@
     "prepack": "tsup --clean"
   },
   "dependencies": {
+    "@edge-runtime/cookies": "^4.1.1",
     "@hiogawa/vite-plugin-ssr-middleware": "workspace:*",
     "@vitejs/plugin-react": "^4.2.1",
     "vite-tsconfig-paths": "^4.3.2"

--- a/packages/react-server-next/src/compat/headers.tsx
+++ b/packages/react-server-next/src/compat/headers.tsx
@@ -1,3 +1,5 @@
+import { ResponseCookies } from "@edge-runtime/cookies";
+
 /** @todo */
 export function headers() {
   return new Headers();
@@ -5,7 +7,7 @@ export function headers() {
 
 /** @todo */
 export function cookies() {
-  return {} as any;
+  return new ResponseCookies(new Headers());
 }
 
 /** @todo */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
 
   packages/react-server-next:
     dependencies:
+      '@edge-runtime/cookies':
+        specifier: ^4.1.1
+        version: 4.1.1
       '@hiogawa/vite-plugin-ssr-middleware':
         specifier: workspace:*
         version: link:../vite-plugin-ssr-middleware
@@ -1063,6 +1066,10 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@edge-runtime/cookies@4.1.1':
+    resolution: {integrity: sha512-ATZLTOpnCUD9ZLNBIXhxOmP/UVx6BfhCjDy9P1YACpD8vrHb5Uw7YlG9RYUl1AMF7Y10TIIN3jhFbUSMiH2J7g==}
+    engines: {node: '>=16'}
 
   '@emotion/hash@0.9.1':
     resolution: {integrity: sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==}
@@ -5008,6 +5015,8 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+
+  '@edge-runtime/cookies@4.1.1': {}
 
   '@emotion/hash@0.9.1': {}
 


### PR DESCRIPTION
This would unblock this demo https://app-router-vite.vercel.app/streaming/node/product/1