### PR TITLE
refactor: tweak request context API

### DIFF
--- a/packages/react-server/src/entry/react-server.tsx
+++ b/packages/react-server/src/entry/react-server.tsx
@@ -27,6 +27,7 @@ import {
   ReactServerDigestError,
   createError,
   getErrorContext,
+  isRedirectError,
 } from "../lib/error";
 
 const debug = createDebug("react-server:rsc");
@@ -82,6 +83,17 @@ export const handler: ReactServerHandler = async (ctx) => {
       streamActionId: streamParam?.actionId,
       requestContext,
     });
+    // return action redirect directly when nojs
+    const error = actionResult.error;
+    if (!isStream && error && isRedirectError(error)) {
+      return new Response(null, {
+        status: error.status,
+        headers: {
+          ...actionResult.responseHeaders,
+          ...error.headers,
+        },
+      });
+    }
   }
 
   const layoutRequest = revalidateLayoutContentRequest(

--- a/packages/react-server/src/entry/server.tsx
+++ b/packages/react-server/src/entry/server.tsx
@@ -181,13 +181,7 @@ export async function renderHtml(
   } catch (e) {
     const ctx = getErrorContext(e) ?? DEFAULT_ERROR_CONTEXT;
     if (isRedirectError(ctx)) {
-      return new Response(null, {
-        status: ctx.status,
-        headers: {
-          ...result.actionResult?.responseHeaders,
-          ...ctx.headers,
-        },
-      });
+      return new Response(null, { status: ctx.status, headers: ctx.headers });
     }
     status = ctx.status;
     // render empty as error fallback and

--- a/packages/react-server/src/features/request-context/server.ts
+++ b/packages/react-server/src/features/request-context/server.ts
@@ -19,29 +19,29 @@ export class RequestContext {
   run<T>(f: () => T): T {
     return requestContextStorage.run(this, f);
   }
+}
 
-  static get() {
-    const context = requestContextStorage.getStore();
-    if (!context) {
-      // we tolerate non-existing context
-      // since async storage is not well supported on stackblitz
-      console.error("[WARNING] RequestContext not available");
-      return new RequestContext(new Headers());
-    }
-    return context;
+export function useRequestContext() {
+  const context = requestContextStorage.getStore();
+  if (!context) {
+    // we tolerate non-existing context
+    // since async storage is not well supported on stackblitz
+    console.error("[WARNING] RequestContext not available");
+    return new RequestContext(new Headers());
   }
+  return context;
 }
 
 export function headers() {
-  return RequestContext.get().requestHeaders;
+  return useRequestContext().requestHeaders;
 }
 
 export function cookies() {
-  return RequestContext.get().cookiesWrapper.cookies;
+  return useRequestContext().cookiesWrapper.cookies;
 }
 
 export function revalidatePath(path: string) {
-  RequestContext.get().revalidate = path;
+  useRequestContext().revalidate = path;
 }
 
 // it seems Next.js's cookies API has to track modified response cookies

--- a/packages/react-server/src/features/request-context/server.ts
+++ b/packages/react-server/src/features/request-context/server.ts
@@ -21,7 +21,7 @@ export class RequestContext {
   }
 }
 
-export function useRequestContext() {
+function getRequestContext() {
   const context = requestContextStorage.getStore();
   if (!context) {
     // we tolerate non-existing context
@@ -33,15 +33,15 @@ export function useRequestContext() {
 }
 
 export function headers() {
-  return useRequestContext().requestHeaders;
+  return getRequestContext().requestHeaders;
 }
 
 export function cookies() {
-  return useRequestContext().cookiesWrapper.cookies;
+  return getRequestContext().cookiesWrapper.cookies;
 }
 
 export function revalidatePath(path: string) {
-  useRequestContext().revalidate = path;
+  getRequestContext().revalidate = path;
 }
 
 // it seems Next.js's cookies API has to track modified response cookies

--- a/packages/react-server/src/server.ts
+++ b/packages/react-server/src/server.ts
@@ -10,7 +10,6 @@ export {
 } from "./lib/error";
 export type { Metadata } from "./features/meta/utils";
 export {
-  useRequestContext,
   headers,
   cookies,
   revalidatePath,

--- a/packages/react-server/src/server.ts
+++ b/packages/react-server/src/server.ts
@@ -10,6 +10,7 @@ export {
 } from "./lib/error";
 export type { Metadata } from "./features/meta/utils";
 export {
+  useRequestContext,
   headers,
   cookies,
   revalidatePath,


### PR DESCRIPTION
- follow up https://github.com/hi-ogawa/vite-plugins/pull/484

Overall structure is fine but Next.js style API `headers, cookies, revalidatePath` feels clumsy (and especially `RequestCookies` and `RequestCookies` trick required for that seems convoluted), so let's move that to just next compat.