### PR TITLE
feat: add hooks to provide current route params

### DIFF
--- a/packages/react-server-next/src/compat/navigation.tsx
+++ b/packages/react-server-next/src/compat/navigation.tsx
@@ -27,7 +27,7 @@ export function useParams<T extends Params = Params>(): T {
 }
 
 export function useSelectedLayoutSegments(_todo?: string): string[] {
-  const selected = useSelectedParams({ below: true });
+  const selected = useSelectedParams();
   return Object.values(selected);
 }
 

--- a/packages/react-server-next/src/compat/navigation.tsx
+++ b/packages/react-server-next/src/compat/navigation.tsx
@@ -2,6 +2,7 @@
 
 import {
   routerRevalidate,
+  useParams as useParams_,
   useRouter as useRouter_,
 } from "@hiogawa/react-server/client";
 import React from "react";
@@ -16,12 +17,12 @@ export function usePathname() {
 }
 
 interface Params {
+  /** @todo no array */
   [key: string]: string | string[];
 }
 
-/** @todo */
 export function useParams<T extends Params = Params>(): T {
-  return {} as any;
+  return useParams_() as any;
 }
 
 /** @todo */

--- a/packages/react-server-next/src/compat/navigation.tsx
+++ b/packages/react-server-next/src/compat/navigation.tsx
@@ -15,23 +15,22 @@ export function usePathname() {
   return useRouter_((s) => s.location.pathname);
 }
 
