### PR TITLE
refactor: simplify matchRouteTree

### DIFF
--- a/packages/react-server/src/features/router/__snapshots__/tree.test.ts.snap
+++ b/packages/react-server/src/features/router/__snapshots__/tree.test.ts.snap
@@ -1315,3 +1315,161 @@ exports[`createFsRouteTree > basic 17`] = `
   ],
 }
 `;
+
+exports[`matchRouteTree2 > basic 1`] = `
+{
+  "children": {
+    "": {
+      "children": {
+        "[x]": {
+          "children": {
+            "b": {
+              "children": {
+                "d": {
+                  "value": {
+                    "page": "/[x]/b/d/page.js",
+                  },
+                },
+              },
+            },
+          },
+          "value": {
+            "not-found": "/[x]/not-found.js",
+          },
+        },
+        "a": {
+          "children": {
+            "b": {
+              "children": {
+                "c": {
+                  "value": {
+                    "page": "/a/b/c/page.js",
+                  },
+                },
+              },
+            },
+          },
+          "value": {
+            "not-found": "/a/not-found.js",
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`matchRouteTree2 > basic 2`] = `
+{
+  "_pathname": "/a/b/c",
+  "matches": [
+    {
+      "node": undefined,
+      "segment": {
+        "type": "static",
+        "value": "",
+      },
+    },
+    {
+      "node": {
+        "not-found": "/a/not-found.js",
+      },
+      "segment": {
+        "type": "static",
+        "value": "a",
+      },
+    },
+    {
+      "node": undefined,
+      "segment": {
+        "type": "static",
+        "value": "b",
+      },
+    },
+    {
+      "node": {
+        "page": "/a/b/c/page.js",
+      },
+      "segment": {
+        "type": "static",
+        "value": "c",
+      },
+    },
+    {
+      "node": {
+        "page": "/a/b/c/page.js",
+      },
+      "segment": {
+        "type": "page",
+      },
+    },
+  ],
+}
+`;
+
+exports[`matchRouteTree2 > basic 3`] = `
+{
+  "_pathname": "/a/b/d",
+  "matches": [
+    {
+      "node": undefined,
+      "segment": {
+        "type": "static",
+        "value": "",
+      },
+    },
+    {
+      "node": {
+        "not-found": "/a/not-found.js",
+      },
+      "segment": {
+        "type": "static",
+        "value": "a",
+      },
+    },
+    {
+      "node": {
+        "not-found": "/a/not-found.js",
+      },
+      "segment": {
+        "type": "not-found",
+        "value": "b/d",
+      },
+    },
+  ],
+}
+`;
+
+exports[`matchRouteTree2 > basic 4`] = `
+{
+  "_pathname": "/x/b/e",
+  "matches": [
+    {
+      "node": undefined,
+      "segment": {
+        "type": "static",
+        "value": "",
+      },
+    },
+    {
+      "node": {
+        "not-found": "/[x]/not-found.js",
+      },
+      "segment": {
+        "key": "x",
+        "type": "dynamic",
+        "value": "x",
+      },
+    },
+    {
+      "node": {
+        "not-found": "/[x]/not-found.js",
+      },
+      "segment": {
+        "type": "not-found",
+        "value": "b/e",
+      },
+    },
+  ],
+}
+`;

--- a/packages/react-server/src/features/router/api-route.ts
+++ b/packages/react-server/src/features/router/api-route.ts
@@ -1,7 +1,7 @@
 import { injectResponseCookies } from "../next/cookie";
 import type { RequestContext } from "../request-context/server";
 import type { RouteModuleTree } from "./server";
-import { type MatchParams, matchRouteTree, toMatchParamsObject } from "./tree";
+import { type MatchParams, matchRouteTree2, toMatchParams } from "./tree";
 
 // https://nextjs.org/docs/app/api-reference/file-conventions/route
 
@@ -30,12 +30,12 @@ export async function handleApiRoutes(
 ): Promise<Response | undefined> {
   const method = request.method as ApiMethod;
   const url = new URL(request.url);
-  const result = matchRouteTree(tree, url.pathname, "route");
-  if (!result.notFound) {
-    const m = result.matches.at(-1);
-    const handler = m?.node.value?.route?.[method];
+  const matches = matchRouteTree2(tree, url.pathname, "route");
+  const match = matches?.at(-1);
+  if (matches && match && match.segment.type === "route") {
+    const handler = match?.node.value?.route?.[method];
     if (handler) {
-      const params = toMatchParamsObject(m.params);
+      const params = toMatchParams(matches.map((m) => m.segment));
       const response = await requestContext.run(() =>
         handler(request, { params }),
       );

--- a/packages/react-server/src/features/router/manifest.ts
+++ b/packages/react-server/src/features/router/manifest.ts
@@ -1,6 +1,6 @@
 import { objectMapValues, typedBoolean, uniq } from "@hiogawa/utils";
 import type { RouteModuleKey } from "./server";
-import { type TreeNode, matchRouteTree } from "./tree";
+import { type TreeNode, matchRouteTree2 } from "./tree";
 
 export type RouteManifest = {
   routeTree: TreeNode<RouteAssetDeps>;
@@ -21,12 +21,12 @@ export function getRouteAssetDeps(
   manifest: RouteManifest,
   pathname: string,
 ): AssetDeps {
-  const result = matchRouteTree(manifest.routeTree, pathname);
-  const deps = result.matches.flatMap((m) => {
+  const matches = matchRouteTree2(manifest.routeTree, pathname, "page");
+  const deps = matches?.flatMap((m) => {
     const v = m.node.value;
     return [v?.page, v?.layout, v?.error].filter(typedBoolean);
   });
-  return mergeAssetDeps(deps);
+  return mergeAssetDeps(deps ?? []);
 }
 
 export function mergeAssetDeps(entries: AssetDeps[]): AssetDeps {

--- a/packages/react-server/src/features/router/server.tsx
+++ b/packages/react-server/src/features/router/server.tsx
@@ -16,6 +16,7 @@ import {
 } from "./tree";
 import { LAYOUT_ROOT_NAME, isAncestorPath } from "./utils";
 
+// TODO(refactor): move to tree.ts with ROUTE_MODULE_KEYS constants
 // cf. https://nextjs.org/docs/app/building-your-application/routing#file-conventions
 export interface RouteModule {
   page?: {

--- a/packages/react-server/src/features/router/tree.test.ts
+++ b/packages/react-server/src/features/router/tree.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { AnyRouteModule } from "./server";
-import { createFsRouteTree, matchRouteTree } from "./tree";
+import { createFsRouteTree, matchRouteTree, matchRouteTree2 } from "./tree";
 
 describe(createFsRouteTree, () => {
   it("basic", async () => {
@@ -54,6 +54,36 @@ describe(createFsRouteTree, () => {
       "/dynamic/catchall/x/y",
       "/dynamic/catchall/x/y/z",
     ];
+    for (const e of testCases) {
+      expect(testMatch(e)).matchSnapshot();
+    }
+  });
+});
+
+describe(matchRouteTree2, () => {
+  it.only("basic", async () => {
+    const files = [
+      "/a/b/c/page.js",
+      "/a/not-found.js",
+      "/[x]/b/d/page.js",
+      "/[x]/not-found.js",
+    ];
+    const input = Object.fromEntries(files.map((k) => [k, k]));
+    const { tree } = createFsRouteTree<AnyRouteModule>(input);
+    expect(tree).toMatchSnapshot();
+
+    function testMatch(pathname: string) {
+      const matches = matchRouteTree2(tree, pathname, "page");
+      return {
+        _pathname: pathname,
+        matches: matches?.map((m) => ({
+          ...m,
+          node: m.node.value,
+        })),
+      };
+    }
+
+    const testCases = ["/a/b/c", "/a/b/d", "/x/b/e"];
     for (const e of testCases) {
       expect(testMatch(e)).matchSnapshot();
     }

--- a/packages/react-server/src/features/router/tree.test.ts
+++ b/packages/react-server/src/features/router/tree.test.ts
@@ -61,7 +61,7 @@ describe(createFsRouteTree, () => {
 });
 
 describe(matchRouteTree2, () => {
-  it.only("basic", async () => {
+  it("basic", async () => {
     const files = [
       "/a/b/c/page.js",
       "/a/not-found.js",

--- a/packages/react-server/src/features/router/tree.ts
+++ b/packages/react-server/src/features/router/tree.ts
@@ -142,10 +142,20 @@ export function matchRouteTree2<T extends AnyRouteModule>(
   ): MatchEntry2<T>[] | undefined {
     // check page or route
     if (segments.length === 0) {
-      if (parent?.value?.[leafType]) {
-        return [{ node: parent, segment: { type: leafType } }];
-      }
-      return;
+      tinyassert(parent);
+      return [
+        {
+          node: parent,
+          segment: parent.value?.[leafType]
+            ? {
+                type: leafType,
+              }
+            : {
+                type: "not-found",
+                value: segments.join("/"),
+              },
+        },
+      ];
     }
 
     // recurse children
@@ -157,20 +167,17 @@ export function matchRouteTree2<T extends AnyRouteModule>(
       }
     }
 
-    // check not-found
+    // not-found
     if (branches.length === 0) {
-      if (node.value?.["not-found"]) {
-        return [
-          {
-            node,
-            segment: {
-              type: "not-found",
-              value: segments.join("/"),
-            },
+      return [
+        {
+          node,
+          segment: {
+            type: "not-found",
+            value: segments.join("/"),
           },
-        ];
-      }
-      return;
+        },
+      ];
     }
 
     // tie break branches

--- a/packages/react-server/src/features/router/tree.ts
+++ b/packages/react-server/src/features/router/tree.ts
@@ -123,10 +123,30 @@ type MatchEntry2<T> = {
   segment: MatchSegment;
 };
 
+export function toMatchParam(s: MatchSegment) {
+  if (s.type === "static") return [null, s.value];
+  if (s.type === "dynamic") return [s.key, s.value];
+  if (s.type === "catchall") return [s.key, s.value];
+  if (s.type === "group") return [null, s.key];
+  if (s.type === "not-found") return [null, s.value];
+  return [null, null];
+}
+
+export function toMatchParams(segments: MatchSegment[]) {
+  let result: MatchParams = {};
+  for (const s of segments) {
+    const [k, v] = toMatchParam(s);
+    if (typeof k === "string" && typeof v === "string") {
+      result[k] = v;
+    }
+  }
+  return result;
+}
+
 export function matchRouteTree2<T extends AnyRouteModule>(
   tree: TreeNode<T>,
   pathname: string,
-  leafType: "page" | "route" = "page",
+  leafType: "page" | "route",
 ): MatchEntry2<T>[] | undefined {
   // TODO: fix up not-found
   return recurse(

--- a/packages/react-server/src/features/router/tree.ts
+++ b/packages/react-server/src/features/router/tree.ts
@@ -55,6 +55,7 @@ export function toMatchParamsObject(params: MatchParamEntry[]): MatchParams {
 }
 
 export type MatchNodeEntry<T> = {
+  id?: string;
   prefix: string;
   type: MatchNodeType;
   node: TreeNode<T>;
@@ -72,11 +73,24 @@ export type MatchResult<T> = {
   notFound: boolean;
 };
 
+/**
+ * @example
+ * "/" => [""]
+ * "/a" => ["", "a"]
+ * "/a/b" => ["", "a", "b"]
+ */
+function toRawSegments(pathname: string) {
+  return ["", ...pathname.slice(1).split("/")];
+}
+
 export function matchRouteTree<T extends AnyRouteModule>(
   tree: TreeNode<T>,
   pathname: string,
   leafType: "page" | "route" = "page",
 ): MatchResult<T> {
+  const rawSegments = toRawSegments(pathname);
+  rawSegments;
+
   const prefixes = getPathPrefixes(pathname);
 
   let node = tree;


### PR DESCRIPTION
For now putting a random experiments in this PR and later probably stack changes properly.

## todo

- [ ] tie-break multiple branches (for group routes later)
- [ ] route id
- [ ] prototype group routes https://github.com/hi-ogawa/vite-plugins/pull/489