### PR TITLE
feat(next): adapters for deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
       - run: pnpm -C packages/react-server/examples/next test-e2e
       - run: pnpm -C packages/react-server/examples/next build
       - run: pnpm -C packages/react-server/examples/next test-e2e-preview
+      - run: pnpm -C packages/react-server/examples/next cf-build
+      - run: pnpm -C packages/react-server/examples/next vc-build
       - run: pnpm -C packages/react-server/examples/prerender test-e2e
       - run: pnpm -C packages/react-server/examples/prerender build
       - run: pnpm -C packages/react-server/examples/prerender test-e2e-preview

--- a/packages/react-server-next/package.json
+++ b/packages/react-server-next/package.json
@@ -41,6 +41,7 @@
     "@edge-runtime/cookies": "^4.1.1",
     "@hiogawa/vite-plugin-ssr-middleware": "workspace:*",
     "@vitejs/plugin-react": "^4.2.1",
+    "esbuild": "^0.20.2",
     "vite-tsconfig-paths": "^4.3.2"
   },
   "devDependencies": {

--- a/packages/react-server-next/src/vite/adapters/cloudflare/build.ts
+++ b/packages/react-server-next/src/vite/adapters/cloudflare/build.ts
@@ -1,0 +1,63 @@
+import { cp, mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export async function build() {
+  const buildDir = join(process.cwd(), "dist");
+  const outDir = join(process.cwd(), "dist/cloudflare");
+
+  // clean
+  await rm(outDir, { recursive: true, force: true });
+  await mkdir(outDir, { recursive: true });
+
+  // assets
+  await cp(join(buildDir, "browser"), outDir, {
+    recursive: true,
+  });
+
+  // worker routes
+  // https://developers.cloudflare.com/pages/functions/routing/#create-a-_routesjson-file
+  await writeFile(
+    join(outDir, "_routes.json"),
+    JSON.stringify(
+      {
+        version: 1,
+        include: ["/*"],
+        exclude: ["/favicon.ico", "/assets/*"],
+      },
+      null,
+      2,
+    ),
+  );
+
+  // headers
+  // https://developers.cloudflare.com/pages/configuration/headers/
+  await writeFile(
+    join(outDir, "_headers"),
+    `\
+/favicon.ico
+  Cache-Control: public, max-age=3600, s-maxage=3600
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+`,
+  );
+
+  // worker
+  // https://developers.cloudflare.com/pages/functions/advanced-mode/
+  const esbuild = await import("esbuild");
+  const result = await esbuild.build({
+    entryPoints: [join(buildDir, "server/index.js")],
+    outfile: join(outDir, "_worker.js"),
+    bundle: true,
+    minify: true,
+    metafile: true,
+    format: "esm",
+    platform: "browser",
+    logOverride: {
+      "ignored-bare-import": "silent",
+    },
+  });
+  await writeFile(
+    join(buildDir, "esbuild-metafile.json"),
+    JSON.stringify(result.metafile),
+  );
+}

--- a/packages/react-server-next/src/vite/adapters/cloudflare/build.ts
+++ b/packages/react-server-next/src/vite/adapters/cloudflare/build.ts
@@ -10,7 +10,7 @@ export async function build() {
   await mkdir(outDir, { recursive: true });
 
   // assets
-  await cp(join(buildDir, "browser"), outDir, {
+  await cp(join(buildDir, "client"), outDir, {
     recursive: true,
   });
 

--- a/packages/react-server-next/src/vite/adapters/cloudflare/entry.ts
+++ b/packages/react-server-next/src/vite/adapters/cloudflare/entry.ts
@@ -1,0 +1,3 @@
+import { handler } from "@hiogawa/react-server/entry-server";
+
+export default { fetch: handler };

--- a/packages/react-server-next/src/vite/adapters/index.ts
+++ b/packages/react-server-next/src/vite/adapters/index.ts
@@ -1,6 +1,6 @@
 import type { Plugin } from "vite";
 
-export type AdapterType = "node" | "vercel" | "cloudlare";
+export type AdapterType = "node" | "vercel" | "cloudflare";
 
 export function adapterPlugin(options: {
   adapter?: AdapterType;
@@ -27,7 +27,7 @@ export function adapterPlugin(options: {
     },
     async writeBundle() {
       console.log(`▶▶▶ Using adapter: ${adapter}`);
-      if (adapter === "cloudlare") {
+      if (adapter === "cloudflare") {
         const { build } = await import("./cloudflare/build");
         await build();
       }
@@ -47,7 +47,7 @@ function autoSelectAdapter(): AdapterType {
     return "vercel";
   }
   if (process.env["CF_PAGES"]) {
-    return "cloudlare";
+    return "cloudflare";
   }
   return "node";
 }

--- a/packages/react-server-next/src/vite/adapters/index.ts
+++ b/packages/react-server-next/src/vite/adapters/index.ts
@@ -13,8 +13,8 @@ export function adapterPlugin(options: {
   const buildPlugin: Plugin = {
     name: adapterPlugin.name + ":build",
     enforce: "post",
-    apply: (_config, env) => env.command === "build" && !env.isSsrBuild,
-    config(_config, _env) {
+    apply: (_config, env) => !!env.isSsrBuild,
+    config() {
       return {
         build: {
           rollupOptions: {
@@ -26,6 +26,7 @@ export function adapterPlugin(options: {
       };
     },
     async writeBundle() {
+      console.log(`▶▶▶ Using adapter: ${adapter}`);
       if (adapter === "cloudlare") {
         const { build } = await import("./cloudflare/build");
         await build();

--- a/packages/react-server-next/src/vite/adapters/index.ts
+++ b/packages/react-server-next/src/vite/adapters/index.ts
@@ -1,0 +1,27 @@
+import type { Plugin } from "vite";
+
+export type AdapterType = "node" | "vercel" | "cloudlare";
+
+export function buildAdapterPlugin(options: {
+  adapter?: AdapterType;
+}): Plugin {
+  const adapter = options.adapter ?? autoSelectAdapter();
+  adapter;
+  return {
+    name: buildAdapterPlugin.name,
+    enforce: "post",
+    apply: (_config, env) => env.command === "build" && !env.isSsrBuild,
+    async writeBundle() {},
+  };
+}
+
+// cf. https://github.com/sveltejs/kit/blob/52e5461b055a104694f276859a7104f58452fab0/packages/adapter-auto/adapters.js
+function autoSelectAdapter(): AdapterType {
+  if (process.env["VERCEL"]) {
+    return "vercel";
+  }
+  if (process.env["CF_PAGES"]) {
+    return "cloudlare";
+  }
+  return "node";
+}

--- a/packages/react-server-next/src/vite/adapters/index.ts
+++ b/packages/react-server-next/src/vite/adapters/index.ts
@@ -19,15 +19,21 @@ export function adapterPlugin(options: {
         build: {
           rollupOptions: {
             input: {
-              // overwrite vitePluginSsrMiddleware's entry
-              index: "@hiogawa/react-server/entry-server",
+              index: `next/vite/adapters/${adapter}/entry`,
             },
           },
         },
       };
     },
     async writeBundle() {
-      adapter;
+      if (adapter === "cloudlare") {
+        const { build } = await import("./cloudflare/build");
+        await build();
+      }
+      if (adapter === "vercel") {
+        const { build } = await import("./vercel/build");
+        await build();
+      }
     },
   };
 

--- a/packages/react-server-next/src/vite/adapters/index.ts
+++ b/packages/react-server-next/src/vite/adapters/index.ts
@@ -6,12 +6,14 @@ export function adapterPlugin(options: {
   adapter?: AdapterType;
 }): Plugin[] {
   const adapter = options.adapter ?? autoSelectAdapter();
+  if (adapter === "node") {
+    return [];
+  }
 
   const buildPlugin: Plugin = {
     name: adapterPlugin.name + ":build",
     enforce: "post",
-    apply: (_config, env) =>
-      env.command === "build" && !env.isSsrBuild && adapter !== "node",
+    apply: (_config, env) => env.command === "build" && !env.isSsrBuild,
     config(_config, _env) {
       return {
         build: {

--- a/packages/react-server-next/src/vite/adapters/node/entry.ts
+++ b/packages/react-server-next/src/vite/adapters/node/entry.ts
@@ -1,4 +1,0 @@
-import { handler } from "@hiogawa/react-server/entry-server";
-import { webToNodeHandler } from "@hiogawa/utils-node";
-
-export default webToNodeHandler(handler);

--- a/packages/react-server-next/src/vite/adapters/node/entry.ts
+++ b/packages/react-server-next/src/vite/adapters/node/entry.ts
@@ -1,0 +1,4 @@
+import { handler } from "@hiogawa/react-server/entry-server";
+import { webToNodeHandler } from "@hiogawa/utils-node";
+
+export default webToNodeHandler(handler);

--- a/packages/react-server-next/src/vite/adapters/vercel/build.ts
+++ b/packages/react-server-next/src/vite/adapters/vercel/build.ts
@@ -21,10 +21,10 @@ const configJson = {
   ],
 };
 
-// TODO: vercel edge
+// edge only for now
 const vcConfigJson = {
-  runtime: "nodejs20.x",
-  handler: "index.mjs",
+  runtime: "edge",
+  entrypoint: "index.js",
 };
 
 export async function build() {
@@ -58,7 +58,7 @@ export async function build() {
   const esbuild = await import("esbuild");
   const result = await esbuild.build({
     entryPoints: [join(buildDir, "server/index.js")],
-    outfile: join(outDir, "functions/index.func/index.mjs"),
+    outfile: join(outDir, "functions/index.func/index.js"),
     metafile: true,
     bundle: true,
     minify: true,
@@ -72,7 +72,7 @@ export async function build() {
     },
   });
   await writeFile(
-    join(outDir, "esbuild-metafile.json"),
+    join(buildDir, "esbuild-metafile.json"),
     JSON.stringify(result.metafile),
   );
 }

--- a/packages/react-server-next/src/vite/adapters/vercel/build.ts
+++ b/packages/react-server-next/src/vite/adapters/vercel/build.ts
@@ -1,0 +1,78 @@
+import { cp, mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const configJson = {
+  version: 3,
+  trailingSlash: false,
+  routes: [
+    {
+      src: "^/assets/(.*)$",
+      headers: {
+        "cache-control": "public, immutable, max-age=31536000",
+      },
+    },
+    {
+      handle: "filesystem",
+    },
+    {
+      src: ".*",
+      dest: "/",
+    },
+  ],
+};
+
+// TODO: vercel edge
+const vcConfigJson = {
+  runtime: "nodejs20.x",
+  handler: "index.mjs",
+};
+
+export async function build() {
+  const buildDir = join(process.cwd(), "dist");
+  const outDir = join(process.cwd(), ".vercel/output");
+
+  // clean
+  await rm(outDir, { recursive: true, force: true });
+  await mkdir(outDir, { recursive: true });
+
+  // config
+  await writeFile(
+    join(outDir, "config.json"),
+    JSON.stringify(configJson, null, 2),
+  );
+
+  // static
+  await mkdir(join(outDir, "static"), { recursive: true });
+  await cp(join(buildDir, "client"), join(outDir, "static"), {
+    recursive: true,
+  });
+
+  // function config
+  await mkdir(join(outDir, "functions/index.func"), { recursive: true });
+  await writeFile(
+    join(outDir, "functions/index.func/.vc-config.json"),
+    JSON.stringify(vcConfigJson, null, 2),
+  );
+
+  // bundle function
+  const esbuild = await import("esbuild");
+  const result = await esbuild.build({
+    entryPoints: [join(buildDir, "server/index.js")],
+    outfile: join(outDir, "functions/index.func/index.mjs"),
+    metafile: true,
+    bundle: true,
+    minify: true,
+    format: "esm",
+    platform: "node",
+    define: {
+      "process.env.NODE_ENV": `"production"`,
+    },
+    logOverride: {
+      "ignored-bare-import": "silent",
+    },
+  });
+  await writeFile(
+    join(outDir, "esbuild-metafile.json"),
+    JSON.stringify(result.metafile),
+  );
+}

--- a/packages/react-server-next/src/vite/adapters/vercel/entry.ts
+++ b/packages/react-server-next/src/vite/adapters/vercel/entry.ts
@@ -1,5 +1,3 @@
-// import { handler } from "@hiogawa/react-server/entry-server";
-// import { webToNodeHandler } from "@hiogawa/utils-node";
+import { handler } from "@hiogawa/react-server/entry-server";
 
-// export default webToNodeHandler(handler);
-// export { default } from "../entry"
+export default handler;

--- a/packages/react-server-next/src/vite/adapters/vercel/entry.ts
+++ b/packages/react-server-next/src/vite/adapters/vercel/entry.ts
@@ -1,0 +1,5 @@
+// import { handler } from "@hiogawa/react-server/entry-server";
+// import { webToNodeHandler } from "@hiogawa/utils-node";
+
+// export default webToNodeHandler(handler);
+// export { default } from "../entry"

--- a/packages/react-server-next/src/vite/index.ts
+++ b/packages/react-server-next/src/vite/index.ts
@@ -14,7 +14,6 @@ export default function vitePluginReactServerNext(options?: {
   plugins?: PluginOption[];
   adapter?: AdapterType;
 }): PluginOption {
-  options?.adapter;
   return [
     react(),
     tsconfigPaths(),

--- a/packages/react-server-next/src/vite/index.ts
+++ b/packages/react-server-next/src/vite/index.ts
@@ -8,7 +8,7 @@ import {
 import react from "@vitejs/plugin-react";
 import type { Plugin, PluginOption } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
-import { type AdapterType, buildAdapterPlugin } from "./adapters";
+import { type AdapterType, adapterPlugin } from "./adapters";
 
 export default function vitePluginReactServerNext(options?: {
   plugins?: PluginOption[];
@@ -35,12 +35,12 @@ export default function vitePluginReactServerNext(options?: {
         ...(options?.plugins ?? []),
       ],
     }),
-    buildAdapterPlugin({ adapter: options?.adapter }),
     vitePluginLogger(),
     vitePluginSsrMiddleware({
       entry: "next/vite/entry-ssr",
       preview: path.resolve("./dist/server/index.js"),
     }),
+    adapterPlugin({ adapter: options?.adapter }),
     appFaviconPlugin(),
     {
       name: "next-exclude-optimize",

--- a/packages/react-server-next/src/vite/index.ts
+++ b/packages/react-server-next/src/vite/index.ts
@@ -8,10 +8,13 @@ import {
 import react from "@vitejs/plugin-react";
 import type { Plugin, PluginOption } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
+import { type AdapterType, buildAdapterPlugin } from "./adapters";
 
 export default function vitePluginReactServerNext(options?: {
   plugins?: PluginOption[];
+  adapter?: AdapterType;
 }): PluginOption {
+  options?.adapter;
   return [
     react(),
     tsconfigPaths(),
@@ -32,6 +35,7 @@ export default function vitePluginReactServerNext(options?: {
         ...(options?.plugins ?? []),
       ],
     }),
+    buildAdapterPlugin({ adapter: options?.adapter }),
     vitePluginLogger(),
     vitePluginSsrMiddleware({
       entry: "next/vite/entry-ssr",

--- a/packages/react-server-next/tsup.config.ts
+++ b/packages/react-server-next/tsup.config.ts
@@ -8,6 +8,8 @@ export default defineConfig([
       "src/vite/entry-browser.tsx",
       "src/vite/entry-ssr.tsx",
       "src/vite/entry-server.tsx",
+      "src/vite/adapters/cloudflare/entry.ts",
+      "src/vite/adapters/vercel/entry.ts",
       "src/compat/index.tsx",
       "src/compat/link.tsx",
       "src/compat/navigation.tsx",

--- a/packages/react-server/examples/next/README.md
+++ b/packages/react-server/examples/next/README.md
@@ -1,17 +1,18 @@
 # next test
 
+- https://test-next-vite.vercel.app
 - https://test-next-vite.pages.dev
 
 ```sh
-# deploy cloudflare
-wrangler pages project create test-next-vite --production-branch main --compatibility-date=2024-01-01
-pnpm cf-build
-pnpm cf-preview
-pnpm cf-release
-
 # deploy vercel
 vercel projects add test-next-vite
 vercel link -p test-next-vite
 pnpm vc-build
 pnpm vc-release
+
+# deploy cloudflare
+wrangler pages project create test-next-vite --production-branch main --compatibility-date=2024-01-01
+pnpm cf-build
+pnpm cf-preview
+pnpm cf-release
 ```

--- a/packages/react-server/examples/next/README.md
+++ b/packages/react-server/examples/next/README.md
@@ -1,2 +1,17 @@
-Based on Next.js template
-- https://github.com/vercel/next.js/tree/6604c187ece3021e9b429ecf1207f34d41efbe0a/packages/create-next-app/templates/app/ts
+# next test
+
+- https://test-next-vite.pages.dev
+
+```sh
+# deploy cloudflare
+wrangler pages project create test-next-vite --production-branch main --compatibility-date=2024-01-01
+pnpm cf-build
+pnpm cf-preview
+pnpm cf-deploy
+
+# deploy vercel
+vercel projects add test-next-vite
+vercel link -p test-next-vite
+pnpm vc-build
+pnpm vc-deploy
+```

--- a/packages/react-server/examples/next/README.md
+++ b/packages/react-server/examples/next/README.md
@@ -7,11 +7,11 @@
 wrangler pages project create test-next-vite --production-branch main --compatibility-date=2024-01-01
 pnpm cf-build
 pnpm cf-preview
-pnpm cf-deploy
+pnpm cf-release
 
 # deploy vercel
 vercel projects add test-next-vite
 vercel link -p test-next-vite
 pnpm vc-build
-pnpm vc-deploy
+pnpm vc-release
 ```

--- a/packages/react-server/examples/next/package.json
+++ b/packages/react-server/examples/next/package.json
@@ -22,6 +22,5 @@
     "@types/react": "18.3.1",
     "@types/react-dom": "18.3.0",
     "vite": "latest"
-  },
-  "packageManager": "pnpm@9.3.0+sha512.ee7b93e0c2bd11409c6424f92b866f31d3ea1bef5fbe47d3c7500cdc3c9668833d2e55681ad66df5b640c61fa9dc25d546efa54d76d7f8bf54b13614ac293631"
+  }
 }

--- a/packages/react-server/examples/next/package.json
+++ b/packages/react-server/examples/next/package.json
@@ -8,7 +8,12 @@
     "start": "next start",
     "lint": "next lint",
     "test-e2e": "playwright test",
-    "test-e2e-preview": "E2E_PREVIEW=1 playwright test"
+    "test-e2e-preview": "E2E_PREVIEW=1 playwright test",
+    "cf-build": "CF_PAGES=1 pnpm build",
+    "cf-preview": "wrangler pages dev ./dist/cloudflare --compatibility-date=2024-01-01",
+    "cf-release": "wrangler pages deploy ./dist/cloudflare --commit-dirty --branch main --project-name test-next-vite",
+    "vc-build": "VERCEL=1 pnpm build",
+    "vc-release": "vercel deploy --prod --prebuilt"
   },
   "dependencies": {
     "@hiogawa/react-server": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.2.1
         version: 4.2.1(vite@5.2.3(@types/node@20.11.28)(terser@5.29.2))
+      esbuild:
+        specifier: ^0.20.2
+        version: 0.20.2
       vite-tsconfig-paths:
         specifier: ^4.3.2
         version: 4.3.2(typescript@5.4.2)(vite@5.2.3(@types/node@20.11.28)(terser@5.29.2))


### PR DESCRIPTION
For https://github.com/hi-ogawa/next-app-router-playground/pull/2

Just copying some scripts from `packages/react-server/examples/basic/misc/cf/build.js` and `packages/react-server/examples/basic/misc/vercel/build.js`.

## todo

- [x] vercel edge
- [x] cf pages
- [ ] test zero config github integration
  - [ ] vercel
  - [ ] cf