-/** @todo */
-export function useParams(): Record<string, string | string[]> {
-  return {};
+interface Params {
+  [key: string]: string | string[];
 }
 
 /** @todo */
-export function getSelectedLayoutSegmentPath(..._args: unknown[]): string[] {
+export function useParams<T extends Params = Params>(): T {
+  return {} as any;
+}
+
+/** @todo */
+export function useSelectedLayoutSegments(_todo?: string): string[] {
   return [];
 }
 
 /** @todo */
-export function useSelectedLayoutSegments(..._args: unknown[]): string[] {
-  return [];
-}
-
-/** @todo */
-export function useSelectedLayoutSegment(..._args: unknown[]): string | null {
+export function useSelectedLayoutSegment(_todo?: string): string | null {
   return null;
 }
 

--- a/packages/react-server-next/src/compat/navigation.tsx
+++ b/packages/react-server-next/src/compat/navigation.tsx
@@ -32,7 +32,7 @@ export function useSelectedLayoutSegments(_todo?: string): string[] {
 }
 
 export function useSelectedLayoutSegment(_todo?: string): string | null {
-  return useSelectedLayoutSegments().slice(-1)[0] ?? null;
+  return useSelectedLayoutSegments()[0] ?? null;
 }
 
 export function useRouter() {

--- a/packages/react-server-next/src/compat/navigation.tsx
+++ b/packages/react-server-next/src/compat/navigation.tsx
@@ -27,7 +27,7 @@ export function useParams<T extends Params = Params>(): T {
 }
 
 export function useSelectedLayoutSegments(_todo?: string): string[] {
-  const selected = useSelectedParams();
+  const selected = useSelectedParams({ below: true });
   return Object.values(selected);
 }
 

--- a/packages/react-server-next/src/compat/navigation.tsx
+++ b/packages/react-server-next/src/compat/navigation.tsx
@@ -4,6 +4,7 @@ import {
   routerRevalidate,
   useParams as useParams_,
   useRouter as useRouter_,
+  useSelectedParams,
 } from "@hiogawa/react-server/client";
 import React from "react";
 
@@ -25,14 +26,13 @@ export function useParams<T extends Params = Params>(): T {
   return useParams_() as any;
 }
 
-/** @todo */
 export function useSelectedLayoutSegments(_todo?: string): string[] {
-  return [];
+  const selected = useSelectedParams();
+  return Object.values(selected);
 }
 
-/** @todo */
 export function useSelectedLayoutSegment(_todo?: string): string | null {
-  return null;
+  return useSelectedLayoutSegments().slice(-1)[0] ?? null;
 }
 
 export function useRouter() {

--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -976,30 +976,30 @@ test("dynamic routes", async ({ page }) => {
 
   await page.getByText("file: /test/dynamic/page.tsx").click();
   await page.getByText("pathname: /test/dynamic").click();
-  await page.getByText("params: {}").click();
+  await page.getByText("props.params: {}").click();
 
   await page.getByRole("link", { name: "• /test/dynamic/static" }).click();
   await page.getByText("file: /test/dynamic/static/page.tsx").click();
   await page.getByText("pathname: /test/dynamic/static").click();
-  await page.getByText("params: {}").click();
+  await page.getByText("props.params: {}").click();
 
   await page
     .getByRole("link", { name: "• /test/dynamic/abc", exact: true })
     .click();
   await page.getByText("file: /test/dynamic/[id]/page.tsx").click();
   await page.getByText("pathname: /test/dynamic/abc").click();
-  await page.getByText('params: {"id":"abc"}').click();
+  await page.getByText('props.params: {"id":"abc"}').click();
 
   await page.getByRole("link", { name: "• /test/dynamic/abc/def" }).click();
   await page.getByText("file: /test/dynamic/[id]/[nested]/page.tsx").click();
   await page.getByText("pathname: /test/dynamic/abc/def").click();
-  await page.getByText('params: {"id":"abc","nested":"def"}').click();
+  await page.getByText('props.params: {"id":"abc","nested":"def"}').click();
 
   // regardless of Link.href prop
   // - pathname is always encoded
   // - param is always decoded
   await page.getByRole("link", { name: "/test/dynamic/✅" }).click();
-  await page.getByText('params: {"id":"✅"}').click();
+  await page.getByText('props.params: {"id":"✅"}').click();
   await page.waitForURL("/test/dynamic/✅");
   await expect(
     page.getByRole("link", { name: "/test/dynamic/✅" }),
@@ -1009,7 +1009,7 @@ test("dynamic routes", async ({ page }) => {
   ).toHaveAttribute("aria-current", "page");
 
   await page.getByRole("link", { name: "/test/dynamic/%E2%9C%85" }).click();
-  await page.getByText('params: {"id":"✅"}').click();
+  await page.getByText('props.params: {"id":"✅"}').click();
   await page.waitForURL("/test/dynamic/✅");
   await expect(
     page.getByRole("link", { name: "/test/dynamic/✅" }),
@@ -1053,13 +1053,13 @@ async function testCatchallRoute(page: Page, _options: { js: boolean }) {
   await page
     .getByRole("link", { name: "• /test/dynamic/catchall/static" })
     .click();
-  await page.getByText("params: {}").click();
+  await page.getByText("props.params: {}").click();
   await page.getByText("file: /test/dynamic/catchall/").click();
 
   await page
     .getByRole("link", { name: "• /test/dynamic/catchall/x", exact: true })
     .click();
-  await page.getByText('params: {"any":"x"}').click();
+  await page.getByText('props.params: {"any":"x"}').click();
   await page.getByText("file: /test/dynamic/catchall").click();
   await page.getByLabel("test state").check();
 
@@ -1067,7 +1067,7 @@ async function testCatchallRoute(page: Page, _options: { js: boolean }) {
     .getByRole("link", { name: "• /test/dynamic/catchall/x/y", exact: true })
     .click();
   await page.getByText("file: /test/dynamic/catchall").click();
-  await page.getByText('params: {"any":"x/y"}').click();
+  await page.getByText('props.params: {"any":"x/y"}').click();
   // state is not preserved
   await expect(page.getByLabel("test state")).not.toBeChecked();
 
@@ -1075,14 +1075,14 @@ async function testCatchallRoute(page: Page, _options: { js: boolean }) {
     .getByRole("link", { name: "• /test/dynamic/catchall/x/y/z" })
     .click();
   await page.getByText("file: /test/dynamic/catchall").click();
-  await page.getByText('params: {"any":"x/y/z"}').click();
+  await page.getByText('props.params: {"any":"x/y/z"}').click();
   await page.getByLabel("test state").check();
 
   await page
     .getByRole("link", { name: "• /test/dynamic/catchall/x/y/w" })
     .click();
   await page.getByText("file: /test/dynamic/catchall").click();
-  await page.getByText('params: {"any":"x/y/w"}').click();
+  await page.getByText('props.params: {"any":"x/y/w"}').click();
   // state is not preserved
   await expect(page.getByLabel("test state")).not.toBeChecked();
 }

--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -976,38 +976,30 @@ test("dynamic routes", async ({ page }) => {
 
   await page.getByText("file: /test/dynamic/page.tsx").click();
   await page.getByText("pathname: /test/dynamic").click();
-  await page.getByText("props.params: {}").click();
-  await page.getByText("useParams: {}").click();
-  await page.getByText("useSelectedParams: {}").click();
+  await page.getByText("params: {}").click();
 
   await page.getByRole("link", { name: "• /test/dynamic/static" }).click();
   await page.getByText("file: /test/dynamic/static/page.tsx").click();
   await page.getByText("pathname: /test/dynamic/static").click();
-  await page.getByText("props.params: {}").click();
-  await page.getByText("useParams: {}").click();
-  await page.getByText("useSelectedParams: {}").click();
+  await page.getByText("params: {}").click();
 
   await page
     .getByRole("link", { name: "• /test/dynamic/abc", exact: true })
     .click();
   await page.getByText("file: /test/dynamic/[id]/page.tsx").click();
   await page.getByText("pathname: /test/dynamic/abc").click();
-  await page.getByText('props.params: {"id":"abc"}').click();
-  await page.getByText('useParams: {"id":"abc"}').click();
-  await page.getByText('useSelectedParams: {"id":"abc"}').click();
+  await page.getByText('params: {"id":"abc"}').click();
 
   await page.getByRole("link", { name: "• /test/dynamic/abc/def" }).click();
   await page.getByText("file: /test/dynamic/[id]/[nested]/page.tsx").click();
   await page.getByText("pathname: /test/dynamic/abc/def").click();
-  await page.getByText('props.params: {"id":"abc","nested":"def"}').click();
-  await page.getByText('useParams: {"id":"abc","nested":"def"}').click();
-  await page.getByText('useSelectedParams: {"nested":"def"}').click();
+  await page.getByText('params: {"id":"abc","nested":"def"}').click();
 
   // regardless of Link.href prop
   // - pathname is always encoded
   // - param is always decoded
   await page.getByRole("link", { name: "/test/dynamic/✅" }).click();
-  await page.getByText('props.params: {"id":"✅"}').click();
+  await page.getByText('params: {"id":"✅"}').click();
   await page.waitForURL("/test/dynamic/✅");
   await expect(
     page.getByRole("link", { name: "/test/dynamic/✅" }),
@@ -1017,7 +1009,7 @@ test("dynamic routes", async ({ page }) => {
   ).toHaveAttribute("aria-current", "page");
 
   await page.getByRole("link", { name: "/test/dynamic/%E2%9C%85" }).click();
-  await page.getByText('props.params: {"id":"✅"}').click();
+  await page.getByText('params: {"id":"✅"}').click();
   await page.waitForURL("/test/dynamic/✅");
   await expect(
     page.getByRole("link", { name: "/test/dynamic/✅" }),
@@ -1061,15 +1053,13 @@ async function testCatchallRoute(page: Page, _options: { js: boolean }) {
   await page
     .getByRole("link", { name: "• /test/dynamic/catchall/static" })
     .click();
-  await page.getByText("props.params: {}").click();
-  await page.getByText("useParams: {}").click();
-  await page.getByText("useSelectedParams: {}").click();
+  await page.getByText("params: {}").click();
   await page.getByText("file: /test/dynamic/catchall/").click();
 
   await page
     .getByRole("link", { name: "• /test/dynamic/catchall/x", exact: true })
     .click();
-  await page.getByText('props.params: {"any":"x"}').click();
+  await page.getByText('params: {"any":"x"}').click();
   await page.getByText("file: /test/dynamic/catchall").click();
   await page.getByLabel("test state").check();
 
@@ -1077,9 +1067,7 @@ async function testCatchallRoute(page: Page, _options: { js: boolean }) {
     .getByRole("link", { name: "• /test/dynamic/catchall/x/y", exact: true })
     .click();
   await page.getByText("file: /test/dynamic/catchall").click();
-  await page.getByText('props.params: {"any":"x/y"}').click();
-  await page.getByText('useParams: {"any":"x/y"}').click();
-  await page.getByText('useSelectedParams: {"any":"x/y"}').click();
+  await page.getByText('params: {"any":"x/y"}').click();
   // state is not preserved
   await expect(page.getByLabel("test state")).not.toBeChecked();
 
@@ -1087,14 +1075,14 @@ async function testCatchallRoute(page: Page, _options: { js: boolean }) {
     .getByRole("link", { name: "• /test/dynamic/catchall/x/y/z" })
     .click();
   await page.getByText("file: /test/dynamic/catchall").click();
-  await page.getByText('props.params: {"any":"x/y/z"}').click();
+  await page.getByText('params: {"any":"x/y/z"}').click();
   await page.getByLabel("test state").check();
 
   await page
     .getByRole("link", { name: "• /test/dynamic/catchall/x/y/w" })
     .click();
   await page.getByText("file: /test/dynamic/catchall").click();
-  await page.getByText('props.params: {"any":"x/y/w"}').click();
+  await page.getByText('params: {"any":"x/y/w"}').click();
   // state is not preserved
   await expect(page.getByLabel("test state")).not.toBeChecked();
 }

--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -977,11 +977,15 @@ test("dynamic routes", async ({ page }) => {
   await page.getByText("file: /test/dynamic/page.tsx").click();
   await page.getByText("pathname: /test/dynamic").click();
   await page.getByText("props.params: {}").click();
+  await page.getByText("useParams: {}").click();
+  await page.getByText("useSelectedParams: {}").click();
 
   await page.getByRole("link", { name: "• /test/dynamic/static" }).click();
   await page.getByText("file: /test/dynamic/static/page.tsx").click();
   await page.getByText("pathname: /test/dynamic/static").click();
   await page.getByText("props.params: {}").click();
+  await page.getByText("useParams: {}").click();
+  await page.getByText("useSelectedParams: {}").click();
 
   await page
     .getByRole("link", { name: "• /test/dynamic/abc", exact: true })
@@ -989,11 +993,15 @@ test("dynamic routes", async ({ page }) => {
   await page.getByText("file: /test/dynamic/[id]/page.tsx").click();
   await page.getByText("pathname: /test/dynamic/abc").click();
   await page.getByText('props.params: {"id":"abc"}').click();
+  await page.getByText('useParams: {"id":"abc"}').click();
+  await page.getByText('useSelectedParams: {"id":"abc"}').click();
 
   await page.getByRole("link", { name: "• /test/dynamic/abc/def" }).click();
   await page.getByText("file: /test/dynamic/[id]/[nested]/page.tsx").click();
   await page.getByText("pathname: /test/dynamic/abc/def").click();
   await page.getByText('props.params: {"id":"abc","nested":"def"}').click();
+  await page.getByText('useParams: {"id":"abc","nested":"def"}').click();
+  await page.getByText('useSelectedParams: {"nested":"def"}').click();
 
   // regardless of Link.href prop
   // - pathname is always encoded
@@ -1054,6 +1062,8 @@ async function testCatchallRoute(page: Page, _options: { js: boolean }) {
     .getByRole("link", { name: "• /test/dynamic/catchall/static" })
     .click();
   await page.getByText("props.params: {}").click();
+  await page.getByText("useParams: {}").click();
+  await page.getByText("useSelectedParams: {}").click();
   await page.getByText("file: /test/dynamic/catchall/").click();
 
   await page
@@ -1068,6 +1078,8 @@ async function testCatchallRoute(page: Page, _options: { js: boolean }) {
     .click();
   await page.getByText("file: /test/dynamic/catchall").click();
   await page.getByText('props.params: {"any":"x/y"}').click();
+  await page.getByText('useParams: {"any":"x/y"}').click();
+  await page.getByText('useSelectedParams: {"any":"x/y"}').click();
   // state is not preserved
   await expect(page.getByLabel("test state")).not.toBeChecked();
 

--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -1087,6 +1087,41 @@ async function testCatchallRoute(page: Page, _options: { js: boolean }) {
   await expect(page.getByLabel("test state")).not.toBeChecked();
 }
 
+test("useSelectedParams", async ({ page }) => {
+  await page.goto("/test/dynamic/selected");
+  await page.getByText("/layout.tsx: {}").click();
+  await page.getByText("/page.tsx: {}").click();
+
+  await page
+    .getByRole("link", { name: "• /test/dynamic/selected/x", exact: true })
+    .click();
+  await page.getByText('/layout.tsx: {"p1":"x"}').click();
+  await page.getByText("/[p1]/layout.tsx: {}").click();
+
+  await page
+    .getByRole("link", { name: "• /test/dynamic/selected/x/y" })
+    .click();
+  await page.getByText('/layout.tsx: {"p1":"x","p2":"y"}').click();
+  await page.getByText('/[p1]/layout.tsx: {"p2":"y"}').click();
+  await page.getByText("/[p1]/[p2]/layout.tsx: {}").click();
+
+  await page
+    .getByRole("link", {
+      name: "• /test/dynamic/selected/x/static",
+      exact: true,
+    })
+    .click();
+  await page.getByText('/layout.tsx: {"p1":"x"}').click();
+  await page.getByText("/[p1]/layout.tsx: {}").click();
+
+  await page
+    .getByRole("link", { name: "• /test/dynamic/selected/x/static/y" })
+    .click();
+  await page.getByText('/layout.tsx: {"p1":"x","q1":"y"}').click();
+  await page.getByText('/[p1]/layout.tsx: {"q1":"y"}').click();
+  await page.getByText('/[p1]/static/layout.tsx: {"q1":"y"}').click();
+});
+
 test("full client route", async ({ page }) => {
   checkNoError(page);
   await page.goto("/test/client/full");

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/_cilent.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/_cilent.tsx
@@ -1,23 +1,8 @@
 "use client";
 
-import {
-  useParams,
-  useRouter,
-  useSelectedParams,
-} from "@hiogawa/react-server/client";
+import { useRouter } from "@hiogawa/react-server/client";
 
 export function ClientLocation() {
   const location = useRouter((s) => s.location);
   return <>{location.pathname}</>;
-}
-
-export function ClientParams() {
-  const params = useParams();
-  const selectedParams = useSelectedParams();
-  return (
-    <>
-      <div>useParams: {JSON.stringify(params)}</div>
-      <div>useSelectedParams: {JSON.stringify(selectedParams)}</div>
-    </>
-  );
 }

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/_cilent.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/_cilent.tsx
@@ -16,8 +16,8 @@ export function ClientParams() {
   const selectedParams = useSelectedParams();
   return (
     <>
-      <pre>useParams: {JSON.stringify(params)}</pre>
-      <pre>useSelectedParams: {JSON.stringify(selectedParams)}</pre>
+      <div>useParams: {JSON.stringify(params)}</div>
+      <div>useSelectedParams: {JSON.stringify(selectedParams)}</div>
     </>
   );
 }

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/_cilent.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/_cilent.tsx
@@ -1,8 +1,23 @@
 "use client";
 
-import { useRouter } from "@hiogawa/react-server/client";
+import {
+  useParams,
+  useRouter,
+  useSelectedParams,
+} from "@hiogawa/react-server/client";
 
 export function ClientLocation() {
   const location = useRouter((s) => s.location);
   return <>{location.pathname}</>;
+}
+
+export function ClientParams() {
+  const params = useParams();
+  const selectedParams = useSelectedParams();
+  return (
+    <>
+      <pre>useParams: {JSON.stringify(params)}</pre>
+      <pre>useSelectedParams: {JSON.stringify(selectedParams)}</pre>
+    </>
+  );
 }

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/_utils.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/_utils.tsx
@@ -18,7 +18,7 @@ export function TestDynamic({
       <div>
         pathname (client): <ClientLocation />
       </div>
-      <div>params: {JSON.stringify(props.params)}</div>
+      <div>props.params: {JSON.stringify(props.params)}</div>
       <ClientParams />
     </div>
   );

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/_utils.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/_utils.tsx
@@ -1,5 +1,5 @@
 import type { PageProps } from "@hiogawa/react-server/server";
-import { ClientLocation } from "./_cilent";
+import { ClientLocation, ClientParams } from "./_cilent";
 
 export function TestDynamic({
   file: file,
@@ -19,6 +19,7 @@ export function TestDynamic({
         pathname (client): <ClientLocation />
       </div>
       <div>params: {JSON.stringify(props.params)}</div>
+      <ClientParams />
     </div>
   );
 }

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/_utils.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/_utils.tsx
@@ -1,5 +1,5 @@
 import type { PageProps } from "@hiogawa/react-server/server";
-import { ClientLocation, ClientParams } from "./_cilent";
+import { ClientLocation } from "./_cilent";
 
 export function TestDynamic({
   file: file,
@@ -18,8 +18,7 @@ export function TestDynamic({
       <div>
         pathname (client): <ClientLocation />
       </div>
-      <div>props.params: {JSON.stringify(props.params)}</div>
-      <ClientParams />
+      <div>params: {JSON.stringify(props.params)}</div>
     </div>
   );
 }

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/layout.tsx
@@ -6,7 +6,7 @@ export default function Layout(props: LayoutProps) {
     <div className="flex flex-col gap-2 p-2">
       <h3 className="font-bold">Dynamic Route Test</h3>
       <NavMenu
-        className="flex flex-col items-start gap-1"
+        className="grid grid-cols-2 gap-1"
         links={[
           "/test/dynamic",
           "/test/dynamic/static",
@@ -20,6 +20,7 @@ export default function Layout(props: LayoutProps) {
           "/test/dynamic/catchall/x/y",
           "/test/dynamic/catchall/x/y/z",
           "/test/dynamic/catchall/x/y/w",
+          "/test/dynamic/selected",
         ]}
         activeProps={{
           "aria-current": "page",

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/selected/[p1]/[p2]/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/selected/[p1]/[p2]/layout.tsx
@@ -1,0 +1,13 @@
+import type { LayoutProps } from "@hiogawa/react-server/server";
+import { SelectedParams } from "../../_client";
+
+export default function Page(props: LayoutProps) {
+  return (
+    <>
+      <pre>
+        /[p1]/[p2]/layout.tsx: <SelectedParams />
+      </pre>
+      {props.children}
+    </>
+  );
+}

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/selected/[p1]/[p2]/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/selected/[p1]/[p2]/page.tsx
@@ -1,0 +1,9 @@
+import { SelectedParams } from "../../_client";
+
+export default function Page() {
+  return (
+    <pre>
+      /[p1]/[p2]/page.tsx: <SelectedParams />
+    </pre>
+  );
+}

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/selected/[p1]/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/selected/[p1]/layout.tsx
@@ -1,0 +1,13 @@
+import type { LayoutProps } from "@hiogawa/react-server/server";
+import { SelectedParams } from "../_client";
+
+export default function Page(props: LayoutProps) {
+  return (
+    <>
+      <pre>
+        /[p1]/layout.tsx: <SelectedParams />
+      </pre>
+      {props.children}
+    </>
+  );
+}

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/selected/[p1]/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/selected/[p1]/page.tsx
@@ -1,0 +1,9 @@
+import { SelectedParams } from "../_client";
+
+export default function Page() {
+  return (
+    <pre>
+      /[p1]/page.tsx: <SelectedParams />
+    </pre>
+  );
+}

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/selected/[p1]/static/[q1]/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/selected/[p1]/static/[q1]/layout.tsx
@@ -1,0 +1,13 @@
+import type { LayoutProps } from "@hiogawa/react-server/server";
+import { SelectedParams } from "../../../_client";
+
+export default function Page(props: LayoutProps) {
+  return (
+    <>
+      <pre>
+        /[p1]/static/[q1]/layout.tsx: <SelectedParams />
+      </pre>
+      {props.children}
+    </>
+  );
+}

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/selected/[p1]/static/[q1]/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/selected/[p1]/static/[q1]/page.tsx
@@ -1,0 +1,9 @@
+import { SelectedParams } from "../../../_client";
+
+export default function Page() {
+  return (
+    <pre>
+      /[p1]/static/[q1]/page.tsx: <SelectedParams />
+    </pre>
+  );
+}

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/selected/[p1]/static/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/selected/[p1]/static/layout.tsx
@@ -1,0 +1,13 @@
+import type { LayoutProps } from "@hiogawa/react-server/server";
+import { SelectedParams } from "../../_client";
+
+export default function Page(props: LayoutProps) {
+  return (
+    <>
+      <pre>
+        /[p1]/static/layout.tsx: <SelectedParams />
+      </pre>
+      {props.children}
+    </>
+  );
+}

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/selected/[p1]/static/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/selected/[p1]/static/page.tsx
@@ -1,0 +1,9 @@
+import { SelectedParams } from "../../_client";
+
+export default function Page() {
+  return (
+    <pre>
+      /[p1]/static/page.tsx: <SelectedParams />
+    </pre>
+  );
+}

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/selected/_client.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/selected/_client.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { useSelectedParams } from "@hiogawa/react-server/client";
+
+export function SelectedParams() {
+  const params = useSelectedParams({ below: true });
+  return <>{JSON.stringify(params)}</>;
+}

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/selected/_client.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/selected/_client.tsx
@@ -3,6 +3,6 @@
 import { useSelectedParams } from "@hiogawa/react-server/client";
 
 export function SelectedParams() {
-  const params = useSelectedParams({ below: true });
+  const params = useSelectedParams();
   return <>{JSON.stringify(params)}</>;
 }

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/selected/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/selected/layout.tsx
@@ -1,0 +1,25 @@
+import type { LayoutProps } from "@hiogawa/react-server/server";
+import { NavMenu } from "../../../../components/nav-menu";
+import { SelectedParams } from "./_client";
+
+export default function Page(props: LayoutProps) {
+  return (
+    <div className="flex flex-col gap-2 text-sm">
+      <h3 className="font-bold">Test useSelectedParams</h3>
+      <NavMenu
+        className="grid grid-cols-2 gap-1"
+        links={[
+          "/test/dynamic/selected",
+          "/test/dynamic/selected/x",
+          "/test/dynamic/selected/x/y",
+          "/test/dynamic/selected/x/static",
+          "/test/dynamic/selected/x/static/y",
+        ]}
+      />
+      <pre>
+        /layout.tsx: <SelectedParams />
+      </pre>
+      {props.children}
+    </div>
+  );
+}

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/selected/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/selected/page.tsx
@@ -1,0 +1,9 @@
+import { SelectedParams } from "./_client";
+
+export default function Page() {
+  return (
+    <pre>
+      /page.tsx: <SelectedParams />
+    </pre>
+  );
+}

--- a/packages/react-server/examples/next/.gitignore
+++ b/packages/react-server/examples/next/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+tsconfig.tsbuildinfo

--- a/packages/react-server/src/client.tsx
+++ b/packages/react-server/src/client.tsx
@@ -2,6 +2,8 @@
 
 export { Link, LinkForm } from "./lib/client/link";
 export { useRouter } from "./lib/client/router";
-export { routerRevalidate } from "./features/router/client";
-export { useLayoutMatch } from "./features/router/client";
-export { useParams } from "./features/router/client";
+export {
+  routerRevalidate,
+  useParams,
+  useSelectedParams,
+} from "./features/router/client";

--- a/packages/react-server/src/client.tsx
+++ b/packages/react-server/src/client.tsx
@@ -4,3 +4,4 @@ export { Link, LinkForm } from "./lib/client/link";
 export { useRouter } from "./lib/client/router";
 export { routerRevalidate } from "./features/router/client";
 export { useLayoutMatch } from "./features/router/client";
+export { useParams } from "./features/router/client";

--- a/packages/react-server/src/client.tsx
+++ b/packages/react-server/src/client.tsx
@@ -3,3 +3,4 @@
 export { Link, LinkForm } from "./lib/client/link";
 export { useRouter } from "./lib/client/router";
 export { routerRevalidate } from "./features/router/client";
+export { useLayoutMatch } from "./features/router/client";

--- a/packages/react-server/src/entry/browser.tsx
+++ b/packages/react-server/src/entry/browser.tsx
@@ -89,6 +89,7 @@ export async function start() {
           return {
             action: next.action,
             metadata: next.metadata,
+            params: next.params,
             layout: {
               ...current.layout,
               ...next.layout,

--- a/packages/react-server/src/entry/react-server.tsx
+++ b/packages/react-server/src/entry/react-server.tsx
@@ -106,6 +106,7 @@ async function render({
   actionResult?: ActionResult;
 }) {
   const result = await renderRouteMap(router.tree, request);
+  console.log(result);
   const nodeMap = objectMapValues(
     layoutRequest,
     (v) => result[`${v.type}s`][v.name],
@@ -115,6 +116,7 @@ async function render({
     {
       layout: nodeMap,
       metadata: result.metadata,
+      params: result.params,
       action: actionResult
         ? objectPick(actionResult, ["data", "error"])
         : undefined,

--- a/packages/react-server/src/entry/react-server.tsx
+++ b/packages/react-server/src/entry/react-server.tsx
@@ -106,7 +106,6 @@ async function render({
   actionResult?: ActionResult;
 }) {
   const result = await renderRouteMap(router.tree, request);
-  console.log(result);
   const nodeMap = objectMapValues(
     layoutRequest,
     (v) => result[`${v.type}s`][v.name],

--- a/packages/react-server/src/features/router/__snapshots__/server.test.tsx.snap
+++ b/packages/react-server/src/features/router/__snapshots__/server.test.tsx.snap
@@ -48,7 +48,12 @@ exports[`generateRouteModuleTree > basic 2`] = `
     "/": <LayoutMatchProvider
       value={
         {
-          "params": {},
+          "params": [
+            [
+              null,
+              "",
+            ],
+          ],
         }
       }
     >
@@ -86,7 +91,16 @@ exports[`generateRouteModuleTree > basic 2`] = `
     "/x": <LayoutMatchProvider
       value={
         {
-          "params": {},
+          "params": [
+            [
+              null,
+              "",
+            ],
+            [
+              null,
+              "x",
+            ],
+          ],
         }
       }
     >
@@ -130,7 +144,16 @@ exports[`generateRouteModuleTree > basic 2`] = `
       }
     />,
   },
-  "params": {},
+  "params": [
+    [
+      null,
+      "",
+    ],
+    [
+      null,
+      "x",
+    ],
+  ],
 }
 `;
 
@@ -141,7 +164,12 @@ exports[`generateRouteModuleTree > basic 3`] = `
     "/": <LayoutMatchProvider
       value={
         {
-          "params": {},
+          "params": [
+            [
+              null,
+              "",
+            ],
+          ],
         }
       }
     >
@@ -179,7 +207,16 @@ exports[`generateRouteModuleTree > basic 3`] = `
     "/x": <LayoutMatchProvider
       value={
         {
-          "params": {},
+          "params": [
+            [
+              null,
+              "",
+            ],
+            [
+              null,
+              "x",
+            ],
+          ],
         }
       }
     >
@@ -198,7 +235,20 @@ exports[`generateRouteModuleTree > basic 3`] = `
     "/x/y": <LayoutMatchProvider
       value={
         {
-          "params": {},
+          "params": [
+            [
+              null,
+              "",
+            ],
+            [
+              null,
+              "x",
+            ],
+            [
+              null,
+              "y",
+            ],
+          ],
         }
       }
     >
@@ -261,7 +311,20 @@ exports[`generateRouteModuleTree > basic 3`] = `
       }
     />,
   },
-  "params": {},
+  "params": [
+    [
+      null,
+      "",
+    ],
+    [
+      null,
+      "x",
+    ],
+    [
+      null,
+      "y",
+    ],
+  ],
 }
 `;
 
@@ -272,7 +335,12 @@ exports[`generateRouteModuleTree > basic 4`] = `
     "/": <LayoutMatchProvider
       value={
         {
-          "params": {},
+          "params": [
+            [
+              null,
+              "",
+            ],
+          ],
         }
       }
     >
@@ -310,7 +378,12 @@ exports[`generateRouteModuleTree > basic 4`] = `
     "/z": <LayoutMatchProvider
       value={
         {
-          "params": {},
+          "params": [
+            [
+              null,
+              "",
+            ],
+          ],
         }
       }
     >
@@ -350,6 +423,11 @@ exports[`generateRouteModuleTree > basic 4`] = `
       }
     />,
   },
-  "params": {},
+  "params": [
+    [
+      null,
+      "",
+    ],
+  ],
 }
 `;

--- a/packages/react-server/src/features/router/__snapshots__/server.test.tsx.snap
+++ b/packages/react-server/src/features/router/__snapshots__/server.test.tsx.snap
@@ -45,47 +45,63 @@ exports[`generateRouteModuleTree > basic 2`] = `
 {
   "__pathname": "/x",
   "layouts": {
-    "/": </LAYOUT.TSX
-      params={{}}
-      request={
+    "/": <LayoutMatchProvider
+      value={
         {
-          "headers": {},
-          "url": "https://test.local/x",
-        }
-      }
-      url={
-        {
-          "hash": "",
-          "host": "test.local",
-          "hostname": "test.local",
-          "href": "https://test.local/x",
-          "origin": "https://test.local",
-          "password": "",
-          "pathname": "/x",
-          "port": "",
-          "protocol": "https:",
-          "search": "",
-          "username": "",
+          "params": {},
         }
       }
     >
-      <RedirectBoundary>
-        <LayoutContent
-          name="/"
-        />
-      </RedirectBoundary>
-    <//LAYOUT.TSX>,
-    "/x": <React.Fragment>
-      <ErrorBoundary
-        errorComponent="/X/ERROR.TSX"
+      </LAYOUT.TSX
+        params={{}}
+        request={
+          {
+            "headers": {},
+            "url": "https://test.local/x",
+          }
+        }
+        url={
+          {
+            "hash": "",
+            "host": "test.local",
+            "hostname": "test.local",
+            "href": "https://test.local/x",
+            "origin": "https://test.local",
+            "password": "",
+            "pathname": "/x",
+            "port": "",
+            "protocol": "https:",
+            "search": "",
+            "username": "",
+          }
+        }
       >
         <RedirectBoundary>
           <LayoutContent
-            name="/x"
+            name="/"
           />
         </RedirectBoundary>
-      </ErrorBoundary>
-    </React.Fragment>,
+      <//LAYOUT.TSX>
+    </LayoutMatchProvider>,
+    "/x": <LayoutMatchProvider
+      value={
+        {
+          "params": {},
+        }
+      }
+    >
+      <React.Fragment>
+        <ErrorBoundary
+          errorComponent="/X/ERROR.TSX"
+        >
+          <RedirectBoundary>
+            <LayoutContent
+              name="/x"
+            />
+          </RedirectBoundary>
+        </ErrorBoundary>
+      </React.Fragment>
+    </LayoutMatchProvider>,
   },
   "metadata": <React.Fragment />,
   "pages": {
@@ -114,6 +130,7 @@ exports[`generateRouteModuleTree > basic 2`] = `
       }
     />,
   },
+  "params": {},
 }
 `;
 
@@ -121,77 +138,101 @@ exports[`generateRouteModuleTree > basic 3`] = `
 {
   "__pathname": "/x/y",
   "layouts": {
-    "/": </LAYOUT.TSX
-      params={{}}
-      request={
+    "/": <LayoutMatchProvider
+      value={
         {
-          "headers": {},
-          "url": "https://test.local/x/y",
-        }
-      }
-      url={
-        {
-          "hash": "",
-          "host": "test.local",
-          "hostname": "test.local",
-          "href": "https://test.local/x/y",
-          "origin": "https://test.local",
-          "password": "",
-          "pathname": "/x/y",
-          "port": "",
-          "protocol": "https:",
-          "search": "",
-          "username": "",
+          "params": {},
         }
       }
     >
-      <RedirectBoundary>
-        <LayoutContent
-          name="/"
-        />
-      </RedirectBoundary>
-    <//LAYOUT.TSX>,
-    "/x": <React.Fragment>
-      <ErrorBoundary
-        errorComponent="/X/ERROR.TSX"
+      </LAYOUT.TSX
+        params={{}}
+        request={
+          {
+            "headers": {},
+            "url": "https://test.local/x/y",
+          }
+        }
+        url={
+          {
+            "hash": "",
+            "host": "test.local",
+            "hostname": "test.local",
+            "href": "https://test.local/x/y",
+            "origin": "https://test.local",
+            "password": "",
+            "pathname": "/x/y",
+            "port": "",
+            "protocol": "https:",
+            "search": "",
+            "username": "",
+          }
+        }
       >
         <RedirectBoundary>
           <LayoutContent
-            name="/x"
+            name="/"
           />
         </RedirectBoundary>
-      </ErrorBoundary>
-    </React.Fragment>,
-    "/x/y": </X/Y/LAYOUT.TSX
-      params={{}}
-      request={
+      <//LAYOUT.TSX>
+    </LayoutMatchProvider>,
+    "/x": <LayoutMatchProvider
+      value={
         {
-          "headers": {},
-          "url": "https://test.local/x/y",
-        }
-      }
-      url={
-        {
-          "hash": "",
-          "host": "test.local",
-          "hostname": "test.local",
-          "href": "https://test.local/x/y",
-          "origin": "https://test.local",
-          "password": "",
-          "pathname": "/x/y",
-          "port": "",
-          "protocol": "https:",
-          "search": "",
-          "username": "",
+          "params": {},
         }
       }
     >
-      <RedirectBoundary>
-        <LayoutContent
-          name="/x/y"
-        />
-      </RedirectBoundary>
-    <//X/Y/LAYOUT.TSX>,
+      <React.Fragment>
+        <ErrorBoundary
+          errorComponent="/X/ERROR.TSX"
+        >
+          <RedirectBoundary>
+            <LayoutContent
+              name="/x"
+            />
+          </RedirectBoundary>
+        </ErrorBoundary>
+      </React.Fragment>
+    </LayoutMatchProvider>,
+    "/x/y": <LayoutMatchProvider
+      value={
+        {
+          "params": {},
+        }
+      }
+    >
+      </X/Y/LAYOUT.TSX
+        params={{}}
+        request={
+          {
+            "headers": {},
+            "url": "https://test.local/x/y",
+          }
+        }
+        url={
+          {
+            "hash": "",
+            "host": "test.local",
+            "hostname": "test.local",
+            "href": "https://test.local/x/y",
+            "origin": "https://test.local",
+            "password": "",
+            "pathname": "/x/y",
+            "port": "",
+            "protocol": "https:",
+            "search": "",
+            "username": "",
+          }
+        }
+      >
+        <RedirectBoundary>
+          <LayoutContent
+            name="/x/y"
+          />
+        </RedirectBoundary>
+      <//X/Y/LAYOUT.TSX>
+    </LayoutMatchProvider>,
   },
   "metadata": <React.Fragment />,
   "pages": {
@@ -220,6 +261,7 @@ exports[`generateRouteModuleTree > basic 3`] = `
       }
     />,
   },
+  "params": {},
 }
 `;
 
@@ -227,43 +269,59 @@ exports[`generateRouteModuleTree > basic 4`] = `
 {
   "__pathname": "/z",
   "layouts": {
-    "/": </LAYOUT.TSX
-      params={{}}
-      request={
+    "/": <LayoutMatchProvider
+      value={
         {
-          "headers": {},
-          "url": "https://test.local/z",
-        }
-      }
-      url={
-        {
-          "hash": "",
-          "host": "test.local",
-          "hostname": "test.local",
-          "href": "https://test.local/z",
-          "origin": "https://test.local",
-          "password": "",
-          "pathname": "/z",
-          "port": "",
-          "protocol": "https:",
-          "search": "",
-          "username": "",
+          "params": {},
         }
       }
     >
-      <RedirectBoundary>
-        <LayoutContent
-          name="/"
-        />
-      </RedirectBoundary>
-    <//LAYOUT.TSX>,
-    "/z": <React.Fragment>
-      <RedirectBoundary>
-        <LayoutContent
-          name="/z"
-        />
-      </RedirectBoundary>
-    </React.Fragment>,
+      </LAYOUT.TSX
+        params={{}}
+        request={
+          {
+            "headers": {},
+            "url": "https://test.local/z",
+          }
+        }
+        url={
+          {
+            "hash": "",
+            "host": "test.local",
+            "hostname": "test.local",
+            "href": "https://test.local/z",
+            "origin": "https://test.local",
+            "password": "",
+            "pathname": "/z",
+            "port": "",
+            "protocol": "https:",
+            "search": "",
+            "username": "",
+          }
+        }
+      >
+        <RedirectBoundary>
+          <LayoutContent
+            name="/"
+          />
+        </RedirectBoundary>
+      <//LAYOUT.TSX>
+    </LayoutMatchProvider>,
+    "/z": <LayoutMatchProvider
+      value={
+        {
+          "params": {},
+        }
+      }
+    >
+      <React.Fragment>
+        <RedirectBoundary>
+          <LayoutContent
+            name="/z"
+          />
+        </RedirectBoundary>
+      </React.Fragment>
+    </LayoutMatchProvider>,
   },
   "metadata": <React.Fragment />,
   "pages": {
@@ -292,5 +350,6 @@ exports[`generateRouteModuleTree > basic 4`] = `
       }
     />,
   },
+  "params": {},
 }
 `;

--- a/packages/react-server/src/features/router/__snapshots__/tree.test.ts.snap
+++ b/packages/react-server/src/features/router/__snapshots__/tree.test.ts.snap
@@ -85,7 +85,12 @@ exports[`createFsRouteTree > basic 2`] = `
         "layout": "/layout.tsx",
         "page": "/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+      ],
       "prefix": "/",
       "type": "layout",
     },
@@ -94,7 +99,12 @@ exports[`createFsRouteTree > basic 2`] = `
         "layout": "/layout.tsx",
         "page": "/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+      ],
       "prefix": "/",
       "type": "page",
     },
@@ -111,7 +121,12 @@ exports[`createFsRouteTree > basic 3`] = `
         "layout": "/layout.tsx",
         "page": "/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+      ],
       "prefix": "/",
       "type": "layout",
     },
@@ -119,7 +134,16 @@ exports[`createFsRouteTree > basic 3`] = `
       "node": {
         "page": "/other/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "other",
+        ],
+      ],
       "prefix": "/other",
       "type": "layout",
     },
@@ -127,7 +151,16 @@ exports[`createFsRouteTree > basic 3`] = `
       "node": {
         "page": "/other/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "other",
+        ],
+      ],
       "prefix": "/other",
       "type": "page",
     },
@@ -144,19 +177,34 @@ exports[`createFsRouteTree > basic 4`] = `
         "layout": "/layout.tsx",
         "page": "/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+      ],
       "prefix": "/",
       "type": "layout",
     },
     {
       "node": undefined,
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+      ],
       "prefix": "/not-found",
       "type": "layout",
     },
     {
       "node": undefined,
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+      ],
       "prefix": "/not-found",
       "type": "page",
     },
@@ -173,7 +221,12 @@ exports[`createFsRouteTree > basic 5`] = `
         "layout": "/layout.tsx",
         "page": "/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+      ],
       "prefix": "/",
       "type": "layout",
     },
@@ -182,7 +235,16 @@ exports[`createFsRouteTree > basic 5`] = `
         "layout": "/test/layout.tsx",
         "page": "/test/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "test",
+        ],
+      ],
       "prefix": "/test",
       "type": "layout",
     },
@@ -191,7 +253,16 @@ exports[`createFsRouteTree > basic 5`] = `
         "layout": "/test/layout.tsx",
         "page": "/test/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "test",
+        ],
+      ],
       "prefix": "/test",
       "type": "page",
     },
@@ -208,7 +279,12 @@ exports[`createFsRouteTree > basic 6`] = `
         "layout": "/layout.tsx",
         "page": "/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+      ],
       "prefix": "/",
       "type": "layout",
     },
@@ -217,7 +293,16 @@ exports[`createFsRouteTree > basic 6`] = `
         "layout": "/test/layout.tsx",
         "page": "/test/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "test",
+        ],
+      ],
       "prefix": "/test",
       "type": "layout",
     },
@@ -225,7 +310,20 @@ exports[`createFsRouteTree > basic 6`] = `
       "node": {
         "page": "/test/other/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "test",
+        ],
+        [
+          null,
+          "other",
+        ],
+      ],
       "prefix": "/test/other",
       "type": "layout",
     },
@@ -233,7 +331,20 @@ exports[`createFsRouteTree > basic 6`] = `
       "node": {
         "page": "/test/other/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "test",
+        ],
+        [
+          null,
+          "other",
+        ],
+      ],
       "prefix": "/test/other",
       "type": "page",
     },
@@ -250,7 +361,12 @@ exports[`createFsRouteTree > basic 7`] = `
         "layout": "/layout.tsx",
         "page": "/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+      ],
       "prefix": "/",
       "type": "layout",
     },
@@ -259,19 +375,46 @@ exports[`createFsRouteTree > basic 7`] = `
         "layout": "/test/layout.tsx",
         "page": "/test/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "test",
+        ],
+      ],
       "prefix": "/test",
       "type": "layout",
     },
     {
       "node": undefined,
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "test",
+        ],
+      ],
       "prefix": "/test/not-found",
       "type": "layout",
     },
     {
       "node": undefined,
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "test",
+        ],
+      ],
       "prefix": "/test/not-found",
       "type": "page",
     },
@@ -288,7 +431,12 @@ exports[`createFsRouteTree > basic 8`] = `
         "layout": "/layout.tsx",
         "page": "/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+      ],
       "prefix": "/",
       "type": "layout",
     },
@@ -297,7 +445,16 @@ exports[`createFsRouteTree > basic 8`] = `
         "layout": "/dynamic/layout.tsx",
         "page": "/dynamic/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+      ],
       "prefix": "/dynamic",
       "type": "layout",
     },
@@ -306,7 +463,16 @@ exports[`createFsRouteTree > basic 8`] = `
         "layout": "/dynamic/layout.tsx",
         "page": "/dynamic/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+      ],
       "prefix": "/dynamic",
       "type": "page",
     },
@@ -323,7 +489,12 @@ exports[`createFsRouteTree > basic 9`] = `
         "layout": "/layout.tsx",
         "page": "/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+      ],
       "prefix": "/",
       "type": "layout",
     },
@@ -332,7 +503,16 @@ exports[`createFsRouteTree > basic 9`] = `
         "layout": "/dynamic/layout.tsx",
         "page": "/dynamic/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+      ],
       "prefix": "/dynamic",
       "type": "layout",
     },
@@ -340,7 +520,20 @@ exports[`createFsRouteTree > basic 9`] = `
       "node": {
         "page": "/dynamic/static/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+        [
+          null,
+          "static",
+        ],
+      ],
       "prefix": "/dynamic/static",
       "type": "layout",
     },
@@ -348,7 +541,20 @@ exports[`createFsRouteTree > basic 9`] = `
       "node": {
         "page": "/dynamic/static/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+        [
+          null,
+          "static",
+        ],
+      ],
       "prefix": "/dynamic/static",
       "type": "page",
     },
@@ -365,7 +571,12 @@ exports[`createFsRouteTree > basic 10`] = `
         "layout": "/layout.tsx",
         "page": "/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+      ],
       "prefix": "/",
       "type": "layout",
     },
@@ -374,7 +585,16 @@ exports[`createFsRouteTree > basic 10`] = `
         "layout": "/dynamic/layout.tsx",
         "page": "/dynamic/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+      ],
       "prefix": "/dynamic",
       "type": "layout",
     },
@@ -383,9 +603,20 @@ exports[`createFsRouteTree > basic 10`] = `
         "layout": "/dynamic/[id]/layout.tsx",
         "page": "/dynamic/[id]/page.tsx",
       },
-      "params": {
-        "id": "abc",
-      },
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+        [
+          "id",
+          "abc",
+        ],
+      ],
       "prefix": "/dynamic/abc",
       "type": "layout",
     },
@@ -394,9 +625,20 @@ exports[`createFsRouteTree > basic 10`] = `
         "layout": "/dynamic/[id]/layout.tsx",
         "page": "/dynamic/[id]/page.tsx",
       },
-      "params": {
-        "id": "abc",
-      },
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+        [
+          "id",
+          "abc",
+        ],
+      ],
       "prefix": "/dynamic/abc",
       "type": "page",
     },
@@ -413,7 +655,12 @@ exports[`createFsRouteTree > basic 11`] = `
         "layout": "/layout.tsx",
         "page": "/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+      ],
       "prefix": "/",
       "type": "layout",
     },
@@ -422,7 +669,16 @@ exports[`createFsRouteTree > basic 11`] = `
         "layout": "/dynamic/layout.tsx",
         "page": "/dynamic/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+      ],
       "prefix": "/dynamic",
       "type": "layout",
     },
@@ -431,9 +687,20 @@ exports[`createFsRouteTree > basic 11`] = `
         "layout": "/dynamic/[id]/layout.tsx",
         "page": "/dynamic/[id]/page.tsx",
       },
-      "params": {
-        "id": "abc",
-      },
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+        [
+          "id",
+          "abc",
+        ],
+      ],
       "prefix": "/dynamic/abc",
       "type": "layout",
     },
@@ -441,10 +708,24 @@ exports[`createFsRouteTree > basic 11`] = `
       "node": {
         "page": "/dynamic/[id]/[nested]/page.tsx",
       },
-      "params": {
-        "id": "abc",
-        "nested": "def",
-      },
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+        [
+          "id",
+          "abc",
+        ],
+        [
+          "nested",
+          "def",
+        ],
+      ],
       "prefix": "/dynamic/abc/def",
       "type": "layout",
     },
@@ -452,10 +733,24 @@ exports[`createFsRouteTree > basic 11`] = `
       "node": {
         "page": "/dynamic/[id]/[nested]/page.tsx",
       },
-      "params": {
-        "id": "abc",
-        "nested": "def",
-      },
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+        [
+          "id",
+          "abc",
+        ],
+        [
+          "nested",
+          "def",
+        ],
+      ],
       "prefix": "/dynamic/abc/def",
       "type": "page",
     },
@@ -472,7 +767,12 @@ exports[`createFsRouteTree > basic 12`] = `
         "layout": "/layout.tsx",
         "page": "/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+      ],
       "prefix": "/",
       "type": "layout",
     },
@@ -481,7 +781,16 @@ exports[`createFsRouteTree > basic 12`] = `
         "layout": "/dynamic/layout.tsx",
         "page": "/dynamic/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+      ],
       "prefix": "/dynamic",
       "type": "layout",
     },
@@ -490,9 +799,20 @@ exports[`createFsRouteTree > basic 12`] = `
         "layout": "/dynamic/[id]/layout.tsx",
         "page": "/dynamic/[id]/page.tsx",
       },
-      "params": {
-        "id": "✅",
-      },
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+        [
+          "id",
+          "✅",
+        ],
+      ],
       "prefix": "/dynamic/%E2%9C%85",
       "type": "layout",
     },
@@ -501,9 +821,20 @@ exports[`createFsRouteTree > basic 12`] = `
         "layout": "/dynamic/[id]/layout.tsx",
         "page": "/dynamic/[id]/page.tsx",
       },
-      "params": {
-        "id": "✅",
-      },
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+        [
+          "id",
+          "✅",
+        ],
+      ],
       "prefix": "/dynamic/%E2%9C%85",
       "type": "page",
     },
@@ -520,7 +851,12 @@ exports[`createFsRouteTree > basic 13`] = `
         "layout": "/layout.tsx",
         "page": "/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+      ],
       "prefix": "/",
       "type": "layout",
     },
@@ -529,7 +865,16 @@ exports[`createFsRouteTree > basic 13`] = `
         "layout": "/dynamic/layout.tsx",
         "page": "/dynamic/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+      ],
       "prefix": "/dynamic",
       "type": "layout",
     },
@@ -537,7 +882,20 @@ exports[`createFsRouteTree > basic 13`] = `
       "node": {
         "page": "/dynamic/catchall/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+        [
+          null,
+          "catchall",
+        ],
+      ],
       "prefix": "/dynamic/catchall",
       "type": "layout",
     },
@@ -545,7 +903,20 @@ exports[`createFsRouteTree > basic 13`] = `
       "node": {
         "page": "/dynamic/catchall/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+        [
+          null,
+          "catchall",
+        ],
+      ],
       "prefix": "/dynamic/catchall",
       "type": "page",
     },
@@ -562,7 +933,12 @@ exports[`createFsRouteTree > basic 14`] = `
         "layout": "/layout.tsx",
         "page": "/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+      ],
       "prefix": "/",
       "type": "layout",
     },
@@ -571,7 +947,16 @@ exports[`createFsRouteTree > basic 14`] = `
         "layout": "/dynamic/layout.tsx",
         "page": "/dynamic/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+      ],
       "prefix": "/dynamic",
       "type": "layout",
     },
@@ -579,7 +964,20 @@ exports[`createFsRouteTree > basic 14`] = `
       "node": {
         "page": "/dynamic/catchall/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+        [
+          null,
+          "catchall",
+        ],
+      ],
       "prefix": "/dynamic/catchall",
       "type": "layout",
     },
@@ -587,7 +985,24 @@ exports[`createFsRouteTree > basic 14`] = `
       "node": {
         "page": "/dynamic/catchall/static/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+        [
+          null,
+          "catchall",
+        ],
+        [
+          null,
+          "static",
+        ],
+      ],
       "prefix": "/dynamic/catchall/static",
       "type": "layout",
     },
@@ -595,7 +1010,24 @@ exports[`createFsRouteTree > basic 14`] = `
       "node": {
         "page": "/dynamic/catchall/static/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+        [
+          null,
+          "catchall",
+        ],
+        [
+          null,
+          "static",
+        ],
+      ],
       "prefix": "/dynamic/catchall/static",
       "type": "page",
     },
@@ -612,7 +1044,12 @@ exports[`createFsRouteTree > basic 15`] = `
         "layout": "/layout.tsx",
         "page": "/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+      ],
       "prefix": "/",
       "type": "layout",
     },
@@ -621,7 +1058,16 @@ exports[`createFsRouteTree > basic 15`] = `
         "layout": "/dynamic/layout.tsx",
         "page": "/dynamic/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+      ],
       "prefix": "/dynamic",
       "type": "layout",
     },
@@ -629,7 +1075,20 @@ exports[`createFsRouteTree > basic 15`] = `
       "node": {
         "page": "/dynamic/catchall/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+        [
+          null,
+          "catchall",
+        ],
+      ],
       "prefix": "/dynamic/catchall",
       "type": "layout",
     },
@@ -637,9 +1096,24 @@ exports[`createFsRouteTree > basic 15`] = `
       "node": {
         "page": "/dynamic/catchall/[...any]/page.tsx",
       },
-      "params": {
-        "any": "x",
-      },
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+        [
+          null,
+          "catchall",
+        ],
+        [
+          "any",
+          "x",
+        ],
+      ],
       "prefix": "/dynamic/catchall/x",
       "type": "layout",
     },
@@ -647,9 +1121,24 @@ exports[`createFsRouteTree > basic 15`] = `
       "node": {
         "page": "/dynamic/catchall/[...any]/page.tsx",
       },
-      "params": {
-        "any": "x",
-      },
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+        [
+          null,
+          "catchall",
+        ],
+        [
+          "any",
+          "x",
+        ],
+      ],
       "prefix": "/dynamic/catchall/x",
       "type": "page",
     },
@@ -666,7 +1155,12 @@ exports[`createFsRouteTree > basic 16`] = `
         "layout": "/layout.tsx",
         "page": "/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+      ],
       "prefix": "/",
       "type": "layout",
     },
@@ -675,7 +1169,16 @@ exports[`createFsRouteTree > basic 16`] = `
         "layout": "/dynamic/layout.tsx",
         "page": "/dynamic/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+      ],
       "prefix": "/dynamic",
       "type": "layout",
     },
@@ -683,7 +1186,20 @@ exports[`createFsRouteTree > basic 16`] = `
       "node": {
         "page": "/dynamic/catchall/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+        [
+          null,
+          "catchall",
+        ],
+      ],
       "prefix": "/dynamic/catchall",
       "type": "layout",
     },
