### PR TITLE
perf: emit route manifest as a separate asset

### DIFF
--- a/packages/react-server/src/entry/server.tsx
+++ b/packages/react-server/src/entry/server.tsx
@@ -26,7 +26,6 @@ import {
 } from "../lib/error";
 import { $__global } from "../lib/global";
 import { ENTRY_REACT_SERVER_WRAPPER, invalidateModule } from "../plugin/utils";
-import { escpaeScriptString } from "../utils/escape";
 import {
   createBufferedTransformStream,
   injectFlightStream,
@@ -147,13 +146,13 @@ export async function renderHtml(
 
   // inject DEBUG variable
   if (globalThis?.process?.env?.["DEBUG"]) {
-    head += `<script>globalThis.__DEBUG = "${process.env["DEBUG"]}"</script>\n`;
+    head += `<script>self.__DEBUG = "${process.env["DEBUG"]}"</script>\n`;
   }
 
-  // TODO: too huge?
-  head += `<script>globalThis.__routeManifest = ${escpaeScriptString(
-    JSON.stringify(routeManifest),
-  )}</script>\n`;
+  if (routeManifest.url) {
+    head += `<script>self.__routeManifestUrl = "${routeManifest.url}"</script>\n`;
+    head += `<link rel="modulepreload" href="${routeManifest.url}" />\n`;
+  }
 
   // two pass SSR to re-render on error
   let ssrStream: ReadableStream<Uint8Array>;

--- a/packages/react-server/src/features/router/manifest.ts
+++ b/packages/react-server/src/features/router/manifest.ts
@@ -2,7 +2,6 @@ import { objectMapValues, typedBoolean, uniq } from "@hiogawa/utils";
 import { type BaseRouteEntry, type TreeNode, matchRouteTree } from "./tree";
 
 export type RouteManifest = {
-  url?: string;
   routeTree: TreeNode<BaseRouteEntry<AssetDeps>>;
 };
 

--- a/packages/react-server/src/features/router/manifest.ts
+++ b/packages/react-server/src/features/router/manifest.ts
@@ -2,8 +2,13 @@ import { objectMapValues, typedBoolean, uniq } from "@hiogawa/utils";
 import { type BaseRouteEntry, type TreeNode, matchRouteTree } from "./tree";
 
 export type RouteManifest = {
+  url?: string;
   routeTree: TreeNode<BaseRouteEntry<AssetDeps>>;
 };
+
+export function emptyRouteManifest(): RouteManifest {
+  return { routeTree: {} };
+}
 
 export type AssetDeps = {
   js: string[];

--- a/packages/react-server/src/features/router/plugin.ts
+++ b/packages/react-server/src/features/router/plugin.ts
@@ -8,7 +8,11 @@ import {
 import FastGlob from "fast-glob";
 import type { Plugin, Rollup } from "vite";
 import type { PluginStateManager } from "../../plugin";
-import { type CustomModuleMeta, createVirtualPlugin } from "../../plugin/utils";
+import {
+  type CustomModuleMeta,
+  createVirtualPlugin,
+  hashString,
+} from "../../plugin/utils";
 import { type AssetDeps, mergeAssetDeps } from "./manifest";
 import { createFsRouteTree } from "./tree";
 
@@ -75,6 +79,20 @@ export function routeManifestPluginClient({
           manager.routeManifest = {
             routeTree: createFsRouteTree(routeToAssetDeps),
           };
+
+          const source = `export default ${JSON.stringify(
+            manager.routeManifest,
+            null,
+            2,
+          )}`;
+          const sourceHash = hashString(source).slice(0, 8);
+          const fileName = `assets/route-manifest-${sourceHash}.js`;
+          this.emitFile({
+            type: "asset",
+            fileName,
+            source,
+          });
+          manager.routeManifest.url = `/${fileName}`;
         }
       },
     },


### PR DESCRIPTION
Currently the entire `RouteManifest` is inlined in the ssr html as `<script>self.__routeManifest = ...</script>`, but this is probably not good.
Like Remix does, let's separate assets for manifest so it can be fetched separately.