### PR TITLE
feat(next): support `Image.priority`

### DIFF
--- a/packages/react-server-next/package.json
+++ b/packages/react-server-next/package.json
@@ -49,11 +49,13 @@
     "@types/react": "18.3.1",
     "@types/react-dom": "18.3.0",
     "react": "$react",
+    "react-dom": "$react-dom",
     "vite": "$vite"
   },
   "peerDependencies": {
     "@hiogawa/react-server": "*",
     "react": "*",
+    "react-dom": "*",
     "vite": "*"
   }
 }

--- a/packages/react-server-next/src/compat/image.tsx
+++ b/packages/react-server-next/src/compat/image.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import ReactDOM from "react-dom";
+
 /** @todo */
 export default function Image({
   priority,
@@ -7,9 +9,22 @@ export default function Image({
   blurDataURL,
   ...props
 }: JSX.IntrinsicElements["img"] & {
-  priority?: unknown;
+  priority?: boolean;
   placeholder?: unknown;
   blurDataURL?: unknown;
 }) {
+  // support only preload for now
+  // https://github.com/vercel/next.js/blob/82639520d3b70d6b532ce5ec650c0c5b268706a4/packages/next/src/client/image-component.tsx#L329-L337
+  if (props.src && priority) {
+    ReactDOM.preload(props.src, {
+      as: "image",
+      fetchPriority: "high",
+      imageSrcSet: props.srcSet,
+      imageSizes: props.sizes,
+      crossOrigin: props.crossOrigin,
+      referrerPolicy: props.referrerPolicy,
+    });
+  }
+
   return <img {...props} />;
 }

--- a/packages/react-server/examples/next/e2e/basic.test.ts
+++ b/packages/react-server/examples/next/e2e/basic.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { waitForHydration } from "./helper";
+import { testNoJs, waitForHydration } from "./helper";
 
 test("basic", async ({ page }) => {
   const res = await page.goto("/");
@@ -85,4 +85,14 @@ test("viewport", async ({ page }) => {
     "content",
     "width=device-width, initial-scale=1",
   );
+});
+
+testNoJs("image preload", async ({ page }) => {
+  await page.goto("/");
+  await expect(
+    page.locator('link[href="https://nextjs.org/icons/next.svg"]'),
+  ).toHaveAttribute("fetchPriority", "high");
+  await expect(
+    page.locator('link[href="https://nextjs.org/icons/vercel.svg"]'),
+  ).not.toHaveAttribute("fetchPriority", "high");
 });

--- a/packages/react-server/examples/next/e2e/helper.ts
+++ b/packages/react-server/examples/next/e2e/helper.ts
@@ -1,4 +1,4 @@
-import { type Page, expect } from "@playwright/test";
+import { type Page, expect, test } from "@playwright/test";
 
 export async function waitForHydration(page: Page) {
   await expect(page.locator("html")).toHaveAttribute(
@@ -6,3 +6,7 @@ export async function waitForHydration(page: Page) {
     "hydrated",
   );
 }
+
+export const testNoJs = test.extend({
+  javaScriptEnabled: ({}, use) => use(false),
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,9 @@ importers:
       react:
         specifier: 19.0.0-rc-c21bcd627b-20240624
         version: 19.0.0-rc-c21bcd627b-20240624
+      react-dom:
+        specifier: 19.0.0-rc-c21bcd627b-20240624
+        version: 19.0.0-rc-c21bcd627b-20240624(react@19.0.0-rc-c21bcd627b-20240624)
       vite:
         specifier: ^5.2.3
         version: 5.2.3(@types/node@20.11.28)(terser@5.29.2)


### PR DESCRIPTION
It looks like React already automatically add `<link rel="preload" as="image" ...>` for `<img>`.
Probably explicitly doing `ReactDOM.preload` is only for higher priority?