### PR TITLE
feat: add `PageProps.searchParams`

### DIFF
--- a/packages/react-server/examples/basic/src/routes/test/other/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/other/page.tsx
@@ -15,12 +15,7 @@ export default function Page(props: PageProps) {
       <h5 className="font-bold">props.request</h5>
       <div className="flex flex-col gap-2">
         <pre className="text-sm">
-          searchParams ={" "}
-          {JSON.stringify(
-            Object.fromEntries(
-              new URL(props.request.url).searchParams.entries(),
-            ),
-          )}
+          searchParams = {JSON.stringify(props.searchParams)}
         </pre>
         <div className="flex gap-2">
           <Link

--- a/packages/react-server/src/features/router/__snapshots__/server.test.tsx.snap
+++ b/packages/react-server/src/features/router/__snapshots__/server.test.tsx.snap
@@ -65,6 +65,7 @@ exports[`generateRouteModuleTree > basic 2`] = `
             "url": "https://test.local/x",
           }
         }
+        searchParams={{}}
         url={
           {
             "hash": "",
@@ -127,6 +128,7 @@ exports[`generateRouteModuleTree > basic 2`] = `
           "url": "https://test.local/x",
         }
       }
+      searchParams={{}}
       url={
         {
           "hash": "",
@@ -181,6 +183,7 @@ exports[`generateRouteModuleTree > basic 3`] = `
             "url": "https://test.local/x/y",
           }
         }
+        searchParams={{}}
         url={
           {
             "hash": "",
@@ -260,6 +263,7 @@ exports[`generateRouteModuleTree > basic 3`] = `
             "url": "https://test.local/x/y",
           }
         }
+        searchParams={{}}
         url={
           {
             "hash": "",
@@ -294,6 +298,7 @@ exports[`generateRouteModuleTree > basic 3`] = `
           "url": "https://test.local/x/y",
         }
       }
+      searchParams={{}}
       url={
         {
           "hash": "",
@@ -352,6 +357,7 @@ exports[`generateRouteModuleTree > basic 4`] = `
             "url": "https://test.local/z",
           }
         }
+        searchParams={{}}
         url={
           {
             "hash": "",
@@ -406,6 +412,7 @@ exports[`generateRouteModuleTree > basic 4`] = `
           "url": "https://test.local/z",
         }
       }
+      searchParams={{}}
       url={
         {
           "hash": "",

--- a/packages/react-server/src/features/router/server.tsx
+++ b/packages/react-server/src/features/router/server.tsx
@@ -124,6 +124,7 @@ export async function renderRouteMap(
       url: request.url,
       headers: serializeHeaders(request.headers),
     },
+    searchParams: Object.fromEntries(url.searchParams),
   };
   const pages: Record<string, React.ReactNode> = {};
   const layouts: Record<string, React.ReactNode> = {};
@@ -187,6 +188,7 @@ interface BaseProps {
     headers: Record<string, string>;
   };
   params: Record<string, string>;
+  searchParams: Record<string, string>;
 }
 
 export interface PageProps extends BaseProps {}

--- a/packages/react-server/src/features/router/server.tsx
+++ b/packages/react-server/src/features/router/server.tsx
@@ -117,9 +117,9 @@ export async function renderRouteMap(
   tree: RouteModuleNode,
   request: Pick<Request, "url" | "headers">,
 ) {
-  const url = serializeUrl(new URL(request.url));
+  const url = new URL(request.url);
   const baseProps: Omit<BaseProps, "params"> = {
-    url,
+    url: serializeUrl(url),
     request: {
       url: request.url,
       headers: serializeHeaders(request.headers),


### PR DESCRIPTION
At the moment, the lack of this `searchParams` is causing 500 on https://app-router-vite.vercel.app/patterns/search-params