@@ -691,17 +1207,47 @@ exports[`createFsRouteTree > basic 16`] = `
       "node": {
         "page": "/dynamic/catchall/[...any]/page.tsx",
       },
-      "params": {
-        "any": "x/y",
-      },
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+        [
+          null,
+          "catchall",
+        ],
+        [
+          "any",
+          "x/y",
+        ],
+      ],
       "prefix": "/dynamic/catchall/x",
       "type": "layout",
     },
     {
       "node": undefined,
-      "params": {
-        "any": "x/y",
-      },
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+        [
+          null,
+          "catchall",
+        ],
+        [
+          "any",
+          "x/y",
+        ],
+      ],
       "prefix": "/dynamic/catchall/x/y",
       "type": "layout",
     },
@@ -709,9 +1255,24 @@ exports[`createFsRouteTree > basic 16`] = `
       "node": {
         "page": "/dynamic/catchall/[...any]/page.tsx",
       },
-      "params": {
-        "any": "x/y",
-      },
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+        [
+          null,
+          "catchall",
+        ],
+        [
+          "any",
+          "x/y",
+        ],
+      ],
       "prefix": "/dynamic/catchall/x/y",
       "type": "page",
     },
@@ -728,7 +1289,12 @@ exports[`createFsRouteTree > basic 17`] = `
         "layout": "/layout.tsx",
         "page": "/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+      ],
       "prefix": "/",
       "type": "layout",
     },
@@ -737,7 +1303,16 @@ exports[`createFsRouteTree > basic 17`] = `
         "layout": "/dynamic/layout.tsx",
         "page": "/dynamic/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+      ],
       "prefix": "/dynamic",
       "type": "layout",
     },
