### PR TITLE
feat: route groups

### DIFF
--- a/packages/react-server/src/features/router/__snapshots__/tree.test.ts.snap
+++ b/packages/react-server/src/features/router/__snapshots__/tree.test.ts.snap
@@ -1824,7 +1824,7 @@ exports[`matchRouteTree2 > group routes not-found 4`] = `
       },
       "segment": {
         "type": "not-found",
-        "value": "",
+        "value": "u",
       },
     },
   ],

--- a/packages/react-server/src/features/router/__snapshots__/tree.test.ts.snap
+++ b/packages/react-server/src/features/router/__snapshots__/tree.test.ts.snap
@@ -1830,3 +1830,238 @@ exports[`matchRouteTree2 > group routes not-found 4`] = `
   ],
 }
 `;
+
+exports[`matchRouteTree2 > withMatchRouteId > basic 1`] = `
+{
+  "children": {
+    "": {
+      "children": {
+        "a": {
+          "children": {
+            "b": {
+              "value": {
+                "page": "/a/b/page.js",
+              },
+            },
+          },
+          "value": {
+            "not-found": "/a/not-found.js",
+            "page": "/a/page.js",
+          },
+        },
+      },
+      "value": {
+        "page": "/page.js",
+      },
+    },
+  },
+}
+`;
+
+exports[`matchRouteTree2 > withMatchRouteId > basic 2`] = `
+{
+  "_pathname": "/a",
+  "matches": [
+    {
+      "id": ":static",
+      "node": "_",
+      "params": [
+        {
+          "type": "static",
+          "value": "",
+        },
+      ],
+      "segment": {
+        "type": "static",
+        "value": "",
+      },
+    },
+    {
+      "id": "/a:static",
+      "node": "_",
+      "params": [
+        {
+          "type": "static",
+          "value": "",
+        },
+        {
+          "type": "static",
+          "value": "a",
+        },
+      ],
+      "segment": {
+        "type": "static",
+        "value": "a",
+      },
+    },
+    {
+      "id": "/a/:page",
+      "node": "_",
+      "params": [
+        {
+          "type": "static",
+          "value": "",
+        },
+        {
+          "type": "static",
+          "value": "a",
+        },
+        {
+          "type": "page",
+        },
+      ],
+      "segment": {
+        "type": "page",
+      },
+    },
+  ],
+}
+`;
+
+exports[`matchRouteTree2 > withMatchRouteId > basic 3`] = `
+{
+  "_pathname": "/a/b",
+  "matches": [
+    {
+      "id": ":static",
+      "node": "_",
+      "params": [
+        {
+          "type": "static",
+          "value": "",
+        },
+      ],
+      "segment": {
+        "type": "static",
+        "value": "",
+      },
+    },
+    {
+      "id": "/a:static",
+      "node": "_",
+      "params": [
+        {
+          "type": "static",
+          "value": "",
+        },
+        {
+          "type": "static",
+          "value": "a",
+        },
+      ],
+      "segment": {
+        "type": "static",
+        "value": "a",
+      },
+    },
+    {
+      "id": "/a/b:static",
+      "node": "_",
+      "params": [
+        {
+          "type": "static",
+          "value": "",
+        },
+        {
+          "type": "static",
+          "value": "a",
+        },
+        {
+          "type": "static",
+          "value": "b",
+        },
+      ],
+      "segment": {
+        "type": "static",
+        "value": "b",
+      },
+    },
+    {
+      "id": "/a/b/:page",
+      "node": "_",
+      "params": [
+        {
+          "type": "static",
+          "value": "",
+        },
+        {
+          "type": "static",
+          "value": "a",
+        },
+        {
+          "type": "static",
+          "value": "b",
+        },
+        {
+          "type": "page",
+        },
+      ],
+      "segment": {
+        "type": "page",
+      },
+    },
+  ],
+}
+`;
+
+exports[`matchRouteTree2 > withMatchRouteId > basic 4`] = `
+{
+  "_pathname": "/a/b/c",
+  "matches": [
+    {
+      "id": ":static",
+      "node": "_",
+      "params": [
+        {
+          "type": "static",
+          "value": "",
+        },
+      ],
+      "segment": {
+        "type": "static",
+        "value": "",
+      },
+    },
+    {
+      "id": "/a:static",
+      "node": "_",
+      "params": [
+        {
+          "type": "static",
+          "value": "",
+        },
+        {
+          "type": "static",
+          "value": "a",
+        },
+      ],
+      "segment": {
+        "type": "static",
+        "value": "a",
+      },
+    },
+    {
+      "id": "/a/b/c:not-found",
+      "node": "_",
+      "params": [
+        {
+          "type": "static",
+          "value": "",
+        },
+        {
+          "type": "static",
+          "value": "a",
+        },
+        {
+          "type": "not-found",
+          "value": "b/c",
+        },
+      ],
+      "segment": {
+        "type": "not-found",
+        "value": "b/c",
+      },
+    },
+  ],
+}
+`;

--- a/packages/react-server/src/features/router/__snapshots__/tree.test.ts.snap
+++ b/packages/react-server/src/features/router/__snapshots__/tree.test.ts.snap
@@ -1563,8 +1563,8 @@ exports[`matchRouteTree2 > group routes basic 3`] = `
     {
       "node": undefined,
       "segment": {
-        "key": "x",
         "type": "group",
+        "value": "(x)",
       },
     },
     {
@@ -1611,8 +1611,8 @@ exports[`matchRouteTree2 > group routes basic 4`] = `
         "page": "/c/(x)/page.js",
       },
       "segment": {
-        "key": "x",
         "type": "group",
+        "value": "(x)",
       },
     },
     {
@@ -1641,8 +1641,8 @@ exports[`matchRouteTree2 > group routes basic 5`] = `
     {
       "node": undefined,
       "segment": {
-        "key": "x",
         "type": "group",
+        "value": "(x)",
       },
     },
     {
@@ -1657,8 +1657,8 @@ exports[`matchRouteTree2 > group routes basic 5`] = `
         "page": "/(x)/d/(y)/page.js",
       },
       "segment": {
-        "key": "y",
         "type": "group",
+        "value": "(y)",
       },
     },
     {
@@ -1805,8 +1805,8 @@ exports[`matchRouteTree2 > group routes not-found 4`] = `
     {
       "node": undefined,
       "segment": {
-        "key": "x",
         "type": "group",
+        "value": "(x)",
       },
     },
     {
@@ -1863,7 +1863,7 @@ exports[`matchRouteTree2 > withMatchRouteId > basic 2`] = `
   "_pathname": "/a",
   "matches": [
     {
-      "id": ":static",
+      "id": "/:static",
       "node": "_",
       "params": [
         {
@@ -1871,6 +1871,7 @@ exports[`matchRouteTree2 > withMatchRouteId > basic 2`] = `
           "value": "",
         },
       ],
+      "path": "/",
       "segment": {
         "type": "static",
         "value": "",
@@ -1889,13 +1890,14 @@ exports[`matchRouteTree2 > withMatchRouteId > basic 2`] = `
           "value": "a",
         },
       ],
+      "path": "/a",
       "segment": {
         "type": "static",
         "value": "a",
       },
     },
     {
-      "id": "/a/:page",
+      "id": "/a:page",
       "node": "_",
       "params": [
         {
@@ -1910,6 +1912,7 @@ exports[`matchRouteTree2 > withMatchRouteId > basic 2`] = `
           "type": "page",
         },
       ],
