### PR TITLE
test: tweak env

### DIFF
--- a/packages/react-server/examples/basic/playwright.config.ts
+++ b/packages/react-server/examples/basic/playwright.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
   webServer: {
     command,
     port,
+    env: { ...process.env, E2E: "true" },
   },
   grepInvert: isPreview ? /@dev/ : /@build/,
   forbidOnly: !!process.env["CI"],

--- a/packages/react-server/examples/basic/vite.config.ts
+++ b/packages/react-server/examples/basic/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
   plugins: [
     react(),
     unocss(),
-    !process.env["CI"] &&
+    !process.env["E2E"] &&
       vitePluginErrorOverlay({
         patchConsoleError: true,
       }),


### PR DESCRIPTION
Currently `pnpm test-e2e --headed -g error` fails when running locally without manually adding `CI=1`.
Adding a explicit condition `E2E=true` instead.