@@ -745,7 +1320,20 @@ exports[`createFsRouteTree > basic 17`] = `
       "node": {
         "page": "/dynamic/catchall/page.tsx",
       },
-      "params": {},
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+        [
+          null,
+          "catchall",
+        ],
+      ],
       "prefix": "/dynamic/catchall",
       "type": "layout",
     },
@@ -753,25 +1341,70 @@ exports[`createFsRouteTree > basic 17`] = `
       "node": {
         "page": "/dynamic/catchall/[...any]/page.tsx",
       },
-      "params": {
-        "any": "x/y/z",
-      },
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+        [
+          null,
+          "catchall",
+        ],
+        [
+          "any",
+          "x/y/z",
+        ],
+      ],
       "prefix": "/dynamic/catchall/x",
       "type": "layout",
     },
     {
       "node": undefined,
-      "params": {
-        "any": "x/y/z",
-      },
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+        [
+          null,
+          "catchall",
+        ],
+        [
+          "any",
+          "x/y/z",
+        ],
+      ],
       "prefix": "/dynamic/catchall/x/y",
       "type": "layout",
     },
     {
       "node": undefined,
-      "params": {
-        "any": "x/y/z",
-      },
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+        [
+          null,
+          "catchall",
+        ],
+        [
+          "any",
+          "x/y/z",
+        ],
+      ],
       "prefix": "/dynamic/catchall/x/y/z",
       "type": "layout",
     },
