### PR TITLE
fix(next): fix `useSelectedLayoutSegment`

### DIFF
--- a/packages/react-server-next/src/compat/navigation.tsx
+++ b/packages/react-server-next/src/compat/navigation.tsx
@@ -5,7 +5,6 @@ import {
   useParams as useParams_,
   useRouter as useRouter_,
   useSelectedParamEntries,
-  useSelectedParams,
 } from "@hiogawa/react-server/client";
 import React from "react";
 
@@ -28,8 +27,8 @@ export function useParams<T extends Params = Params>(): T {
 }
 
 export function useSelectedLayoutSegments(_todo?: string): string[] {
-  const selected = useSelectedParams();
-  return Object.values(selected);
+  const entries = useSelectedParamEntries();
+  return React.useMemo(() => entries.map(([_k, v]) => v), [entries]);
 }
 
 export function useSelectedLayoutSegment(_todo?: string): string | null {

--- a/packages/react-server-next/src/compat/navigation.tsx
+++ b/packages/react-server-next/src/compat/navigation.tsx
@@ -4,7 +4,7 @@ import {
   routerRevalidate,
   useParams as useParams_,
   useRouter as useRouter_,
-  useSelectedParamEntries,
+  useSelectedLayoutSegments,
 } from "@hiogawa/react-server/client";
 import React from "react";
 
@@ -26,14 +26,10 @@ export function useParams<T extends Params = Params>(): T {
   return useParams_() as any;
 }
 
-export function useSelectedLayoutSegments(_todo?: string): string[] {
-  const entries = useSelectedParamEntries();
-  return React.useMemo(() => entries.map(([_k, v]) => v), [entries]);
-}
+export { useSelectedLayoutSegments };
 
-export function useSelectedLayoutSegment(_todo?: string): string | null {
-  const [next] = useSelectedParamEntries();
-  return next?.[1] ?? null;
+export function useSelectedLayoutSegment(): string | null {
+  return useSelectedLayoutSegments()[0] ?? null;
 }
 
 export function useRouter() {

--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -1087,23 +1087,23 @@ async function testCatchallRoute(page: Page, _options: { js: boolean }) {
   await expect(page.getByLabel("test state")).not.toBeChecked();
 }
 
-test("useSelectedParams", async ({ page }) => {
+test("useSelectedLayoutSegments", async ({ page }) => {
   await page.goto("/test/dynamic/selected");
-  await page.getByText("/layout.tsx: {}").click();
-  await page.getByText("/page.tsx: {}").click();
+  await page.getByText("/layout.tsx: []").click();
+  await page.getByText("/page.tsx: []").click();
 
   await page
     .getByRole("link", { name: "• /test/dynamic/selected/x", exact: true })
     .click();
-  await page.getByText('/layout.tsx: {"p1":"x"}').click();
-  await page.getByText("/[p1]/layout.tsx: {}").click();
+  await page.getByText('/layout.tsx: ["x"]').click();
+  await page.getByText("/[p1]/layout.tsx: []").click();
 
   await page
     .getByRole("link", { name: "• /test/dynamic/selected/x/y" })
     .click();
-  await page.getByText('/layout.tsx: {"p1":"x","p2":"y"}').click();
-  await page.getByText('/[p1]/layout.tsx: {"p2":"y"}').click();
-  await page.getByText("/[p1]/[p2]/layout.tsx: {}").click();
+  await page.getByText('/layout.tsx: ["x","y"]').click();
+  await page.getByText('/[p1]/layout.tsx: ["y"]').click();
+  await page.getByText("/[p1]/[p2]/layout.tsx: []").click();
 
   await page
     .getByRole("link", {
@@ -1111,15 +1111,15 @@ test("useSelectedParams", async ({ page }) => {
       exact: true,
     })
     .click();
-  await page.getByText('/layout.tsx: {"p1":"x"}').click();
-  await page.getByText("/[p1]/layout.tsx: {}").click();
+  await page.getByText('/layout.tsx: ["x","static"]').click();
+  await page.getByText('/[p1]/layout.tsx: ["static"]').click();
 
   await page
     .getByRole("link", { name: "• /test/dynamic/selected/x/static/y" })
     .click();
-  await page.getByText('/layout.tsx: {"p1":"x","q1":"y"}').click();
-  await page.getByText('/[p1]/layout.tsx: {"q1":"y"}').click();
-  await page.getByText('/[p1]/static/layout.tsx: {"q1":"y"}').click();
+  await page.getByText('/layout.tsx: ["x","static","y"]').click();
+  await page.getByText('/[p1]/layout.tsx: ["static","y"]').click();
+  await page.getByText('/[p1]/static/layout.tsx: ["y"]').click();
 });
 
 test("full client route", async ({ page }) => {

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/selected/[p1]/[p2]/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/selected/[p1]/[p2]/layout.tsx
@@ -1,11 +1,11 @@
 import type { LayoutProps } from "@hiogawa/react-server/server";
-import { SelectedParams } from "../../_client";
+import { Selected } from "../../_client";
 
 export default function Page(props: LayoutProps) {
   return (
     <>
       <pre>
-        /[p1]/[p2]/layout.tsx: <SelectedParams />
+        /[p1]/[p2]/layout.tsx: <Selected />
       </pre>
       {props.children}
     </>

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/selected/[p1]/[p2]/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/selected/[p1]/[p2]/page.tsx
@@ -1,9 +1,9 @@
-import { SelectedParams } from "../../_client";
+import { Selected } from "../../_client";
 
 export default function Page() {
   return (
     <pre>
-      /[p1]/[p2]/page.tsx: <SelectedParams />
+      /[p1]/[p2]/page.tsx: <Selected />
     </pre>
   );
 }

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/selected/[p1]/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/selected/[p1]/layout.tsx
@@ -1,11 +1,11 @@
 import type { LayoutProps } from "@hiogawa/react-server/server";
-import { SelectedParams } from "../_client";
+import { Selected } from "../_client";
 
 export default function Page(props: LayoutProps) {
   return (
     <>
       <pre>
-        /[p1]/layout.tsx: <SelectedParams />
+        /[p1]/layout.tsx: <Selected />
       </pre>
       {props.children}
     </>

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/selected/[p1]/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/selected/[p1]/page.tsx
@@ -1,9 +1,9 @@
-import { SelectedParams } from "../_client";
+import { Selected } from "../_client";
 
 export default function Page() {
   return (
     <pre>
-      /[p1]/page.tsx: <SelectedParams />
+      /[p1]/page.tsx: <Selected />
     </pre>
   );
 }

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/selected/[p1]/static/[q1]/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/selected/[p1]/static/[q1]/layout.tsx
@@ -1,11 +1,11 @@
 import type { LayoutProps } from "@hiogawa/react-server/server";
-import { SelectedParams } from "../../../_client";
+import { Selected } from "../../../_client";
 
 export default function Page(props: LayoutProps) {
   return (
     <>
       <pre>
-        /[p1]/static/[q1]/layout.tsx: <SelectedParams />
+        /[p1]/static/[q1]/layout.tsx: <Selected />
       </pre>
       {props.children}
     </>

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/selected/[p1]/static/[q1]/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/selected/[p1]/static/[q1]/page.tsx
@@ -1,9 +1,9 @@
-import { SelectedParams } from "../../../_client";
+import { Selected } from "../../../_client";
 
 export default function Page() {
   return (
     <pre>
-      /[p1]/static/[q1]/page.tsx: <SelectedParams />
+      /[p1]/static/[q1]/page.tsx: <Selected />
     </pre>
   );
 }

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/selected/[p1]/static/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/selected/[p1]/static/layout.tsx
@@ -1,11 +1,11 @@
 import type { LayoutProps } from "@hiogawa/react-server/server";
-import { SelectedParams } from "../../_client";
+import { Selected } from "../../_client";
 
 export default function Page(props: LayoutProps) {
   return (
     <>
       <pre>
-        /[p1]/static/layout.tsx: <SelectedParams />
+        /[p1]/static/layout.tsx: <Selected />
       </pre>
       {props.children}
     </>

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/selected/[p1]/static/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/selected/[p1]/static/page.tsx
@@ -1,9 +1,9 @@
-import { SelectedParams } from "../../_client";
+import { Selected } from "../../_client";
 
 export default function Page() {
   return (
     <pre>
-      /[p1]/static/page.tsx: <SelectedParams />
+      /[p1]/static/page.tsx: <Selected />
     </pre>
   );
 }

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/selected/_client.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/selected/_client.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useSelectedParams } from "@hiogawa/react-server/client";
+import { useSelectedLayoutSegments } from "@hiogawa/react-server/client";
 
 export function SelectedParams() {
-  const params = useSelectedParams();
+  const params = useSelectedLayoutSegments();
   return <>{JSON.stringify(params)}</>;
 }

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/selected/_client.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/selected/_client.tsx
@@ -2,7 +2,7 @@
 
 import { useSelectedLayoutSegments } from "@hiogawa/react-server/client";
 
-export function SelectedParams() {
+export function Selected() {
   const params = useSelectedLayoutSegments();
   return <>{JSON.stringify(params)}</>;
 }

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/selected/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/selected/layout.tsx
@@ -1,6 +1,6 @@
 import type { LayoutProps } from "@hiogawa/react-server/server";
 import { NavMenu } from "../../../../components/nav-menu";
-import { SelectedParams } from "./_client";
+import { Selected } from "./_client";
 
 export default function Page(props: LayoutProps) {
   return (
@@ -17,7 +17,7 @@ export default function Page(props: LayoutProps) {
         ]}
       />
       <pre>
-        /layout.tsx: <SelectedParams />
+        /layout.tsx: <Selected />
       </pre>
       {props.children}
     </div>

--- a/packages/react-server/examples/basic/src/routes/test/dynamic/selected/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/dynamic/selected/page.tsx
@@ -1,9 +1,9 @@
-import { SelectedParams } from "./_client";
+import { Selected } from "./_client";
 
 export default function Page() {
   return (
     <pre>
-      /page.tsx: <SelectedParams />
+      /page.tsx: <Selected />
     </pre>
   );
 }

--- a/packages/react-server/src/client.tsx
+++ b/packages/react-server/src/client.tsx
@@ -5,6 +5,5 @@ export { useRouter } from "./lib/client/router";
 export {
   routerRevalidate,
   useParams,
-  useSelectedParams,
-  useSelectedParamEntries,
+  useSelectedLayoutSegments,
 } from "./features/router/client";

--- a/packages/react-server/src/features/router/client.tsx
+++ b/packages/react-server/src/features/router/client.tsx
@@ -65,20 +65,20 @@ export function LayoutMatchProvider(
   return <LayoutMatchContext.Provider {...props} />;
 }
 
-export function useSelectedParamEntries() {
+function useSelectedParamEntries() {
   const all = useParamEntries();
   const prefix = React.useContext(LayoutMatchContext).params;
   return React.useMemo(() => all.slice(prefix.length), [all, prefix]);
 }
 
-export function useSelectedParams() {
+export function useSelectedLayoutSegments(): string[] {
   const entries = useSelectedParamEntries();
-  return React.useMemo(() => toMatchParamsObject(entries), [entries]);
+  return React.useMemo(() => entries.map(([_k, v]) => v), [entries]);
 }
 
 export function RemountRoute(props: React.PropsWithChildren) {
-  const [next] = useSelectedParamEntries();
-  return <React.Fragment key={next?.[1]}>{props.children}</React.Fragment>;
+  const key = useSelectedLayoutSegments()[0];
+  return <React.Fragment key={key}>{props.children}</React.Fragment>;
 }
 
 export const ROUTER_REVALIDATE_KEY = "__REVALIDATE";


### PR DESCRIPTION
Just noticed sidebar nav active link is not working https://github.com/hi-ogawa/next-app-router-playground/pull/1. It looks like "selected" should include not only dynamic parameter but everything along the path.

## todo

- [x] test
- [x] probably at this point, we can just have `useSelectedLayoutSegments` in core?