### PR TITLE
fix(next): correctly setup ssg html on vercel adapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
       - run: pnpm -C packages/react-server/examples/prerender build
       - run: pnpm -C packages/react-server/examples/prerender test-e2e-preview
       - run: pnpm -C packages/react-server/examples/prerender cf-build
+      - run: pnpm -C packages/react-server/examples/prerender vc-build
 
   test-react-server-package:
     runs-on: ubuntu-latest

--- a/packages/react-server/examples/prerender/misc/vercel/build.js
+++ b/packages/react-server/examples/prerender/misc/vercel/build.js
@@ -27,10 +27,19 @@ const configJson = {
   ],
 };
 
-const vcConfigJson = {
-  runtime: "edge",
-  entrypoint: "index.js",
-};
+const isNodeRuntime = process.env["VERCE_RUNTIME"];
+
+const vcConfigJson = isNodeRuntime
+  ? {
+      runtime: "nodejs20.x",
+      handler: "index.mjs",
+      launcherType: "Nodejs",
+      regions: ["hnd1"],
+    }
+  : {
+      runtime: "edge",
+      entrypoint: "index.mjs",
+    };
 
 async function main() {
   // clean
@@ -58,12 +67,16 @@ async function main() {
 
   // bundle function
   await esbuild.build({
-    entryPoints: [join(buildDir, "server/index.js")],
-    outfile: join(outDir, "functions/index.func/index.js"),
+    entryPoints: [
+      isNodeRuntime
+        ? join(import.meta.dirname, "entry-node.js")
+        : join(buildDir, "server/index.js"),
+    ],
+    outfile: join(outDir, "functions/index.func/index.mjs"),
     bundle: true,
     minify: true,
     format: "esm",
-    platform: "browser",
+    platform: isNodeRuntime ? "node" : "browser",
     define: {
       "process.env.NODE_ENV": `"production"`,
     },

--- a/packages/react-server/examples/prerender/misc/vercel/entry-node.js
+++ b/packages/react-server/examples/prerender/misc/vercel/entry-node.js
@@ -1,0 +1,4 @@
+import { webToNodeHandler } from "@hiogawa/utils-node";
+import handler from "../../dist/server/index.js";
+
+export default webToNodeHandler(handler);

--- a/packages/react-server/src/server.ts
+++ b/packages/react-server/src/server.ts
@@ -11,4 +11,5 @@ export {
 export type { ActionContext } from "./features/server-action/react-server";
 export { useActionContext } from "./features/server-action/context";
 export type { Metadata } from "./features/meta/utils";
+// TODO: move export to plugin
 export type { PrerenderEntry } from "./features/prerender/plugin";


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/vite-plugins/issues/474

After setting up `overrides`, it looks okay now https://demo-rsc-prerender.vercel.app/posts/1

<details><summary>show screenshot</summary>

![image](https://github.com/hi-ogawa/vite-plugins/assets/4232207/6ea92e85-7f86-4d69-944e-84b6158a4e81)

</details>

## todo

- [x] fix examples/prerender
- [x] fix next adapter