@@ -779,9 +1412,24 @@ exports[`createFsRouteTree > basic 17`] = `
       "node": {
         "page": "/dynamic/catchall/[...any]/page.tsx",
       },
-      "params": {
-        "any": "x/y/z",
-      },
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "dynamic",
+        ],
+        [
+          null,
+          "catchall",
+        ],
+        [
+          "any",
+          "x/y/z",
+        ],
+      ],
       "prefix": "/dynamic/catchall/x/y/z",
       "type": "page",
     },

--- a/packages/react-server/src/features/router/client.tsx
+++ b/packages/react-server/src/features/router/client.tsx
@@ -106,3 +106,7 @@ export function usePreloadHandlers({
     onFocus: callback,
   } satisfies JSX.IntrinsicElements["a"];
 }
+
+// useServerParams
+
+// useServerRouter

--- a/packages/react-server/src/features/router/client.tsx
+++ b/packages/react-server/src/features/router/client.tsx
@@ -9,7 +9,7 @@ import {
   type RouteManifest,
   getRouteAssetDeps,
 } from "./manifest";
-import type { MatchParams } from "./tree";
+import { type MatchParams, toMatchParamsObject } from "./tree";
 import { LAYOUT_ROOT_NAME, type ServerRouterData } from "./utils";
 
 type LayoutStateContextType = {
@@ -45,7 +45,7 @@ function MetadataRenderer() {
 export function useParams() {
   const ctx = React.useContext(LayoutStateContext);
   const data = React.use(ctx.data);
-  return data.params;
+  return toMatchParamsObject(data.params);
 }
 
 type LayoutMatchType = {

--- a/packages/react-server/src/features/router/client.tsx
+++ b/packages/react-server/src/features/router/client.tsx
@@ -9,7 +9,7 @@ import {
   type RouteManifest,
   getRouteAssetDeps,
 } from "./manifest";
-import { type MatchParams, toMatchParamsObject } from "./tree";
+import { type MatchParamEntry, toMatchParamsObject } from "./tree";
 import { LAYOUT_ROOT_NAME, type ServerRouterData } from "./utils";
 
 type LayoutStateContextType = {
@@ -49,7 +49,7 @@ export function useParams() {
 }
 
 type LayoutMatchType = {
-  params: MatchParams;
+  params: MatchParamEntry[];
 };
 
 const LayoutMatchContext = React.createContext<LayoutMatchType>(undefined!);

--- a/packages/react-server/src/features/router/client.tsx
+++ b/packages/react-server/src/features/router/client.tsx
@@ -9,7 +9,11 @@ import {
   type RouteManifest,
   getRouteAssetDeps,
 } from "./manifest";
-import { type MatchParamEntry, toMatchParamsObject } from "./tree";
+import {
+  type MatchParamEntry,
+  toMatchParamsObject,
+  toSelectedParams,
+} from "./tree";
 import { LAYOUT_ROOT_NAME, type ServerRouterData } from "./utils";
 
 type LayoutStateContextType = {
@@ -42,10 +46,15 @@ function MetadataRenderer() {
   return data.metadata;
 }
 
-export function useParams() {
+function useParamEntries() {
   const ctx = React.useContext(LayoutStateContext);
   const data = React.use(ctx.data);
-  return toMatchParamsObject(data.params);
+  return data.params;
+}
+
+export function useParams() {
+  const entries = useParamEntries();
+  return React.useMemo(() => toMatchParamsObject(entries), [entries]);
 }
 
 type LayoutMatchType = {
@@ -60,16 +69,13 @@ export function LayoutMatchProvider(
   return <LayoutMatchContext.Provider {...props} />;
 }
 
-// TODO
 export function useSelectedParams() {
-  const all = useParams();
+  const all = useParamEntries();
   const prefix = React.useContext(LayoutMatchContext).params;
-  return React.useMemo(() => {
-    Object.entries;
-    all;
-    all;
-    prefix;
-  }, [all, prefix]);
+  return React.useMemo(
+    () => toMatchParamsObject(toSelectedParams(prefix, all)),
+    [all, prefix],
+  );
 }
 
 export const ROUTER_REVALIDATE_KEY = "__REVALIDATE";

--- a/packages/react-server/src/features/router/client.tsx
+++ b/packages/react-server/src/features/router/client.tsx
@@ -65,6 +65,7 @@ export function LayoutMatchProvider(
   return <LayoutMatchContext.Provider {...props} />;
 }
 
+// TODO: remove options
 export function useSelectedParams(options?: { below?: boolean }) {
   const all = useParamEntries();
   const prefix = React.useContext(LayoutMatchContext).params;

--- a/packages/react-server/src/features/router/client.tsx
+++ b/packages/react-server/src/features/router/client.tsx
@@ -9,6 +9,7 @@ import {
   type RouteManifest,
   getRouteAssetDeps,
 } from "./manifest";
+import type { MatchParams } from "./tree";
 import { LAYOUT_ROOT_NAME, type ServerRouterData } from "./utils";
 
 type LayoutStateContextType = {
@@ -48,7 +49,7 @@ export function useParams() {
 }
 
 type LayoutMatchType = {
-  params: Record<string, string>;
+  params: MatchParams;
 };
 
 const LayoutMatchContext = React.createContext<LayoutMatchType>(undefined!);
@@ -59,8 +60,16 @@ export function LayoutMatchProvider(
   return <LayoutMatchContext.Provider {...props} />;
 }
 
-export function useLayoutMatch() {
-  return React.useContext(LayoutMatchContext);
+// TODO
+export function useSelectedParams() {
+  const all = useParams();
+  const prefix = React.useContext(LayoutMatchContext).params;
+  return React.useMemo(() => {
+    Object.entries;
+    all;
+    all;
+    prefix;
+  }, [all, prefix]);
 }
 
 export const ROUTER_REVALIDATE_KEY = "__REVALIDATE";

--- a/packages/react-server/src/features/router/client.tsx
+++ b/packages/react-server/src/features/router/client.tsx
@@ -41,6 +41,18 @@ function MetadataRenderer() {
   return data.metadata;
 }
 
+type LayoutMatchType = {
+  params: Record<string, string>;
+};
+
+export const LayoutMatchContext = React.createContext<LayoutMatchType>(
+  undefined!,
+);
+
+export function useLayoutMatch() {
+  return React.useContext(LayoutMatchContext);
+}
+
 export const ROUTER_REVALIDATE_KEY = "__REVALIDATE";
 
 declare module "@tanstack/history" {
@@ -106,7 +118,3 @@ export function usePreloadHandlers({
     onFocus: callback,
   } satisfies JSX.IntrinsicElements["a"];
 }
-
-// useServerParams
-
-// useServerRouter

--- a/packages/react-server/src/features/router/client.tsx
+++ b/packages/react-server/src/features/router/client.tsx
@@ -9,11 +9,7 @@ import {
   type RouteManifest,
   getRouteAssetDeps,
 } from "./manifest";
-import {
-  type MatchParamEntry,
-  toMatchParamsObject,
-  toSelectedParams,
-} from "./tree";
+import { type MatchParamEntry, toMatchParamsObject } from "./tree";
 import { LAYOUT_ROOT_NAME, type ServerRouterData } from "./utils";
 
 type LayoutStateContextType = {
@@ -69,12 +65,13 @@ export function LayoutMatchProvider(
   return <LayoutMatchContext.Provider {...props} />;
 }
 
-export function useSelectedParams() {
+export function useSelectedParams(options?: { below?: boolean }) {
   const all = useParamEntries();
   const prefix = React.useContext(LayoutMatchContext).params;
+  const offset = options?.below ? 0 : 1;
   return React.useMemo(
-    () => toMatchParamsObject(toSelectedParams(prefix, all)),
-    [all, prefix],
+    () => toMatchParamsObject(all.slice(prefix.length - offset)),
+    [all, prefix, offset],
   );
 }
 

--- a/packages/react-server/src/features/router/client.tsx
+++ b/packages/react-server/src/features/router/client.tsx
@@ -65,14 +65,12 @@ export function LayoutMatchProvider(
   return <LayoutMatchContext.Provider {...props} />;
 }
 
-// TODO: remove options
-export function useSelectedParams(options?: { below?: boolean }) {
+export function useSelectedParams() {
   const all = useParamEntries();
   const prefix = React.useContext(LayoutMatchContext).params;
-  const offset = options?.below ? 0 : 1;
   return React.useMemo(
-    () => toMatchParamsObject(all.slice(prefix.length - offset)),
-    [all, prefix, offset],
+    () => toMatchParamsObject(all.slice(prefix.length)),
+    [all, prefix],
   );
 }
 

--- a/packages/react-server/src/features/router/client.tsx
+++ b/packages/react-server/src/features/router/client.tsx
@@ -41,13 +41,23 @@ function MetadataRenderer() {
   return data.metadata;
 }
 
+export function useParams() {
+  const ctx = React.useContext(LayoutStateContext);
+  const data = React.use(ctx.data);
+  return data.params;
+}
+
 type LayoutMatchType = {
   params: Record<string, string>;
 };
 
-export const LayoutMatchContext = React.createContext<LayoutMatchType>(
-  undefined!,
-);
+const LayoutMatchContext = React.createContext<LayoutMatchType>(undefined!);
+
+export function LayoutMatchProvider(
+  props: React.ComponentProps<typeof LayoutMatchContext.Provider>,
+) {
+  return <LayoutMatchContext.Provider {...props} />;
+}
 
 export function useLayoutMatch() {
   return React.useContext(LayoutMatchContext);

--- a/packages/react-server/src/features/router/server.tsx
+++ b/packages/react-server/src/features/router/server.tsx
@@ -3,6 +3,7 @@ import { type ReactServerErrorContext, createError } from "../../lib/error";
 import { renderMetadata } from "../meta/server";
 import type { Metadata } from "../meta/utils";
 import {
+  type MatchNodeEntry,
   type TreeNode,
   createFsRouteTree,
   matchRouteTree,
@@ -44,7 +45,7 @@ function renderPage(node: RouteModuleNode, props: PageProps) {
 async function renderLayout(
   node: RouteModuleNode,
   props: PageProps,
-  prefix: string,
+  { prefix, params }: MatchNodeEntry<RouteEntry>,
 ) {
   const {
     ErrorBoundary,
@@ -70,11 +71,7 @@ async function renderLayout(
   } else {
     acc = <React.Fragment key={prefix}>{acc}</React.Fragment>;
   }
-  acc = (
-    <LayoutMatchProvider value={{ params: props.params }}>
-      {acc}
-    </LayoutMatchProvider>
-  );
+  acc = <LayoutMatchProvider value={{ params }}>{acc}</LayoutMatchProvider>;
   return acc;
 }
 
@@ -100,7 +97,7 @@ export async function renderRouteMap(
       params: toMatchParamsObject(m.params),
     };
     if (m.type === "layout") {
-      layouts[m.prefix] = await renderLayout(m.node, props, m.prefix);
+      layouts[m.prefix] = await renderLayout(m.node, props, m);
       Object.assign(metadata, m.node.value?.layout?.metadata);
     } else if (m.type === "page") {
       pages[m.prefix] = renderPage(m.node, props);

--- a/packages/react-server/src/features/router/server.tsx
+++ b/packages/react-server/src/features/router/server.tsx
@@ -41,9 +41,7 @@ async function renderLayout(
   props: PageProps,
   prefix: string,
 ) {
-  // TODO: provide it via client context?
-  props.params;
-  const { ErrorBoundary, RedirectBoundary, LayoutContent } =
+  const { ErrorBoundary, RedirectBoundary, LayoutContent, LayoutMatchContext } =
     await importRuntimeClient();
 
   let acc = <LayoutContent name={prefix} />;
@@ -63,6 +61,12 @@ async function renderLayout(
   } else {
     acc = <React.Fragment key={prefix}>{acc}</React.Fragment>;
   }
+  // TODO: provide full params from root
+  acc = (
+    <LayoutMatchContext.Provider value={{ params: props.params }}>
+      {acc}
+    </LayoutMatchContext.Provider>
+  );
   return acc;
 }
 

--- a/packages/react-server/src/features/router/server.tsx
+++ b/packages/react-server/src/features/router/server.tsx
@@ -41,6 +41,8 @@ async function renderLayout(
   props: PageProps,
   prefix: string,
 ) {
+  // TODO: provide it via client context?
+  props.params;
   const { ErrorBoundary, RedirectBoundary, LayoutContent } =
     await importRuntimeClient();
 

--- a/packages/react-server/src/features/router/server.tsx
+++ b/packages/react-server/src/features/router/server.tsx
@@ -41,8 +41,12 @@ async function renderLayout(
   props: PageProps,
   prefix: string,
 ) {
-  const { ErrorBoundary, RedirectBoundary, LayoutContent, LayoutMatchContext } =
-    await importRuntimeClient();
+  const {
+    ErrorBoundary,
+    RedirectBoundary,
+    LayoutContent,
+    LayoutMatchProvider,
+  } = await importRuntimeClient();
 
   let acc = <LayoutContent name={prefix} />;
   acc = <RedirectBoundary>{acc}</RedirectBoundary>;
@@ -61,11 +65,10 @@ async function renderLayout(
   } else {
     acc = <React.Fragment key={prefix}>{acc}</React.Fragment>;
   }
-  // TODO: provide full params from root
   acc = (
-    <LayoutMatchContext.Provider value={{ params: props.params }}>
+    <LayoutMatchProvider value={{ params: props.params }}>
       {acc}
-    </LayoutMatchContext.Provider>
+    </LayoutMatchProvider>
   );
   return acc;
 }
@@ -98,7 +101,12 @@ export async function renderRouteMap(
       m.type satisfies never;
     }
   }
-  return { pages, layouts, metadata: renderMetadata(metadata) };
+  return {
+    pages,
+    layouts,
+    metadata: renderMetadata(metadata),
+    params: result.matches.at(-1)?.params ?? {},
+  };
 }
 
 const ThrowNotFound: React.FC = () => {

--- a/packages/react-server/src/features/router/server.tsx
+++ b/packages/react-server/src/features/router/server.tsx
@@ -2,7 +2,12 @@ import React from "react";
 import { type ReactServerErrorContext, createError } from "../../lib/error";
 import { renderMetadata } from "../meta/server";
 import type { Metadata } from "../meta/utils";
-import { type TreeNode, createFsRouteTree, matchRouteTree } from "./tree";
+import {
+  type TreeNode,
+  createFsRouteTree,
+  matchRouteTree,
+  toMatchParamsObject,
+} from "./tree";
 
 // cf. https://nextjs.org/docs/app/building-your-application/routing#file-conventions
 interface RouteEntry {
@@ -90,7 +95,10 @@ export async function renderRouteMap(
   const metadata: Metadata = {};
   const result = matchRouteTree(tree, url.pathname);
   for (const m of result.matches) {
-    const props: BaseProps = { ...baseProps, params: m.params };
+    const props: BaseProps = {
+      ...baseProps,
+      params: toMatchParamsObject(m.params),
+    };
     if (m.type === "layout") {
       layouts[m.prefix] = await renderLayout(m.node, props, m.prefix);
       Object.assign(metadata, m.node.value?.layout?.metadata);
@@ -105,7 +113,7 @@ export async function renderRouteMap(
     pages,
     layouts,
     metadata: renderMetadata(metadata),
-    params: result.matches.at(-1)?.params ?? {},
+    params: result.params,
   };
 }
 

--- a/packages/react-server/src/features/router/tree.ts
+++ b/packages/react-server/src/features/router/tree.ts
@@ -55,6 +55,13 @@ export function toMatchParamsObject(params: MatchParamEntry[]): MatchParams {
   return result;
 }
 
+export function toSelectedParams(
+  prefix: MatchParamEntry[],
+  all: MatchParamEntry[],
+) {
+  return all.slice(prefix.length - 1);
+}
+
 export type MatchNodeEntry<T> = {
   prefix: string;
   type: "layout" | "page";

--- a/packages/react-server/src/features/router/tree.ts
+++ b/packages/react-server/src/features/router/tree.ts
@@ -55,13 +55,6 @@ export function toMatchParamsObject(params: MatchParamEntry[]): MatchParams {
   return result;
 }
 
-export function toSelectedParams(
-  prefix: MatchParamEntry[],
-  all: MatchParamEntry[],
-) {
-  return all.slice(prefix.length - 1);
-}
-
 export type MatchNodeEntry<T> = {
   prefix: string;
   type: "layout" | "page";

--- a/packages/react-server/src/features/router/tree.ts
+++ b/packages/react-server/src/features/router/tree.ts
@@ -42,11 +42,13 @@ function sortDynamicRoutes<T>(tree: TreeNode<T>) {
   }
 }
 
+export type MatchParams = Record<string, string>;
+
 type MatchNodeEntry<T> = {
   prefix: string;
   type: "layout" | "page";
   node: TreeNode<T>;
-  params: Record<string, string>;
+  params: MatchParams;
 };
 
 type MatchResult<T> = {

--- a/packages/react-server/src/features/router/tree.ts
+++ b/packages/react-server/src/features/router/tree.ts
@@ -42,25 +42,40 @@ function sortDynamicRoutes<T>(tree: TreeNode<T>) {
   }
 }
 
+export type MatchParamEntry = [key: string | null, value: string];
 export type MatchParams = Record<string, string>;
+
+export function toMatchParamsObject(params: MatchParamEntry[]): MatchParams {
+  let result: MatchParams = {};
+  for (const [k, v] of params) {
+    if (k) {
+      result[k] = v;
+    }
+  }
+  return result;
+}
 
 type MatchNodeEntry<T> = {
   prefix: string;
   type: "layout" | "page";
   node: TreeNode<T>;
-  params: MatchParams;
+  params: MatchParamEntry[];
 };
 
-type MatchResult<T> = {
+export type MatchResult<T> = {
   matches: MatchNodeEntry<T>[];
+  params: MatchParamEntry[];
 };
 
-export function matchRouteTree<T>(tree: TreeNode<T>, pathname: string) {
+export function matchRouteTree<T>(
+  tree: TreeNode<T>,
+  pathname: string,
+): MatchResult<T> {
   const prefixes = getPathPrefixes(pathname);
 
   let node = tree;
-  let params: Record<string, string> = {};
-  const result: MatchResult<T> = { matches: [] };
+  let params: MatchParamEntry[] = [];
+  const matches: MatchNodeEntry<T>[] = [];
   for (let i = 0; i < prefixes.length; i++) {
     const prefix = prefixes[i]!;
     const segment = prefix.split("/").at(-1)!;
@@ -69,31 +84,33 @@ export function matchRouteTree<T>(tree: TreeNode<T>, pathname: string) {
       node = next.child;
       if (next.catchAll) {
         const rest = pathname.slice(prefixes[i - 1]!.length + 1);
-        params = { ...params, [next.param]: decodeURI(rest) };
-        result.matches.push({ prefix, type: "layout", node, params });
+        params = [...params, [next.param, decodeURI(rest)]];
+        matches.push({ prefix, type: "layout", node, params });
         for (const prefix of prefixes.slice(i + 1)) {
-          result.matches.push({
+          matches.push({
             prefix,
             type: "layout",
             node: initTreeNode(),
             params,
           });
         }
-        result.matches.push({ prefix: pathname, type: "page", node, params });
+        matches.push({ prefix: pathname, type: "page", node, params });
         break;
       }
       if (next.param) {
-        params = { ...params, [next.param]: decodeURI(segment) };
+        params = [...params, [next.param, decodeURI(segment)]];
+      } else {
+        params = [...params, [null, decodeURI(segment)]];
       }
     } else {
       node = initTreeNode();
     }
-    result.matches.push({ prefix, type: "layout", node, params });
+    matches.push({ prefix, type: "layout", node, params });
     if (prefix === pathname) {
-      result.matches.push({ prefix, type: "page", node, params });
+      matches.push({ prefix, type: "page", node, params });
     }
   }
-  return result;
+  return { matches, params };
 }
 
 const DYNAMIC_RE = /^\[(\w*)\]$/;

--- a/packages/react-server/src/features/router/tree.ts
+++ b/packages/react-server/src/features/router/tree.ts
@@ -55,7 +55,7 @@ export function toMatchParamsObject(params: MatchParamEntry[]): MatchParams {
   return result;
 }
 
-type MatchNodeEntry<T> = {
+export type MatchNodeEntry<T> = {
   prefix: string;
   type: "layout" | "page";
   node: TreeNode<T>;

--- a/packages/react-server/src/features/router/utils.tsx
+++ b/packages/react-server/src/features/router/utils.tsx
@@ -14,6 +14,7 @@ export type ServerRouterData = {
   action?: Pick<ActionResult, "error" | "data">;
   metadata?: React.ReactNode;
   layout: Record<string, React.ReactNode>;
+  params: Record<string, string>;
 };
 
 export const LAYOUT_ROOT_NAME = "__root";

--- a/packages/react-server/src/features/router/utils.tsx
+++ b/packages/react-server/src/features/router/utils.tsx
@@ -1,6 +1,7 @@
 import { objectPickBy, typedBoolean } from "@hiogawa/utils";
 import type { ActionResult } from "../server-action/react-server";
 import type { RevalidationType } from "../server-component/utils";
+import type { MatchParamEntry } from "./tree";
 
 export type LayoutRequest = Record<
   string,
@@ -14,7 +15,7 @@ export type ServerRouterData = {
   action?: Pick<ActionResult, "error" | "data">;
   metadata?: React.ReactNode;
   layout: Record<string, React.ReactNode>;
-  params: Record<string, string>;
+  params: MatchParamEntry[];
 };
 
 export const LAYOUT_ROOT_NAME = "__root";

--- a/packages/react-server/src/lib/client/router.tsx
+++ b/packages/react-server/src/lib/client/router.tsx
@@ -37,6 +37,7 @@ export class Router {
 
 export const RouterContext = React.createContext<Router>(undefined!);
 
+// TODO: rename it to useClientRouter and provide a separate useRouteState for server state?
 export function useRouter<U = RouterState>(select?: (v: RouterState) => U) {
   const router = React.useContext(RouterContext);
   return useStore(router.store, select);

--- a/packages/react-server/src/runtime-client.ts
+++ b/packages/react-server/src/runtime-client.ts
@@ -1,4 +1,4 @@
 "use client";
 
 export { ErrorBoundary, RedirectBoundary } from "./lib/client/error-boundary";
-export { LayoutContent, LayoutMatchContext } from "./features/router/client";
+export { LayoutContent, LayoutMatchProvider } from "./features/router/client";

--- a/packages/react-server/src/runtime-client.ts
+++ b/packages/react-server/src/runtime-client.ts
@@ -1,4 +1,4 @@
 "use client";
 
 export { ErrorBoundary, RedirectBoundary } from "./lib/client/error-boundary";
-export { LayoutContent } from "./features/router/client";
+export { LayoutContent, LayoutMatchContext } from "./features/router/client";


### PR DESCRIPTION
This is an essential as a core feature and also unblocks next compat https://github.com/hi-ogawa/next-app-router-playground/pull/1


## todo

- [x] test
- [x] next compat
  - `useSelectedLayoutSegments`
  - `useSelectedLayoutSegment`