### PR TITLE
fix: fix ssr flight stream injection by buffering

### DIFF
--- a/packages/react-server/src/entry/browser.tsx
+++ b/packages/react-server/src/entry/browser.tsx
@@ -21,6 +21,7 @@ import {
 } from "../lib/client/router";
 import { $__global } from "../lib/global";
 import type { CallServerCallback } from "../lib/types";
+import { readStreamScript } from "../utils/stream-script";
 
 const debug = createDebug("react-server:browser");
 
@@ -66,7 +67,7 @@ export async function start() {
   // TODO: needs to await for hydration formState. does it affect startup perf?
   const initialLayout =
     await ReactClient.createFromReadableStream<ServerRouterData>(
-      (self as any).__flightStream, // injected by StreamTransfer
+      readStreamScript<string>().pipeThrough(new TextEncoderStream()),
       { callServer },
     );
   const initialLayoutPromise = Promise.resolve(initialLayout);

--- a/packages/react-server/src/entry/browser.tsx
+++ b/packages/react-server/src/entry/browser.tsx
@@ -21,7 +21,6 @@ import {
 } from "../lib/client/router";
 import { $__global } from "../lib/global";
 import type { CallServerCallback } from "../lib/types";
-import { getBrowserFlightStream } from "../utils/stream-script";
 
 const debug = createDebug("react-server:browser");
 
@@ -67,7 +66,7 @@ export async function start() {
   // TODO: needs to await for hydration formState. does it affect startup perf?
   const initialLayout =
     await ReactClient.createFromReadableStream<ServerRouterData>(
-      getBrowserFlightStream(),
+      (self as any).__flightStream, // injected by StreamTransfer
       { callServer },
     );
   const initialLayoutPromise = Promise.resolve(initialLayout);

--- a/packages/react-server/src/entry/browser.tsx
+++ b/packages/react-server/src/entry/browser.tsx
@@ -21,7 +21,6 @@ import {
 } from "../lib/client/router";
 import { $__global } from "../lib/global";
 import type { CallServerCallback } from "../lib/types";
-import { readStreamScript } from "../utils/stream-script";
 
 const debug = createDebug("react-server:browser");
 
@@ -67,7 +66,7 @@ export async function start() {
   // TODO: needs to await for hydration formState. does it affect startup perf?
   const initialLayout =
     await ReactClient.createFromReadableStream<ServerRouterData>(
-      readStreamScript<string>().pipeThrough(new TextEncoderStream()),
+      (self as any).__flightStream, // injected by StreamTransfer
       { callServer },
     );
   const initialLayoutPromise = Promise.resolve(initialLayout);

--- a/packages/react-server/src/entry/browser.tsx
+++ b/packages/react-server/src/entry/browser.tsx
@@ -21,6 +21,7 @@ import {
 } from "../lib/client/router";
 import { $__global } from "../lib/global";
 import type { CallServerCallback } from "../lib/types";
+import { getBrowserFlightStream } from "../utils/stream-script";
 
 const debug = createDebug("react-server:browser");
 
@@ -66,7 +67,7 @@ export async function start() {
   // TODO: needs to await for hydration formState. does it affect startup perf?
   const initialLayout =
     await ReactClient.createFromReadableStream<ServerRouterData>(
-      (self as any).__flightStream, // injected by StreamTransfer
+      getBrowserFlightStream(),
       { callServer },
     );
   const initialLayoutPromise = Promise.resolve(initialLayout);

--- a/packages/react-server/src/entry/server.tsx
+++ b/packages/react-server/src/entry/server.tsx
@@ -27,8 +27,7 @@ import {
 import { $__global } from "../lib/global";
 import { ENTRY_REACT_SERVER_WRAPPER, invalidateModule } from "../plugin/utils";
 import { escpaeScriptString } from "../utils/escape";
-import { jsonStringifyTransform } from "../utils/stream";
-import { injectStreamScript } from "../utils/stream-script";
+import { StreamTransfer } from "../utils/stream-script";
 import type { ReactServerHandlerStreamResult } from "./react-server";
 
 const debug = createDebug("react-server:ssr");
@@ -125,6 +124,7 @@ export async function renderHtml(
         <RouteManifestContext.Provider value={routeManifest}>
           <RouteAssetLinks />
           <LayoutRoot />
+          <StreamTransfer stream={stream2} />
         </RouteManifestContext.Provider>
       </LayoutStateContext.Provider>
     </RouterContext.Provider>
@@ -200,13 +200,6 @@ export async function renderHtml(
   const htmlStream = ssrStream
     .pipeThrough(new TextDecoderStream())
     .pipeThrough(injectToHead(head))
-    .pipeThrough(
-      injectStreamScript(
-        stream2
-          .pipeThrough(new TextDecoderStream())
-          .pipeThrough(jsonStringifyTransform()),
-      ),
-    )
     .pipeThrough(new TextEncoderStream());
 
   return new Response(htmlStream, {

--- a/packages/react-server/src/entry/server.tsx
+++ b/packages/react-server/src/entry/server.tsx
@@ -27,7 +27,8 @@ import {
 import { $__global } from "../lib/global";
 import { ENTRY_REACT_SERVER_WRAPPER, invalidateModule } from "../plugin/utils";
 import { escpaeScriptString } from "../utils/escape";
-import { StreamTransfer } from "../utils/stream-script";
+import { jsonStringifyTransform } from "../utils/stream";
+import { injectStreamScript } from "../utils/stream-script";
 import type { ReactServerHandlerStreamResult } from "./react-server";
 
 const debug = createDebug("react-server:ssr");
@@ -124,7 +125,6 @@ export async function renderHtml(
         <RouteManifestContext.Provider value={routeManifest}>
           <RouteAssetLinks />
           <LayoutRoot />
-          <StreamTransfer stream={stream2} />
         </RouteManifestContext.Provider>
       </LayoutStateContext.Provider>
     </RouterContext.Provider>
@@ -200,6 +200,13 @@ export async function renderHtml(
   const htmlStream = ssrStream
     .pipeThrough(new TextDecoderStream())
     .pipeThrough(injectToHead(head))
+    .pipeThrough(
+      injectStreamScript(
+        stream2
+          .pipeThrough(new TextDecoderStream())
+          .pipeThrough(jsonStringifyTransform()),
+      ),
+    )
     .pipeThrough(new TextEncoderStream());
 
   return new Response(htmlStream, {

--- a/packages/react-server/src/entry/server.tsx
+++ b/packages/react-server/src/entry/server.tsx
@@ -28,7 +28,10 @@ import { $__global } from "../lib/global";
 import { ENTRY_REACT_SERVER_WRAPPER, invalidateModule } from "../plugin/utils";
 import { escpaeScriptString } from "../utils/escape";
 import { jsonStringifyTransform } from "../utils/stream";
-import { injectStreamScript } from "../utils/stream-script";
+import {
+  bufferedTransformStream,
+  injectStreamScript,
+} from "../utils/stream-script";
 import type { ReactServerHandlerStreamResult } from "./react-server";
 
 const debug = createDebug("react-server:ssr");
@@ -199,6 +202,7 @@ export async function renderHtml(
 
   const htmlStream = ssrStream
     .pipeThrough(new TextDecoderStream())
+    .pipeThrough(bufferedTransformStream())
     .pipeThrough(injectToHead(head))
     .pipeThrough(
       injectStreamScript(

--- a/packages/react-server/src/utils/stream-script.tsx
+++ b/packages/react-server/src/utils/stream-script.tsx
@@ -6,7 +6,6 @@
 
 export function injectStreamScript(stream: ReadableStream<string>) {
   const search = "</body>";
-  let i = 0;
   return new TransformStream<string, string>({
     async transform(chunk, controller) {
       if (!chunk.includes(search)) {

--- a/packages/react-server/src/utils/stream-script.tsx
+++ b/packages/react-server/src/utils/stream-script.tsx
@@ -9,7 +9,6 @@ export function injectStreamScript(stream: ReadableStream<string>) {
   let i = 0;
   return new TransformStream<string, string>({
     async transform(chunk, controller) {
-      console.log("[injectStreamScript]", { i: i++, chunk });
       if (!chunk.includes(search)) {
         controller.enqueue(chunk);
         return;

--- a/packages/react-server/src/utils/stream-script.tsx
+++ b/packages/react-server/src/utils/stream-script.tsx
@@ -5,8 +5,10 @@
 
 export function injectStreamScript(stream: ReadableStream<string>) {
   const search = "</body>";
+  let i = 0;
   return new TransformStream<string, string>({
     async transform(chunk, controller) {
+      console.log("[injectStreamScript]", { i: i++, chunk });
       if (!chunk.includes(search)) {
         controller.enqueue(chunk);
         return;

--- a/packages/react-server/src/utils/stream-script.tsx
+++ b/packages/react-server/src/utils/stream-script.tsx
@@ -1,47 +1,64 @@
-import React from "react";
+// cf.
+// https://github.com/vercel/next.js/blob/1c5aa7fa09cc5503c621c534fc40065cbd2aefcb/packages/next/src/server/app-render/use-flight-response.tsx#L19-L26
+// https://github.com/vercel/next.js/blob/1c5aa7fa09cc5503c621c534fc40065cbd2aefcb/packages/next/src/client/app-index.tsx#L110-L113
+// https://github.com/devongovett/rsc-html-stream/
 
-// based on
-// https://github.com/remix-run/react-router/blob/09b52e491e3927e30e707abe67abdd8e9b9de946/packages/react-router/lib/dom/ssr/single-fetch.tsx#L49
+export function injectStreamScript(stream: ReadableStream<string>) {
+  const search = "</body>";
+  let i = 0;
+  return new TransformStream<string, string>({
+    async transform(chunk, controller) {
+      console.log("[injectStreamScript]", { i: i++, chunk });
+      if (!chunk.includes(search)) {
+        controller.enqueue(chunk);
+        return;
+      }
 
-export function StreamTransfer(props: { stream: ReadableStream<Uint8Array> }) {
-  const textStream = props.stream.pipeThrough(new TextDecoderStream());
-  const reader = textStream.getReader();
+      const [pre, post] = chunk.split(search);
+      controller.enqueue(pre);
 
-  const results = new Array<Promise<ReadableStreamReadResult<string>>>();
+      // TODO: handle cancel?
+      await stream.pipeTo(
+        new WritableStream({
+          start() {
+            controller.enqueue(`<script>self.__stream_chunks||=[]</script>`);
+          },
+          write(chunk) {
+            // assume chunk is already encoded as javascript code e.g. by
+            //   stream.pipeThrough(jsonStringifyTransform())
+            controller.enqueue(
+              `<script>__stream_chunks.push(${chunk})</script>`,
+            );
+          },
+        }),
+      );
 
-  function Recurse(props: { depth: number }) {
-    const result = React.use((results[props.depth] ??= reader.read()));
-    if (result.done) {
-      return renderScript(`self.__f_close()`);
-    }
-    // TODO: escape?
-    return (
-      <>
-        {renderScript(`self.__f_push(${JSON.stringify(result.value)})`)}
-        <React.Suspense>
-          <Recurse depth={props.depth + 1} />
-        </React.Suspense>
-      </>
-    );
-  }
-
-  return (
-    <>
-      {renderScript(`
-self.__flightStream = new ReadableStream({
-	start(ctrl) {
-		self.__f_push = (c) => ctrl.enqueue(c);
-		self.__f_close = () => ctrl.close();
-	}
-}).pipeThrough(new TextEncoderStream())
-`)}
-      <React.Suspense>
-        <Recurse depth={0} />
-      </React.Suspense>
-    </>
-  );
+      controller.enqueue(search + post);
+    },
+  });
 }
 
-function renderScript(code: string) {
-  return <script dangerouslySetInnerHTML={{ __html: code }} />;
+export function readStreamScript<T>() {
+  return new ReadableStream<T>({
+    start(controller) {
+      const chunks: T[] = ((globalThis as any).__stream_chunks ||= []);
+
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+
+      chunks.push = function (chunk) {
+        controller.enqueue(chunk);
+        return 0;
+      };
+
+      if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", () => {
+          controller.close();
+        });
+      } else {
+        controller.close();
+      }
+    },
+  });
 }

--- a/packages/react-server/src/utils/stream-script.tsx
+++ b/packages/react-server/src/utils/stream-script.tsx
@@ -1,4 +1,5 @@
 // cf.
+// https://github.com/vercel/next.js/blob/b2eafbf6b3550b1f0d643c326515814610747532/packages/next/src/server/stream-utils/node-web-streams-helper.ts#L382-L387
 // https://github.com/vercel/next.js/blob/1c5aa7fa09cc5503c621c534fc40065cbd2aefcb/packages/next/src/server/app-render/use-flight-response.tsx#L19-L26
 // https://github.com/vercel/next.js/blob/1c5aa7fa09cc5503c621c534fc40065cbd2aefcb/packages/next/src/client/app-index.tsx#L110-L113
 // https://github.com/devongovett/rsc-html-stream/
@@ -58,6 +59,33 @@ export function readStreamScript<T>() {
         });
       } else {
         controller.close();
+      }
+    },
+  });
+}
+
+// it seems buffering is necessary to ensure tag marker (e.g. `</body>`) is not split into multiple chunks.
+// Without this, above `injectStreamScript` breaks when receiving two chunks for "...<" and "/body>...".
+// see https://github.com/hi-ogawa/vite-plugins/pull/457
+export function bufferedTransformStream() {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  let buffer = "";
+  return new TransformStream<string, string>({
+    transform(chunk, controller) {
+      buffer += chunk;
+      if (typeof timeout !== "undefined") {
+        clearTimeout(timeout);
+      }
+      timeout = setTimeout(() => {
+        controller.enqueue(buffer);
+        buffer = "";
+        timeout = undefined;
+      }, 0);
+    },
+    async flush(controller) {
+      if (typeof timeout !== "undefined") {
+        clearTimeout(timeout);
+        controller.enqueue(buffer);
       }
     },
   });

--- a/packages/react-server/src/utils/stream-script.tsx
+++ b/packages/react-server/src/utils/stream-script.tsx
@@ -45,7 +45,3 @@ self.__flightStream = new ReadableStream({
 function renderScript(code: string) {
   return <script dangerouslySetInnerHTML={{ __html: code }} />;
 }
-
-export function getBrowserFlightStream(): ReadableStream<Uint8Array> {
-  return (self as any).__flightStream;
-}

--- a/packages/react-server/src/utils/stream-script.tsx
+++ b/packages/react-server/src/utils/stream-script.tsx
@@ -45,3 +45,7 @@ self.__flightStream = new ReadableStream({
 function renderScript(code: string) {
   return <script dangerouslySetInnerHTML={{ __html: code }} />;
 }
+
+export function getBrowserFlightStream(): ReadableStream<Uint8Array> {
+  return (self as any).__flightStream;
+}


### PR DESCRIPTION
Investigating cf e2e error in https://github.com/hi-ogawa/vite-plugins/pull/456.

It looks like it's not guaranteed that `</body>` would shows up nicely in a single chunk...

```
[injectStreamScript] { i: 2, chunk: 'body></html>' }
[injectStreamScript] { i: 3, chunk: '' }
```

---

Let's revive `StreamTransfer` removed in https://github.com/hi-ogawa/experiments/pull/26.
EDIT: Well, this has a problem for two-pass ssr...

---

Not sure but Next.js might be relying on buffering to somehow ensure tag to be not split?
https://github.com/vercel/next.js/blob/b2eafbf6b3550b1f0d643c326515814610747532/packages/next/src/server/stream-utils/node-web-streams-helper.ts#L382-L387