### PR TITLE
feat: support `metadata` export

### DIFF
--- a/packages/react-server-next/src/compat/index.tsx
+++ b/packages/react-server-next/src/compat/index.tsx
@@ -1,2 +1,1 @@
-/** @todo */
-export type Metadata = any;
+export type { Metadata } from "@hiogawa/react-server/server";

--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -1,9 +1,8 @@
-import fs from "node:fs";
 import { type Page, expect, test } from "@playwright/test";
-import type { Manifest } from "vite";
 import {
   checkNoError,
   editFile,
+  getClientManifest,
   inspectDevModules,
   setupCheckClientState,
   testNoJs,
@@ -1151,8 +1150,26 @@ async function testReactCache(page: Page, options: { js: boolean }) {
   if (options.js) await page.getByText("Inner2: state = 0").click();
 }
 
-function getClientManifest(): Manifest {
-  return JSON.parse(
-    fs.readFileSync("dist/client/.vite/manifest.json", "utf-8"),
-  );
+test("meta @js", async ({ page }) => {
+  await page.goto("/test");
+  await waitForHydration(page);
+  await testMetadata(page);
+});
+
+testNoJs("meta @nojs", async ({ page }) => {
+  await page.goto("/test");
+  await testMetadata(page);
+});
+
+async function testMetadata(page: Page) {
+  await expect(page).toHaveTitle("rsc-experiment");
+  if (1) {
+    return;
+  }
+
+  await page.getByRole("link", { name: "/test/other" }).click();
+  await expect(page).toHaveTitle("rsc-experiment");
+
+  await page.getByRole("link", { name: "/test/metadata" }).click();
+  await expect(page).toHaveTitle("test-metadata");
 }

--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -1163,9 +1163,6 @@ testNoJs("meta @nojs", async ({ page }) => {
 
 async function testMetadata(page: Page) {
   await expect(page).toHaveTitle("rsc-experiment");
-  if (1) {
-    return;
-  }
 
   await page.getByRole("link", { name: "/test/other" }).click();
   await expect(page).toHaveTitle("rsc-experiment");

--- a/packages/react-server/examples/basic/e2e/helper.ts
+++ b/packages/react-server/examples/basic/e2e/helper.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import test, { type Page, expect } from "@playwright/test";
+import type { Manifest } from "vite";
 
 export async function waitForHydration(page: Page) {
   await expect(page.getByText("[hydrated: 1]")).toBeVisible();
@@ -88,3 +89,9 @@ export async function inspectDevModules<T extends string>(
 export const testNoJs = test.extend({
   javaScriptEnabled: ({}, use) => use(false),
 });
+
+export function getClientManifest(): Manifest {
+  return JSON.parse(
+    fs.readFileSync("dist/client/.vite/manifest.json", "utf-8"),
+  );
+}

--- a/packages/react-server/examples/basic/src/routes/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/layout.tsx
@@ -1,13 +1,16 @@
-import type { LayoutProps } from "@hiogawa/react-server/server";
+import type { LayoutProps, Metadata } from "@hiogawa/react-server/server";
 import { Header } from "../components/header";
 import { NavMenu } from "../components/nav-menu";
+
+export const metadata: Metadata = {
+  title: "rsc-experiment",
+};
 
 export default function Layout(props: LayoutProps) {
   return (
     <html>
       <head>
         <meta charSet="UTF-8" />
-        <title>rsc-experiment</title>
         <link rel="icon" href="/favicon.ico" />
       </head>
       <body>

--- a/packages/react-server/examples/basic/src/routes/test/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/layout.tsx
@@ -25,6 +25,7 @@ export default async function Layout(props: LayoutProps) {
           "/test/revalidate",
           "/test/loading",
           "/test/cache",
+          "/test/metadata",
         ]}
       />
       <div className="flex items-center gap-2 text-sm">

--- a/packages/react-server/examples/basic/src/routes/test/metadata/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/metadata/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "@hiogawa/react-server/server";
+
+export const metadata: Metadata = {
+  title: "test-metadata",
+};
+
+export default function Layout() {
+  return (
+    <div className="p-2">
+      <h3 className="font-bold">Test Metadata</h3>
+    </div>
+  );
+}

--- a/packages/react-server/src/entry/browser.tsx
+++ b/packages/react-server/src/entry/browser.tsx
@@ -88,6 +88,7 @@ export async function start() {
           const next = await nextPromise;
           return {
             action: next.action,
+            metadata: next.metadata,
             layout: {
               ...current.layout,
               ...next.layout,

--- a/packages/react-server/src/entry/react-server.tsx
+++ b/packages/react-server/src/entry/react-server.tsx
@@ -114,6 +114,7 @@ async function render({
   return ReactServer.renderToReadableStream<ServerRouterData>(
     {
       layout: nodeMap,
+      metadata: result.metadata,
       action: actionResult
         ? objectPick(actionResult, ["data", "error"])
         : undefined,

--- a/packages/react-server/src/features/meta/server.tsx
+++ b/packages/react-server/src/features/meta/server.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from "./utils";
+
+export function renderMetadata(m: Metadata) {
+  return (
+    <>
+      {m.title && <title>{m.title}</title>}
+      {m.description && <meta name="description" content={m.description} />}
+    </>
+  );
+}

--- a/packages/react-server/src/features/meta/server.tsx
+++ b/packages/react-server/src/features/meta/server.tsx
@@ -3,8 +3,10 @@ import type { Metadata } from "./utils";
 export function renderMetadata(m: Metadata) {
   return (
     <>
-      {m.title && <title>{m.title}</title>}
-      {m.description && <meta name="description" content={m.description} />}
+      {typeof m.title === "string" && <title>{m.title}</title>}
+      {typeof m.description === "string" && (
+        <meta name="description" content={m.description} />
+      )}
     </>
   );
 }

--- a/packages/react-server/src/features/meta/utils.ts
+++ b/packages/react-server/src/features/meta/utils.ts
@@ -1,0 +1,5 @@
+// cf. https://github.com/vercel/next.js/blob/4b7924b15593322633fe2847f52bac8dbd5d9047/packages/next/src/lib/metadata/types/metadata-interface.ts#L40
+export type Metadata = {
+  title?: null | string;
+  description?: null | string;
+};

--- a/packages/react-server/src/features/router/__snapshots__/server.test.tsx.snap
+++ b/packages/react-server/src/features/router/__snapshots__/server.test.tsx.snap
@@ -87,6 +87,7 @@ exports[`generateRouteModuleTree > basic 2`] = `
       </ErrorBoundary>
     </React.Fragment>,
   },
+  "metadata": {},
   "pages": {
     "/x": </X/PAGE.TSX
       params={{}}
@@ -192,6 +193,7 @@ exports[`generateRouteModuleTree > basic 3`] = `
       </RedirectBoundary>
     <//X/Y/LAYOUT.TSX>,
   },
+  "metadata": {},
   "pages": {
     "/x/y": </X/Y/PAGE.TSX
       params={{}}
@@ -263,6 +265,7 @@ exports[`generateRouteModuleTree > basic 4`] = `
       </RedirectBoundary>
     </React.Fragment>,
   },
+  "metadata": {},
   "pages": {
     "/z": <ThrowNotFound
       params={{}}

--- a/packages/react-server/src/features/router/__snapshots__/server.test.tsx.snap
+++ b/packages/react-server/src/features/router/__snapshots__/server.test.tsx.snap
@@ -87,7 +87,7 @@ exports[`generateRouteModuleTree > basic 2`] = `
       </ErrorBoundary>
     </React.Fragment>,
   },
-  "metadata": {},
+  "metadata": <React.Fragment />,
   "pages": {
     "/x": </X/PAGE.TSX
       params={{}}
@@ -193,7 +193,7 @@ exports[`generateRouteModuleTree > basic 3`] = `
       </RedirectBoundary>
     <//X/Y/LAYOUT.TSX>,
   },
-  "metadata": {},
+  "metadata": <React.Fragment />,
   "pages": {
     "/x/y": </X/Y/PAGE.TSX
       params={{}}
@@ -265,7 +265,7 @@ exports[`generateRouteModuleTree > basic 4`] = `
       </RedirectBoundary>
     </React.Fragment>,
   },
-  "metadata": {},
+  "metadata": <React.Fragment />,
   "pages": {
     "/z": <ThrowNotFound
       params={{}}

--- a/packages/react-server/src/features/router/client.tsx
+++ b/packages/react-server/src/features/router/client.tsx
@@ -30,8 +30,15 @@ export function LayoutRoot() {
     <>
       <LayoutContent name={LAYOUT_ROOT_NAME} />
       <ActionRedirectHandler />
+      <MetadataRenderer />
     </>
   );
+}
+
+function MetadataRenderer() {
+  const ctx = React.useContext(LayoutStateContext);
+  const data = React.use(ctx.data);
+  return data.metadata;
 }
 
 export const ROUTER_REVALIDATE_KEY = "__REVALIDATE";

--- a/packages/react-server/src/features/router/server.tsx
+++ b/packages/react-server/src/features/router/server.tsx
@@ -1,13 +1,16 @@
 import React from "react";
 import { type ReactServerErrorContext, createError } from "../../lib/error";
+import type { Metadata } from "../meta/utils";
 import { type TreeNode, createFsRouteTree, matchRouteTree } from "./tree";
 
 // cf. https://nextjs.org/docs/app/building-your-application/routing#file-conventions
 interface RouteEntry {
   page?: {
+    metadata?: Metadata;
     default: React.FC<PageProps>;
   };
   layout?: {
+    metadata?: Metadata;
     default: React.FC<LayoutProps>;
   };
   error?: {

--- a/packages/react-server/src/features/router/server.tsx
+++ b/packages/react-server/src/features/router/server.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { type ReactServerErrorContext, createError } from "../../lib/error";
+import { renderMetadata } from "../meta/server";
 import type { Metadata } from "../meta/utils";
 import { type TreeNode, createFsRouteTree, matchRouteTree } from "./tree";
 
@@ -77,18 +78,21 @@ export async function renderRouteMap(
   };
   const pages: Record<string, React.ReactNode> = {};
   const layouts: Record<string, React.ReactNode> = {};
+  const metadata: Metadata = {};
   const result = matchRouteTree(tree, url.pathname);
   for (const m of result.matches) {
     const props: BaseProps = { ...baseProps, params: m.params };
     if (m.type === "layout") {
       layouts[m.prefix] = await renderLayout(m.node, props, m.prefix);
+      Object.assign(metadata, m.node.value?.layout?.metadata);
     } else if (m.type === "page") {
       pages[m.prefix] = renderPage(m.node, props);
+      Object.assign(metadata, m.node.value?.page?.metadata);
     } else {
       m.type satisfies never;
     }
   }
-  return { pages, layouts };
+  return { pages, layouts, metadata: renderMetadata(metadata) };
 }
 
 const ThrowNotFound: React.FC = () => {

--- a/packages/react-server/src/features/router/utils.tsx
+++ b/packages/react-server/src/features/router/utils.tsx
@@ -12,6 +12,7 @@ export type LayoutRequest = Record<
 
 export type ServerRouterData = {
   action?: Pick<ActionResult, "error" | "data">;
+  metadata?: React.ReactNode;
   layout: Record<string, React.ReactNode>;
 };
 

--- a/packages/react-server/src/server.ts
+++ b/packages/react-server/src/server.ts
@@ -10,3 +10,4 @@ export {
 } from "./lib/error";
 export type { ActionContext } from "./features/server-action/react-server";
 export { useActionContext } from "./features/server-action/context";
+export type { Metadata } from "./features/meta/utils";


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/vite-plugins/issues/397

For now, let's support minimal features to make simple next example looks a bit prettier.

## todo

- [x] test