### PR TITLE
feat: add default meta viewport

### DIFF
--- a/packages/react-server/examples/basic/src/routes/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/layout.tsx
@@ -12,6 +12,7 @@ export default function Layout(props: LayoutProps) {
       <head>
         <meta charSet="UTF-8" />
         <link rel="icon" href="/favicon.ico" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
       </head>
       <body>
         <div className="p-4 flex flex-col gap-2">

--- a/packages/react-server/examples/next/app/layout.tsx
+++ b/packages/react-server/examples/next/app/layout.tsx
@@ -25,9 +25,6 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <head>
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-      </head>
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
         {children}
       </body>

--- a/packages/react-server/examples/next/app/layout.tsx
+++ b/packages/react-server/examples/next/app/layout.tsx
@@ -25,6 +25,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </head>
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
         {children}
       </body>

--- a/packages/react-server/examples/next/e2e/basic.test.ts
+++ b/packages/react-server/examples/next/e2e/basic.test.ts
@@ -78,3 +78,11 @@ test("favicon.ico", async ({ request }) => {
   expect(res.status()).toBe(200);
   expect(res.headers()["content-type"]).toBe("image/x-icon");
 });
+
+test("viewport", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator(`meta[name="viewport"]`)).toHaveAttribute(
+    "content",
+    "width=device-width, initial-scale=1",
+  );
+});

--- a/packages/react-server/examples/prerender/src/routes/layout.tsx
+++ b/packages/react-server/examples/prerender/src/routes/layout.tsx
@@ -8,6 +8,7 @@ export default function Layout(props: React.PropsWithChildren) {
         <meta charSet="UTF-8" />
         <title>React Server Prerender</title>
         <link rel="icon" href="/favicon.ico" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
       </head>
       <body>
         <h3>React Server Prerender</h3>

--- a/packages/react-server/examples/starter/src/routes/layout.tsx
+++ b/packages/react-server/examples/starter/src/routes/layout.tsx
@@ -7,6 +7,7 @@ export default function Layout(props: React.PropsWithChildren) {
         <meta charSet="UTF-8" />
         <title>React Server Starter</title>
         <link rel="icon" href="/favicon.ico" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
       </head>
       <body>
         <h3>React Server Starter</h3>

--- a/packages/react-server/src/entry/server.tsx
+++ b/packages/react-server/src/entry/server.tsx
@@ -4,6 +4,7 @@ import ReactDOMServer from "react-dom/server.edge";
 import type { ModuleNode, ViteDevServer } from "vite";
 import type { SsrAssetsType } from "../features/assets/plugin";
 import { DEV_SSR_CSS, SERVER_CSS_PROXY } from "../features/assets/shared";
+import { injectDefaultMetaViewport } from "../features/next/ssr";
 import {
   LayoutRoot,
   LayoutStateContext,
@@ -201,6 +202,7 @@ export async function renderHtml(
     .pipeThrough(new TextDecoderStream())
     .pipeThrough(createBufferedTransformStream())
     .pipeThrough(injectToHead(head))
+    .pipeThrough(injectDefaultMetaViewport())
     .pipeThrough(injectFlightStream(stream2))
     .pipeThrough(new TextEncoderStream());
 

--- a/packages/react-server/src/features/next/ssr.tsx
+++ b/packages/react-server/src/features/next/ssr.tsx
@@ -1,0 +1,23 @@
+// inject default meta viewport
+export function injectDefaultMetaViewport() {
+  const HEAD_END = "</head>";
+  const META_VIEWPORT_PATTERN = `<meta name="viewport"`;
+  const META_VIEWPORT_DEFAULT = `<meta name="viewport" content="width=device-width, initial-scale=1">`;
+
+  let done = false;
+  return new TransformStream<string, string>({
+    transform(chunk, controller) {
+      if (done) {
+        controller.enqueue(chunk);
+        return;
+      }
+      if (chunk.includes(META_VIEWPORT_PATTERN)) {
+        done = true;
+      } else if (chunk.includes(HEAD_END)) {
+        chunk.replace(HEAD_END, () => `${META_VIEWPORT_DEFAULT}${HEAD_END}`);
+        done = true;
+      }
+      controller.enqueue(chunk);
+    },
+  });
+}

--- a/packages/react-server/src/features/next/ssr.tsx
+++ b/packages/react-server/src/features/next/ssr.tsx
@@ -14,7 +14,10 @@ export function injectDefaultMetaViewport() {
       if (chunk.includes(META_VIEWPORT_PATTERN)) {
         done = true;
       } else if (chunk.includes(HEAD_END)) {
-        chunk.replace(HEAD_END, () => `${META_VIEWPORT_DEFAULT}${HEAD_END}`);
+        chunk = chunk.replace(
+          HEAD_END,
+          () => `${META_VIEWPORT_DEFAULT}${HEAD_END}`,
+        );
         done = true;
       }
       controller.enqueue(chunk);


### PR DESCRIPTION
For now, quick workaround for https://github.com/hi-ogawa/next-app-router-playground/pull/1

The reason why `viewport` is separated from `metadata` is explained well below, so probably we should catch up later, but it's fine for now.
- https://github.com/vercel/next.js/pull/57302