### PR TITLE
fix: fix late deps optimization on local dev

### DIFF
--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -279,6 +279,7 @@ export function vitePluginReactServer(options?: {
             "react-server-dom-webpack/client.browser",
             "@hiogawa/react-server > @tanstack/history",
             "@hiogawa/react-server > use-sync-external-store/shim/with-selector.js",
+            "@hiogawa/react-server > @edge-runtime/cookies",
           ],
         },
         ssr: {


### PR DESCRIPTION
It looks like this happens on local dev in monorepo links. For now, let's just make it easier by including the deps.

```
  <-- GET / 200 229ms
5:50:30 PM [vite] ✨ new dependencies optimized: @edge-runtime/cookies
5:50:30 PM [vite] ✨ optimized dependencies changed. reloading
```