### PR TITLE
feat: add `useLocation` to provide server url

### DIFF
--- a/packages/react-server-next/src/compat/navigation.tsx
+++ b/packages/react-server-next/src/compat/navigation.tsx
@@ -2,6 +2,7 @@
 
 import {
   routerRevalidate,
+  useLocation,
   useParams as useParams_,
   useRouter as useRouter_,
   useSelectedLayoutSegments,
@@ -9,12 +10,11 @@ import {
 import React from "react";
 
 export function useSearchParams() {
-  const search = useRouter_((s) => s.location.search);
-  return React.useMemo(() => new URLSearchParams(search), [search]);
+  return useLocation().searchParams;
 }
 
 export function usePathname() {
-  return useRouter_((s) => s.location.pathname);
+  return useLocation().pathname;
 }
 
 interface Params {

--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -993,6 +993,8 @@ test("dynamic routes", async ({ page }) => {
   await page.getByRole("link", { name: "• /test/dynamic/abc/def" }).click();
   await page.getByText("file: /test/dynamic/[id]/[nested]/page.tsx").click();
   await page.getByText("pathname: /test/dynamic/abc/def").click();
+  await page.getByText("pathname (client): /test/dynamic/abc/def").click();
+  await page.getByText("pathname (server): /test/dynamic/abc/def").click();
   await page.getByText('params: {"id":"abc","nested":"def"}').click();
 
   // regardless of Link.href prop

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/_cilent.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/_cilent.tsx
@@ -1,8 +1,13 @@
 "use client";
 
-import { useRouter } from "@hiogawa/react-server/client";
+import { useLocation, useRouter } from "@hiogawa/react-server/client";
 
 export function ClientLocation() {
   const location = useRouter((s) => s.location);
+  return <>{location.pathname}</>;
+}
+
+export function ServerLocation() {
+  const location = useLocation();
   return <>{location.pathname}</>;
 }

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/_utils.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/_utils.tsx
@@ -1,5 +1,5 @@
 import type { PageProps } from "@hiogawa/react-server/server";
-import { ClientLocation } from "./_cilent";
+import { ClientLocation, ServerLocation } from "./_cilent";
 
 export function TestDynamic({
   file: file,
@@ -17,6 +17,9 @@ export function TestDynamic({
       </div>
       <div>
         pathname (client): <ClientLocation />
+      </div>
+      <div>
+        pathname (server): <ServerLocation />
       </div>
       <div>params: {JSON.stringify(props.params)}</div>
     </div>

--- a/packages/react-server/src/client.tsx
+++ b/packages/react-server/src/client.tsx
@@ -5,5 +5,6 @@ export { useRouter } from "./lib/client/router";
 export {
   routerRevalidate,
   useParams,
+  useLocation,
   useSelectedLayoutSegments,
 } from "./features/router/client";

--- a/packages/react-server/src/entry/browser.tsx
+++ b/packages/react-server/src/entry/browser.tsx
@@ -94,6 +94,7 @@ export async function start() {
             action: next.action,
             metadata: next.metadata,
             params: next.params,
+            url: next.url,
             layout: {
               ...current.layout,
               ...next.layout,

--- a/packages/react-server/src/entry/react-server.tsx
+++ b/packages/react-server/src/entry/react-server.tsx
@@ -116,6 +116,7 @@ async function render({
       layout: nodeMap,
       metadata: result.metadata,
       params: result.params,
+      url: request.url,
       action: actionResult
         ? objectPick(actionResult, ["data", "error"])
         : undefined,

--- a/packages/react-server/src/features/router/client.tsx
+++ b/packages/react-server/src/features/router/client.tsx
@@ -42,6 +42,13 @@ function MetadataRenderer() {
   return data.metadata;
 }
 
+// TODO: should we remove confusing `useRouter(s => s.location)`?
+export function useLocation() {
+  const ctx = React.useContext(LayoutStateContext);
+  const data = React.use(ctx.data);
+  return React.useMemo(() => new URL(data.url), [data.url]);
+}
+
 function useParamEntries() {
   const ctx = React.useContext(LayoutStateContext);
   const data = React.use(ctx.data);

--- a/packages/react-server/src/features/router/utils.tsx
+++ b/packages/react-server/src/features/router/utils.tsx
@@ -16,6 +16,7 @@ export type ServerRouterData = {
   metadata?: React.ReactNode;
   layout: Record<string, React.ReactNode>;
   params: MatchParamEntry[];
+  url: string;
 };
 
 export const LAYOUT_ROOT_NAME = "__root";

--- a/packages/react-server/src/lib/client/router.tsx
+++ b/packages/react-server/src/lib/client/router.tsx
@@ -37,7 +37,6 @@ export class Router {
 
 export const RouterContext = React.createContext<Router>(undefined!);
 
-// TODO: rename it to useClientRouter and provide a separate useRouteState for server state?
 export function useRouter<U = RouterState>(select?: (v: RouterState) => U) {
   const router = React.useContext(RouterContext);
   return useStore(router.store, select);


### PR DESCRIPTION
I started with `useRouter` which exposes browser location, which is probably necessary to implement demo like https://rsc-experiment-hiroshi.vercel.app/test/transition, but it looks like Next.js doesn't do it and only provides flight tree location via `usePathname` etc... of `next/navigation`.

For now, we keep current `useRouter`, but let's expose `useLocation` for quick next compatibility.

## todo

- [x] test