### PR TITLE
refactor!: string only for `RevalidationType`

### DIFF
--- a/packages/react-server-next/src/compat/navigation.tsx
+++ b/packages/react-server-next/src/compat/navigation.tsx
@@ -35,7 +35,7 @@ export function useSelectedLayoutSegment(): string | null {
 export function useRouter() {
   const history = useRouter_((s) => s.history);
   const refresh = () => {
-    history.replace(window.location.href, routerRevalidate());
+    history.replace(window.location.href, routerRevalidate("/"));
   };
   return React.useMemo(() => ({ ...history, refresh }), [history]);
 }

--- a/packages/react-server/examples/basic/src/routes/test/revalidate/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/revalidate/page.tsx
@@ -14,7 +14,7 @@ export default function Layout(_props: LayoutProps) {
         <Link
           className="antd-btn antd-btn-default px-2 self-start"
           href="/test/revalidate"
-          revalidate
+          revalidate="/"
         >
           Navigation
         </Link>
@@ -22,7 +22,7 @@ export default function Layout(_props: LayoutProps) {
       <LinkForm
         action="/test/revalidate"
         className="flex items-center gap-2"
-        revalidate
+        revalidate="/"
       >
         <input className="antd-input px-2" name="q" placeholder="Search..." />
         <button className="antd-btn antd-btn-default px-2 self-start">

--- a/packages/react-server/src/entry/browser.tsx
+++ b/packages/react-server/src/entry/browser.tsx
@@ -190,7 +190,7 @@ async function start() {
   if (import.meta.hot) {
     import.meta.hot.on("rsc:update", (e) => {
       console.log("[react-server] hot update", e.file);
-      history.replace(history.location.href, routerRevalidate());
+      history.replace(history.location.href, routerRevalidate("/"));
     });
   }
 }

--- a/packages/react-server/src/features/router/client.tsx
+++ b/packages/react-server/src/features/router/client.tsx
@@ -95,7 +95,7 @@ declare module "@tanstack/history" {
   }
 }
 
-export function routerRevalidate(v: string | boolean = true): HistoryState {
+export function routerRevalidate(v: string): HistoryState {
   return { [ROUTER_REVALIDATE_KEY]: v };
 }
 

--- a/packages/react-server/src/features/router/server.tsx
+++ b/packages/react-server/src/features/router/server.tsx
@@ -1,4 +1,4 @@
-import { sortBy, typedBoolean } from "@hiogawa/utils";
+import { sortBy } from "@hiogawa/utils";
 import React from "react";
 import { type ReactServerErrorContext, createError } from "../error/shared";
 import { renderMetadata } from "../meta/server";
@@ -174,15 +174,12 @@ export function getCachedRoutes(
   lastPathname: string,
   revalidations: (RevalidationType | undefined)[],
 ) {
-  const revalidatedPaths: string[] = revalidations
-    .map((r) => (r === true ? "/" : r))
-    .filter(typedBoolean);
   const routeIds: string[] = [];
   const { matches } = matchRouteTree(tree, lastPathname);
   for (const m of matches) {
     if (
       m.type === "layout" &&
-      !revalidatedPaths.some((r) => isAncestorPath(r, m.prefix))
+      !revalidations.some((r) => r && isAncestorPath(r, m.prefix))
     ) {
       routeIds.push(toRouteId(m.prefix, m.type));
     }

--- a/packages/react-server/src/features/server-component/utils.tsx
+++ b/packages/react-server/src/features/server-component/utils.tsx
@@ -2,8 +2,7 @@
 export const RSC_PATH = "__f.data";
 const RSC_PARAM = "x-flight-meta";
 
-// TODO: (breaking) remove boolean `true` in favor of string "/"
-export type RevalidationType = boolean | string;
+export type RevalidationType = string;
 
 export type StreamRequestParam = {
   actionId?: string;


### PR DESCRIPTION
I forgot to include this breaking change in v0.3.0.