+      "path": "/a",
       "segment": {
         "type": "page",
       },
@@ -1923,7 +1926,7 @@ exports[`matchRouteTree2 > withMatchRouteId > basic 3`] = `
   "_pathname": "/a/b",
   "matches": [
     {
-      "id": ":static",
+      "id": "/:static",
       "node": "_",
       "params": [
         {
@@ -1931,6 +1934,7 @@ exports[`matchRouteTree2 > withMatchRouteId > basic 3`] = `
           "value": "",
         },
       ],
+      "path": "/",
       "segment": {
         "type": "static",
         "value": "",
@@ -1949,6 +1953,7 @@ exports[`matchRouteTree2 > withMatchRouteId > basic 3`] = `
           "value": "a",
         },
       ],
+      "path": "/a",
       "segment": {
         "type": "static",
         "value": "a",
@@ -1971,13 +1976,14 @@ exports[`matchRouteTree2 > withMatchRouteId > basic 3`] = `
           "value": "b",
         },
       ],
+      "path": "/a/b",
       "segment": {
         "type": "static",
         "value": "b",
       },
     },
     {
-      "id": "/a/b/:page",
+      "id": "/a/b:page",
       "node": "_",
       "params": [
         {
@@ -1996,6 +2002,7 @@ exports[`matchRouteTree2 > withMatchRouteId > basic 3`] = `
           "type": "page",
         },
       ],
+      "path": "/a/b",
       "segment": {
         "type": "page",
       },
@@ -2009,7 +2016,7 @@ exports[`matchRouteTree2 > withMatchRouteId > basic 4`] = `
   "_pathname": "/a/b/c",
   "matches": [
     {
-      "id": ":static",
+      "id": "/:static",
       "node": "_",
       "params": [
         {
@@ -2017,6 +2024,7 @@ exports[`matchRouteTree2 > withMatchRouteId > basic 4`] = `
           "value": "",
         },
       ],
+      "path": "/",
       "segment": {
         "type": "static",
         "value": "",
@@ -2035,6 +2043,7 @@ exports[`matchRouteTree2 > withMatchRouteId > basic 4`] = `
           "value": "a",
         },
       ],
+      "path": "/a",
       "segment": {
         "type": "static",
         "value": "a",
@@ -2057,6 +2066,7 @@ exports[`matchRouteTree2 > withMatchRouteId > basic 4`] = `
           "value": "b/c",
         },
       ],
+      "path": "/a/b/c",
       "segment": {
         "type": "not-found",
         "value": "b/c",

--- a/packages/react-server/src/features/router/__snapshots__/tree.test.ts.snap
+++ b/packages/react-server/src/features/router/__snapshots__/tree.test.ts.snap
@@ -1316,6 +1316,81 @@ exports[`createFsRouteTree > basic 17`] = `
 }
 `;
 
+exports[`matchRouteTree2 > basic 1`] = `
+{
+  "children": {
+    "": {
+      "children": {
+        "a": {
+          "value": {
+            "page": "/a/page.js",
+          },
+        },
+      },
+      "value": {
+        "page": "/page.js",
+      },
+    },
+  },
+}
+`;
+
+exports[`matchRouteTree2 > basic 2`] = `
+{
+  "_pathname": "/",
+  "matches": [
+    {
+      "node": true,
+      "segment": {
+        "type": "static",
+        "value": "",
+      },
+    },
+    {
+      "node": true,
+      "segment": {
+        "type": "page",
+      },
+    },
+  ],
+}
+`;
+
+exports[`matchRouteTree2 > basic 3`] = `
+{
+  "_pathname": "/a",
+  "matches": [
+    {
+      "node": true,
+      "segment": {
+        "type": "static",
+        "value": "",
+      },
+    },
+    {
+      "node": true,
+      "segment": {
+        "type": "static",
+        "value": "a",
+      },
+    },
+    {
+      "node": true,
+      "segment": {
+        "type": "page",
+      },
+    },
+  ],
+}
+`;
+
+exports[`matchRouteTree2 > basic 4`] = `
+{
+  "_pathname": "/b",
+  "matches": undefined,
+}
+`;
+
 exports[`matchRouteTree2 > dynamic not-found 1`] = `
 {
   "children": {
@@ -1860,6 +1935,43 @@ exports[`matchRouteTree2 > withMatchRouteId > basic 1`] = `
 
 exports[`matchRouteTree2 > withMatchRouteId > basic 2`] = `
 {
+  "_pathname": "/",
+  "matches": [
+    {
+      "id": "/:static",
+      "node": "_",
+      "params": [
+        [
+          null,
+          "",
+        ],
+      ],
+      "path": "/",
+      "segment": {
+        "type": "static",
+        "value": "",
+      },
+    },
+    {
+      "id": "/:page",
+      "node": "_",
+      "params": [
+        [
+          null,
+          "",
+        ],
+      ],
+      "path": "/",
+      "segment": {
+        "type": "page",
+      },
+    },
+  ],
+}
+`;
+
+exports[`matchRouteTree2 > withMatchRouteId > basic 3`] = `
+{
   "_pathname": "/a",
   "matches": [
     {
@@ -1918,7 +2030,7 @@ exports[`matchRouteTree2 > withMatchRouteId > basic 2`] = `
 }
 `;
 
-exports[`matchRouteTree2 > withMatchRouteId > basic 3`] = `
+exports[`matchRouteTree2 > withMatchRouteId > basic 4`] = `
 {
   "_pathname": "/a/b",
   "matches": [
@@ -2005,7 +2117,7 @@ exports[`matchRouteTree2 > withMatchRouteId > basic 3`] = `
 }
 `;
 
-exports[`matchRouteTree2 > withMatchRouteId > basic 4`] = `
+exports[`matchRouteTree2 > withMatchRouteId > basic 5`] = `
 {
   "_pathname": "/a/b/c",
   "matches": [

--- a/packages/react-server/src/features/router/__snapshots__/tree.test.ts.snap
+++ b/packages/react-server/src/features/router/__snapshots__/tree.test.ts.snap
@@ -1316,7 +1316,7 @@ exports[`createFsRouteTree > basic 17`] = `
 }
 `;
 
-exports[`matchRouteTree2 > basic 1`] = `
+exports[`matchRouteTree2 > dynamic not-found 1`] = `
 {
   "children": {
     "": {
@@ -1359,7 +1359,7 @@ exports[`matchRouteTree2 > basic 1`] = `
 }
 `;
 
-exports[`matchRouteTree2 > basic 2`] = `
+exports[`matchRouteTree2 > dynamic not-found 2`] = `
 {
   "_pathname": "/a/b/c",
   "matches": [
@@ -1407,7 +1407,7 @@ exports[`matchRouteTree2 > basic 2`] = `
 }
 `;
 
-exports[`matchRouteTree2 > basic 3`] = `
+exports[`matchRouteTree2 > dynamic not-found 3`] = `
 {
   "_pathname": "/a/b/d",
   "matches": [
@@ -1440,7 +1440,7 @@ exports[`matchRouteTree2 > basic 3`] = `
 }
 `;
 
-exports[`matchRouteTree2 > basic 4`] = `
+exports[`matchRouteTree2 > dynamic not-found 4`] = `
 {
   "_pathname": "/x/b/e",
   "matches": [
@@ -1474,7 +1474,7 @@ exports[`matchRouteTree2 > basic 4`] = `
 }
 `;
 
-exports[`matchRouteTree2 > group routes 1`] = `
+exports[`matchRouteTree2 > group routes basic 1`] = `
 {
   "children": {
     "": {
@@ -1517,7 +1517,7 @@ exports[`matchRouteTree2 > group routes 1`] = `
 }
 `;
 
-exports[`matchRouteTree2 > group routes 2`] = `
+exports[`matchRouteTree2 > group routes basic 2`] = `
 {
   "_pathname": "/a",
   "matches": [
@@ -1549,7 +1549,7 @@ exports[`matchRouteTree2 > group routes 2`] = `
 }
 `;
 
-exports[`matchRouteTree2 > group routes 3`] = `
+exports[`matchRouteTree2 > group routes basic 3`] = `
 {
   "_pathname": "/b",
   "matches": [
@@ -1588,7 +1588,7 @@ exports[`matchRouteTree2 > group routes 3`] = `
 }
 `;
 
-exports[`matchRouteTree2 > group routes 4`] = `
+exports[`matchRouteTree2 > group routes basic 4`] = `
 {
   "_pathname": "/c",
   "matches": [
@@ -1627,7 +1627,7 @@ exports[`matchRouteTree2 > group routes 4`] = `
 }
 `;
 
-exports[`matchRouteTree2 > group routes 5`] = `
+exports[`matchRouteTree2 > group routes basic 5`] = `
 {
   "_pathname": "/d",
   "matches": [
@@ -1667,6 +1667,164 @@ exports[`matchRouteTree2 > group routes 5`] = `
       },
       "segment": {
         "type": "page",
+      },
+    },
+  ],
+}
+`;
+
+exports[`matchRouteTree2 > group routes not-found 1`] = `
+{
+  "children": {
+    "": {
+      "children": {
+        "(x)": {
+          "children": {
+            "a": {
+              "children": {
+                "c": {
+                  "value": {
+                    "not-found": "/(x)/a/c/not-found.js",
+                    "page": "/(x)/a/c/page.js",
+                  },
+                },
+              },
+              "value": {
+                "not-found": "/(x)/a/not-found.js",
+              },
+            },
+            "p": {
+              "children": {
+                "q": {
+                  "value": {
+                    "page": "/(x)/p/q/page.js",
+                  },
+                },
+              },
+              "value": {
+                "not-found": "/(x)/p/not-found.js",
+              },
+            },
+          },
+        },
+        "a": {
+          "children": {
+            "b": {
+              "value": {
+                "page": "/a/b/page.js",
+              },
+            },
+          },
+          "value": {
+            "not-found": "/a/not-found.js",
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`matchRouteTree2 > group routes not-found 2`] = `
+{
+  "_pathname": "/a/u",
+  "matches": [
+    {
+      "node": undefined,
+      "segment": {
+        "type": "static",
+        "value": "",
+      },
+    },
+    {
+      "node": {
+        "not-found": "/a/not-found.js",
+      },
+      "segment": {
+        "type": "static",
+        "value": "a",
+      },
+    },
+    {
+      "node": {
+        "not-found": "/a/not-found.js",
+      },
+      "segment": {
+        "type": "not-found",
+        "value": "u",
+      },
+    },
+  ],
+}
+`;
+
+exports[`matchRouteTree2 > group routes not-found 3`] = `
+{
+  "_pathname": "/a/c/u",
+  "matches": [
+    {
+      "node": undefined,
+      "segment": {
+        "type": "static",
+        "value": "",
+      },
+    },
+    {
+      "node": {
+        "not-found": "/a/not-found.js",
+      },
+      "segment": {
+        "type": "static",
+        "value": "a",
+      },
+    },
+    {
+      "node": {
+        "not-found": "/a/not-found.js",
+      },
+      "segment": {
+        "type": "not-found",
+        "value": "c/u",
+      },
+    },
+  ],
+}
+`;
+
+exports[`matchRouteTree2 > group routes not-found 4`] = `
+{
+  "_pathname": "/p/u",
+  "matches": [
+    {
+      "node": undefined,
+      "segment": {
+        "type": "static",
+        "value": "",
+      },
+    },
+    {
+      "node": undefined,
+      "segment": {
+        "key": "x",
+        "type": "group",
+      },
+    },
+    {
+      "node": {
+        "not-found": "/(x)/p/not-found.js",
+      },
+      "segment": {
+        "type": "static",
+        "value": "p",
+      },
+    },
+    {
+      "node": {
+        "not-found": "/(x)/p/not-found.js",
+      },
+      "segment": {
+        "type": "not-found",
+        "value": "",
       },
     },
   ],

--- a/packages/react-server/src/features/router/__snapshots__/tree.test.ts.snap
+++ b/packages/react-server/src/features/router/__snapshots__/tree.test.ts.snap
@@ -1473,3 +1473,202 @@ exports[`matchRouteTree2 > basic 4`] = `
   ],
 }
 `;
+
+exports[`matchRouteTree2 > group routes 1`] = `
+{
+  "children": {
+    "": {
+      "children": {
+        "(x)": {
+          "children": {
+            "b": {
+              "value": {
+                "page": "/(x)/b/page.js",
+              },
+            },
+            "d": {
+              "children": {
+                "(y)": {
+                  "value": {
+                    "page": "/(x)/d/(y)/page.js",
+                  },
+                },
+              },
+            },
+          },
+        },
+        "a": {
+          "value": {
+            "page": "/a/page.js",
+          },
+        },
+        "c": {
+          "children": {
+            "(x)": {
+              "value": {
+                "page": "/c/(x)/page.js",
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`matchRouteTree2 > group routes 2`] = `
+{
+  "_pathname": "/a",
+  "matches": [
+    {
+      "node": undefined,
+      "segment": {
+        "type": "static",
+        "value": "",
+      },
+    },
+    {
+      "node": {
+        "page": "/a/page.js",
+      },
+      "segment": {
+        "type": "static",
+        "value": "a",
+      },
+    },
+    {
+      "node": {
+        "page": "/a/page.js",
+      },
+      "segment": {
+        "type": "page",
+      },
+    },
+  ],
+}
+`;
+
+exports[`matchRouteTree2 > group routes 3`] = `
+{
+  "_pathname": "/b",
+  "matches": [
+    {
+      "node": undefined,
+      "segment": {
+        "type": "static",
+        "value": "",
+      },
+    },
+    {
+      "node": undefined,
+      "segment": {
+        "key": "x",
+        "type": "group",
+      },
+    },
+    {
+      "node": {
+        "page": "/(x)/b/page.js",
+      },
+      "segment": {
+        "type": "static",
+        "value": "b",
+      },
+    },
+    {
+      "node": {
+        "page": "/(x)/b/page.js",
+      },
+      "segment": {
+        "type": "page",
+      },
+    },
+  ],
+}
+`;
+
+exports[`matchRouteTree2 > group routes 4`] = `
+{
+  "_pathname": "/c",
+  "matches": [
+    {
+      "node": undefined,
+      "segment": {
+        "type": "static",
+        "value": "",
+      },
+    },
+    {
+      "node": undefined,
+      "segment": {
+        "type": "static",
+        "value": "c",
+      },
+    },
+    {
+      "node": {
+        "page": "/c/(x)/page.js",
+      },
+      "segment": {
+        "key": "x",
+        "type": "group",
+      },
+    },
+    {
+      "node": {
+        "page": "/c/(x)/page.js",
+      },
+      "segment": {
+        "type": "page",
+      },
+    },
+  ],
+}
+`;
+
+exports[`matchRouteTree2 > group routes 5`] = `
+{
+  "_pathname": "/d",
+  "matches": [
+    {
+      "node": undefined,
+      "segment": {
+        "type": "static",
+        "value": "",
+      },
+    },
+    {
+      "node": undefined,
+      "segment": {
+        "key": "x",
+        "type": "group",
+      },
+    },
+    {
+      "node": undefined,
+      "segment": {
+        "type": "static",
+        "value": "d",
+      },
+    },
+    {
+      "node": {
+        "page": "/(x)/d/(y)/page.js",
+      },
+      "segment": {
+        "key": "y",
+        "type": "group",
+      },
+    },
+    {
+      "node": {
+        "page": "/(x)/d/(y)/page.js",
+      },
+      "segment": {
+        "type": "page",
+      },
+    },
+  ],
+}
+`;

--- a/packages/react-server/src/features/router/__snapshots__/tree.test.ts.snap
+++ b/packages/react-server/src/features/router/__snapshots__/tree.test.ts.snap
@@ -1866,10 +1866,10 @@ exports[`matchRouteTree2 > withMatchRouteId > basic 2`] = `
       "id": "/:static",
       "node": "_",
       "params": [
-        {
-          "type": "static",
-          "value": "",
-        },
+        [
+          null,
+          "",
+        ],
       ],
       "path": "/",
       "segment": {
@@ -1881,14 +1881,14 @@ exports[`matchRouteTree2 > withMatchRouteId > basic 2`] = `
       "id": "/a:static",
       "node": "_",
       "params": [
-        {
-          "type": "static",
-          "value": "",
-        },
-        {
-          "type": "static",
-          "value": "a",
-        },
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "a",
+        ],
       ],
       "path": "/a",
       "segment": {
@@ -1900,17 +1900,14 @@ exports[`matchRouteTree2 > withMatchRouteId > basic 2`] = `
       "id": "/a:page",
       "node": "_",
       "params": [
-        {
-          "type": "static",
-          "value": "",
-        },
-        {
-          "type": "static",
-          "value": "a",
-        },
-        {
-          "type": "page",
-        },
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "a",
+        ],
       ],
       "path": "/a",
       "segment": {
@@ -1929,10 +1926,10 @@ exports[`matchRouteTree2 > withMatchRouteId > basic 3`] = `
       "id": "/:static",
       "node": "_",
       "params": [
-        {
-          "type": "static",
-          "value": "",
-        },
+        [
+          null,
+          "",
+        ],
       ],
       "path": "/",
       "segment": {
@@ -1944,14 +1941,14 @@ exports[`matchRouteTree2 > withMatchRouteId > basic 3`] = `
       "id": "/a:static",
       "node": "_",
       "params": [
-        {
-          "type": "static",
-          "value": "",
-        },
-        {
-          "type": "static",
-          "value": "a",
-        },
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "a",
+        ],
       ],
       "path": "/a",
       "segment": {
@@ -1963,18 +1960,18 @@ exports[`matchRouteTree2 > withMatchRouteId > basic 3`] = `
       "id": "/a/b:static",
       "node": "_",
       "params": [
-        {
-          "type": "static",
-          "value": "",
-        },
-        {
-          "type": "static",
-          "value": "a",
-        },
-        {
-          "type": "static",
-          "value": "b",
-        },
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "a",
+        ],
+        [
+          null,
+          "b",
+        ],
       ],
       "path": "/a/b",
       "segment": {
@@ -1986,21 +1983,18 @@ exports[`matchRouteTree2 > withMatchRouteId > basic 3`] = `
       "id": "/a/b:page",
       "node": "_",
       "params": [
-        {
-          "type": "static",
-          "value": "",
-        },
-        {
-          "type": "static",
-          "value": "a",
-        },
-        {
-          "type": "static",
-          "value": "b",
-        },
-        {
-          "type": "page",
-        },
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "a",
+        ],
+        [
+          null,
+          "b",
+        ],
       ],
       "path": "/a/b",
       "segment": {
@@ -2019,10 +2013,10 @@ exports[`matchRouteTree2 > withMatchRouteId > basic 4`] = `
       "id": "/:static",
       "node": "_",
       "params": [
-        {
-          "type": "static",
-          "value": "",
-        },
+        [
+          null,
+          "",
+        ],
       ],
       "path": "/",
       "segment": {
@@ -2034,14 +2028,14 @@ exports[`matchRouteTree2 > withMatchRouteId > basic 4`] = `
       "id": "/a:static",
       "node": "_",
       "params": [
-        {
-          "type": "static",
-          "value": "",
-        },
-        {
-          "type": "static",
-          "value": "a",
-        },
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "a",
+        ],
       ],
       "path": "/a",
       "segment": {
@@ -2053,18 +2047,18 @@ exports[`matchRouteTree2 > withMatchRouteId > basic 4`] = `
       "id": "/a/b/c:not-found",
       "node": "_",
       "params": [
-        {
-          "type": "static",
-          "value": "",
-        },
-        {
-          "type": "static",
-          "value": "a",
-        },
-        {
-          "type": "not-found",
-          "value": "b/c",
-        },
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "a",
+        ],
+        [
+          null,
+          "b/c",
+        ],
       ],
       "path": "/a/b/c",
       "segment": {

--- a/packages/react-server/src/features/router/__snapshots__/tree.test.ts.snap
+++ b/packages/react-server/src/features/router/__snapshots__/tree.test.ts.snap
@@ -2069,3 +2069,402 @@ exports[`matchRouteTree2 > withMatchRouteId > basic 4`] = `
   ],
 }
 `;
+
+exports[`matchRouteTree2 > withMatchRouteId > group routes 1`] = `
+{
+  "children": {
+    "": {
+      "children": {
+        "(x)": {
+          "children": {
+            "b": {
+              "value": {
+                "page": "/(x)/b/page.js",
+              },
+            },
+          },
+        },
+        "(y)": {
+          "children": {
+            "d": {
+              "children": {
+                "(z)": {
+                  "value": {
+                    "page": "/(y)/d/(z)/page.js",
+                  },
+                },
+              },
+            },
+          },
+        },
+        "a": {
+          "value": {
+            "page": "/a/page.js",
+          },
+        },
+        "c": {
+          "children": {
+            "(x)": {
+              "value": {
+                "page": "/c/(x)/page.js",
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`matchRouteTree2 > withMatchRouteId > group routes 2`] = `
+{
+  "_pathname": "/a",
+  "matches": [
+    {
+      "id": "/:static",
+      "node": "_",
+      "params": [
+        [
+          null,
+          "",
+        ],
+      ],
+      "path": "/",
+      "segment": {
+        "type": "static",
+        "value": "",
+      },
+    },
+    {
+      "id": "/a:static",
+      "node": "_",
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "a",
+        ],
+      ],
+      "path": "/a",
+      "segment": {
+        "type": "static",
+        "value": "a",
+      },
+    },
+    {
+      "id": "/a:page",
+      "node": "_",
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "a",
+        ],
+      ],
+      "path": "/a",
+      "segment": {
+        "type": "page",
+      },
+    },
+  ],
+}
+`;
+
+exports[`matchRouteTree2 > withMatchRouteId > group routes 3`] = `
+{
+  "_pathname": "/b",
+  "matches": [
+    {
+      "id": "/:static",
+      "node": "_",
+      "params": [
+        [
+          null,
+          "",
+        ],
+      ],
+      "path": "/",
+      "segment": {
+        "type": "static",
+        "value": "",
+      },
+    },
+    {
+      "id": "/(x):group",
+      "node": "_",
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "(x)",
+        ],
+      ],
+      "path": "/(x)",
+      "segment": {
+        "type": "group",
+        "value": "(x)",
+      },
+    },
+    {
+      "id": "/(x)/b:static",
+      "node": "_",
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "(x)",
+        ],
+        [
+          null,
+          "b",
+        ],
+      ],
+      "path": "/(x)/b",
+      "segment": {
+        "type": "static",
+        "value": "b",
+      },
+    },
+    {
+      "id": "/(x)/b:page",
+      "node": "_",
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "(x)",
+        ],
+        [
+          null,
+          "b",
+        ],
+      ],
+      "path": "/(x)/b",
+      "segment": {
+        "type": "page",
+      },
+    },
+  ],
+}
+`;
+
+exports[`matchRouteTree2 > withMatchRouteId > group routes 4`] = `
+{
+  "_pathname": "/c",
+  "matches": [
+    {
+      "id": "/:static",
+      "node": "_",
+      "params": [
+        [
+          null,
+          "",
+        ],
+      ],
+      "path": "/",
+      "segment": {
+        "type": "static",
+        "value": "",
+      },
+    },
+    {
+      "id": "/c:static",
+      "node": "_",
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "c",
+        ],
+      ],
+      "path": "/c",
+      "segment": {
+        "type": "static",
+        "value": "c",
+      },
+    },
+    {
+      "id": "/c/(x):group",
+      "node": "_",
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "c",
+        ],
+        [
+          null,
+          "(x)",
+        ],
+      ],
+      "path": "/c/(x)",
+      "segment": {
+        "type": "group",
+        "value": "(x)",
+      },
+    },
+    {
+      "id": "/c/(x):page",
+      "node": "_",
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "c",
+        ],
+        [
+          null,
+          "(x)",
+        ],
+      ],
+      "path": "/c/(x)",
+      "segment": {
+        "type": "page",
+      },
+    },
+  ],
+}
+`;
+
+exports[`matchRouteTree2 > withMatchRouteId > group routes 5`] = `
+{
+  "_pathname": "/d",
+  "matches": [
+    {
+      "id": "/:static",
+      "node": "_",
+      "params": [
+        [
+          null,
+          "",
+        ],
+      ],
+      "path": "/",
+      "segment": {
+        "type": "static",
+        "value": "",
+      },
+    },
+    {
+      "id": "/(y):group",
+      "node": "_",
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "(y)",
+        ],
+      ],
+      "path": "/(y)",
+      "segment": {
+        "type": "group",
+        "value": "(y)",
+      },
+    },
+    {
+      "id": "/(y)/d:static",
+      "node": "_",
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "(y)",
+        ],
+        [
+          null,
+          "d",
+        ],
+      ],
+      "path": "/(y)/d",
+      "segment": {
+        "type": "static",
+        "value": "d",
+      },
+    },
+    {
+      "id": "/(y)/d/(z):group",
+      "node": "_",
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "(y)",
+        ],
+        [
+          null,
+          "d",
+        ],
+        [
+          null,
+          "(z)",
+        ],
+      ],
+      "path": "/(y)/d/(z)",
+      "segment": {
+        "type": "group",
+        "value": "(z)",
+      },
+    },
+    {
+      "id": "/(y)/d/(z):page",
+      "node": "_",
+      "params": [
+        [
+          null,
+          "",
+        ],
+        [
+          null,
+          "(y)",
+        ],
+        [
+          null,
+          "d",
+        ],
+        [
+          null,
+          "(z)",
+        ],
+      ],
+      "path": "/(y)/d/(z)",
+      "segment": {
+        "type": "page",
+      },
+    },
+  ],
+}
+`;

--- a/packages/react-server/src/features/router/server.tsx
+++ b/packages/react-server/src/features/router/server.tsx
@@ -14,6 +14,7 @@ import {
   parseRoutePath,
   toMatchParamsObject,
   toRouteId,
+  withMatchRouteId,
 } from "./tree";
 import { LAYOUT_ROOT_NAME, isAncestorPath } from "./utils";
 
@@ -205,7 +206,16 @@ export function getCachedRoutes(
   {
     const matches = matchRouteTree2(tree, lastPathname, "page");
     tinyassert(matches);
-    // with rute
+    for (const m of withMatchRouteId(matches)) {
+      // find non-revalidated layouts
+      if (
+        0 &&
+        m.segment.type !== "page" &&
+        !revalidations.some((r) => r && isAncestorPath(r, m.path))
+      ) {
+        routeIds.push(m.id);
+      }
+    }
   }
   for (const m of matches) {
     if (

--- a/packages/react-server/src/features/router/server.tsx
+++ b/packages/react-server/src/features/router/server.tsx
@@ -10,6 +10,7 @@ import {
   type TreeNode,
   createFsRouteTree,
   matchRouteTree,
+  matchRouteTree2,
   parseRoutePath,
   toMatchParamsObject,
   toRouteId,
@@ -201,6 +202,11 @@ export function getCachedRoutes(
 ) {
   const routeIds: string[] = [];
   const { matches } = matchRouteTree(tree, lastPathname, "page");
+  {
+    const matches = matchRouteTree2(tree, lastPathname, "page");
+    tinyassert(matches);
+    // with rute
+  }
   for (const m of matches) {
     if (
       m.type === "layout" &&

--- a/packages/react-server/src/features/router/tree.test.ts
+++ b/packages/react-server/src/features/router/tree.test.ts
@@ -164,6 +164,7 @@ describe(matchRouteTree2, () => {
     }
   });
 
+  // TODO: include this above
   describe(withMatchRouteId, () => {
     it("basic", () => {
       const files = [
@@ -189,6 +190,35 @@ describe(matchRouteTree2, () => {
       }
 
       const testCases = ["/a", "/a/b", "/a/b/c"];
+      for (const e of testCases) {
+        expect(testMatch(e)).matchSnapshot();
+      }
+    });
+
+    it("group routes", () => {
+      const files = [
+        "/a/page.js",
+        "/(x)/b/page.js",
+        "/c/(x)/page.js",
+        "/(y)/d/(z)/page.js",
+      ];
+      const input = Object.fromEntries(files.map((k) => [k, k]));
+      const { tree } = createFsRouteTree<AnyRouteModule>(input);
+      expect(tree).toMatchSnapshot();
+
+      function testMatch(pathname: string) {
+        const matches = matchRouteTree2(tree, pathname, "page");
+        const matches3 = withMatchRouteId(matches ?? []);
+        return {
+          _pathname: pathname,
+          matches: matches3.map((m) => ({
+            ...m,
+            node: "_",
+          })),
+        };
+      }
+
+      const testCases = ["/a", "/b", "/c", "/d"];
       for (const e of testCases) {
         expect(testMatch(e)).matchSnapshot();
       }

--- a/packages/react-server/src/features/router/tree.test.ts
+++ b/packages/react-server/src/features/router/tree.test.ts
@@ -148,7 +148,7 @@ describe(matchRouteTree2, () => {
 
     const testCases = [
       "/a/u",
-      "/a/c/u", // TODO: probably this should trigger /(x)/a/c/not-found.js
+      "/a/c/u", // TODO: probably this should trigger /(x)/a/c/not-found.js (but it appears Next.js doesn't do it either?)
       "/p/u", // TODO: see processNotFound
     ];
     for (const e of testCases) {

--- a/packages/react-server/src/features/router/tree.test.ts
+++ b/packages/react-server/src/features/router/tree.test.ts
@@ -61,7 +61,7 @@ describe(createFsRouteTree, () => {
 });
 
 describe(matchRouteTree2, () => {
-  it("basic", async () => {
+  it("dynamic not-found", async () => {
     const files = [
       "/a/b/c/page.js",
       "/a/not-found.js",
@@ -89,7 +89,7 @@ describe(matchRouteTree2, () => {
     }
   });
 
-  it("group routes", async () => {
+  it("group routes basic", async () => {
     const files = [
       "/a/page.js",
       "/(x)/b/page.js",
@@ -112,6 +112,41 @@ describe(matchRouteTree2, () => {
     }
 
     const testCases = ["/a", "/b", "/c", "/d"];
+    for (const e of testCases) {
+      expect(testMatch(e)).matchSnapshot();
+    }
+  });
+
+  it("group routes not-found", async () => {
+    const files = [
+      "/a/b/page.js",
+      "/a/not-found.js",
+      "/(x)/a/c/page.js",
+      "/(x)/a/c/not-found.js",
+      "/(x)/a/not-found.js",
+      "/(x)/p/q/page.js",
+      "/(x)/p/not-found.js",
+    ];
+    const input = Object.fromEntries(files.map((k) => [k, k]));
+    const { tree } = createFsRouteTree<AnyRouteModule>(input);
+    expect(tree).toMatchSnapshot();
+
+    function testMatch(pathname: string) {
+      const matches = matchRouteTree2(tree, pathname, "page");
+      return {
+        _pathname: pathname,
+        matches: matches?.map((m) => ({
+          ...m,
+          node: m.node.value,
+        })),
+      };
+    }
+
+    const testCases = [
+      "/a/u",
+      "/a/c/u", // TODO: probably this should trigger /(x)/a/c/not-found.js
+      "/p/u", // TODO: see processNotFound
+    ];
     for (const e of testCases) {
       expect(testMatch(e)).matchSnapshot();
     }

--- a/packages/react-server/src/features/router/tree.test.ts
+++ b/packages/react-server/src/features/router/tree.test.ts
@@ -66,6 +66,29 @@ describe(createFsRouteTree, () => {
 });
 
 describe(matchRouteTree2, () => {
+  it("basic", async () => {
+    const files = ["/page.js", "/a/page.js"];
+    const input = Object.fromEntries(files.map((k) => [k, k]));
+    const { tree } = createFsRouteTree<AnyRouteModule>(input);
+    expect(tree).toMatchSnapshot();
+
+    function testMatch(pathname: string) {
+      const matches = matchRouteTree2(tree, pathname, "page");
+      return {
+        _pathname: pathname,
+        matches: matches?.map((m) => ({
+          ...m,
+          node: !!m.node.value,
+        })),
+      };
+    }
+
+    const testCases = ["/", "/a", "/b"];
+    for (const e of testCases) {
+      expect(testMatch(e)).matchSnapshot();
+    }
+  });
+
   it("dynamic not-found", async () => {
     const files = [
       "/a/b/c/page.js",
@@ -189,7 +212,7 @@ describe(matchRouteTree2, () => {
         };
       }
 
-      const testCases = ["/a", "/a/b", "/a/b/c"];
+      const testCases = ["/", "/a", "/a/b", "/a/b/c"];
       for (const e of testCases) {
         expect(testMatch(e)).matchSnapshot();
       }

--- a/packages/react-server/src/features/router/tree.test.ts
+++ b/packages/react-server/src/features/router/tree.test.ts
@@ -88,4 +88,32 @@ describe(matchRouteTree2, () => {
       expect(testMatch(e)).matchSnapshot();
     }
   });
+
+  it.only("group routes", async () => {
+    const files = [
+      "/a/page.js",
+      "/(x)/b/page.js",
+      "/c/(x)/page.js",
+      "/(x)/d/(y)/page.js",
+    ];
+    const input = Object.fromEntries(files.map((k) => [k, k]));
+    const { tree } = createFsRouteTree<AnyRouteModule>(input);
+    expect(tree).toMatchSnapshot();
+
+    function testMatch(pathname: string) {
+      const matches = matchRouteTree2(tree, pathname, "page");
+      return {
+        _pathname: pathname,
+        matches: matches?.map((m) => ({
+          ...m,
+          node: m.node.value,
+        })),
+      };
+    }
+
+    const testCases = ["/a", "/b", "/c", "/d"];
+    for (const e of testCases) {
+      expect(testMatch(e)).matchSnapshot();
+    }
+  });
 });

--- a/packages/react-server/src/features/router/tree.test.ts
+++ b/packages/react-server/src/features/router/tree.test.ts
@@ -148,8 +148,11 @@ describe(matchRouteTree2, () => {
 
     const testCases = [
       "/a/u",
-      "/a/c/u", // TODO: probably this should trigger /(x)/a/c/not-found.js (but it appears Next.js doesn't do it either?)
-      "/p/u", // TODO: see processNotFound
+      // TODO
+      // maybe this should trigger /(x)/a/c/not-found.js
+      // but Next.js doesn't seem to do it
+      "/a/c/u",
+      "/p/u",
     ];
     for (const e of testCases) {
       expect(testMatch(e)).matchSnapshot();

--- a/packages/react-server/src/features/router/tree.test.ts
+++ b/packages/react-server/src/features/router/tree.test.ts
@@ -83,7 +83,11 @@ describe(matchRouteTree2, () => {
       };
     }
 
-    const testCases = ["/a/b/c", "/a/b/d", "/x/b/e"];
+    const testCases = [
+      "/a/b/c",
+      "/a/b/d", // -> /a/not-found.js
+      "/x/b/e", // -> /[x]/not-found.js
+    ];
     for (const e of testCases) {
       expect(testMatch(e)).matchSnapshot();
     }

--- a/packages/react-server/src/features/router/tree.test.ts
+++ b/packages/react-server/src/features/router/tree.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { AnyRouteModule } from "./server";
-import { createFsRouteTree, matchRouteTree, matchRouteTree2 } from "./tree";
+import {
+  createFsRouteTree,
+  matchRouteTree,
+  matchRouteTree2,
+  withMatchRouteId,
+} from "./tree";
 
 describe(createFsRouteTree, () => {
   it("basic", async () => {
@@ -157,5 +162,36 @@ describe(matchRouteTree2, () => {
     for (const e of testCases) {
       expect(testMatch(e)).matchSnapshot();
     }
+  });
+
+  describe(withMatchRouteId, () => {
+    it("basic", () => {
+      const files = [
+        "/page.js",
+        "/a/page.js",
+        "/a/b/page.js",
+        "/a/not-found.js",
+      ];
+      const input = Object.fromEntries(files.map((k) => [k, k]));
+      const { tree } = createFsRouteTree<AnyRouteModule>(input);
+      expect(tree).toMatchSnapshot();
+
+      function testMatch(pathname: string) {
+        const matches = matchRouteTree2(tree, pathname, "page");
+        const matches3 = withMatchRouteId(matches ?? []);
+        return {
+          _pathname: pathname,
+          matches: matches3.map((m) => ({
+            ...m,
+            node: "_",
+          })),
+        };
+      }
+
+      const testCases = ["/a", "/a/b", "/a/b/c"];
+      for (const e of testCases) {
+        expect(testMatch(e)).matchSnapshot();
+      }
+    });
   });
 });

--- a/packages/react-server/src/features/router/tree.test.ts
+++ b/packages/react-server/src/features/router/tree.test.ts
@@ -89,7 +89,7 @@ describe(matchRouteTree2, () => {
     }
   });
 
-  it.only("group routes", async () => {
+  it("group routes", async () => {
     const files = [
       "/a/page.js",
       "/(x)/b/page.js",

--- a/packages/react-server/src/features/router/tree.ts
+++ b/packages/react-server/src/features/router/tree.ts
@@ -174,6 +174,7 @@ export function matchRouteTree2<T extends AnyRouteModule>(
             ...matches[i]!,
             segment: {
               type: "not-found",
+              // TODO: `i` needs to be offeseted for group routes
               value: segments.slice(i + 1).join("/"),
             },
           });

--- a/packages/react-server/src/features/router/tree.ts
+++ b/packages/react-server/src/features/router/tree.ts
@@ -163,9 +163,6 @@ export function matchRouteTree2<T extends AnyRouteModule>(
     matches: MatchResult2<T>,
     segments: string[],
   ): MatchResult2<T> {
-    console.log(matches);
-    if (1) return matches;
-
     if (matches) {
       const last = matches?.at(-1);
       if (last?.segment.type === "not-found") {
@@ -222,7 +219,7 @@ export function matchRouteTree2<T extends AnyRouteModule>(
 
     // not-found
     if (branches.length === 0) {
-      branches.push([
+      return [
         {
           node,
           segment: {
@@ -230,7 +227,7 @@ export function matchRouteTree2<T extends AnyRouteModule>(
             value: segments.join("/"),
           },
         },
-      ]);
+      ];
     }
 
     // tie break branches
@@ -244,10 +241,11 @@ export function matchRouteTree2<T extends AnyRouteModule>(
     // static = group < dynamic < catchall
     if (first === "dynamic") return 2;
     if (first === "catchall") return 3;
-    // TODO
     // static < group if not-found
-    // if (first === "group" && last === "not-found") return 1;
-    if (last === "not-found") return 1;
+    if (last === "not-found") {
+      if (first === "group") return 1.5;
+      return 1;
+    }
     return 0;
   }
 }

--- a/packages/react-server/src/features/router/tree.ts
+++ b/packages/react-server/src/features/router/tree.ts
@@ -150,10 +150,11 @@ export function matchRouteTree2<T extends AnyRouteModule>(
   pathname: string,
   leafType: "page" | "route",
 ): MatchResult2<T> {
-  const allSegments = toRawSegments(pathname).map((s) => decodeURI(s));
-  return recurse(tree, allSegments);
+  return recurse(
+    tree,
+    toRawSegments(pathname).map((s) => decodeURI(s)),
+  );
 
-  // TODO: move outside?
   function recurse(
     node: TreeNode<T>,
     segments: string[],

--- a/packages/react-server/src/features/router/tree.ts
+++ b/packages/react-server/src/features/router/tree.ts
@@ -123,6 +123,29 @@ type MatchEntry2<T> = {
   segment: MatchSegment;
 };
 
+export type MatchEntry3<T> = MatchEntry2<T> & {
+  id: string;
+  params: MatchSegment[];
+};
+
+export function withMatchRouteId<T>(
+  matches: MatchEntry2<T>[],
+): MatchEntry3<T>[] {
+  const segments = matches.map((m) => m.segment);
+  return matches.map((match, i) => {
+    const params = segments.slice(0, i + 1);
+    const id =
+      params.map((e) => toMatchParamEntry(e)[1] ?? "").join("/") +
+      ":" +
+      match.segment.type;
+    return {
+      id,
+      params,
+      ...match,
+    } satisfies MatchEntry3<T>;
+  });
+}
+
 type MatchResult2<T> = MatchEntry2<T>[] | undefined;
 
 export function toMatchParamEntry(s: MatchSegment) {

--- a/packages/react-server/src/features/router/tree.ts
+++ b/packages/react-server/src/features/router/tree.ts
@@ -79,11 +79,11 @@ export type MatchResult<T> = {
  * "/a" => ["", "a"]
  * "/a/b" => ["", "a", "b"]
  */
-function toRawSegments(pathname: string) {
-  return ["", ...pathname.slice(1).split("/")];
+function toRawSegments(pathname: string): string[] {
+  return pathname === "/" ? [""] : pathname.split("/");
 }
 
-export function fromRawSegments(segments: string[]) {
+export function fromRawSegments(segments: string[]): string {
   return segments.join("/") || "/";
 }
 


### PR DESCRIPTION
## todo

- [x] unit test
- [x] e2e 
- [x] test on app-router demo https://github.com/hi-ogawa/next-app-router-playground/pull/1
- [x] refactor route id
- [x] refactor naming things https://github.com/hi-ogawa/vite-plugins/pull/514
- [x] support prerender https://github.com/hi-ogawa/vite-plugins/pull/516
- [ ] organize PR stack
  - want to have recursive matching refactoring first, then implement "ssr not-found" and "route gorups" later.
  - or just go all in a single PR if that's not worth it.