### PR TITLE
feat: optional catch-all route

### DIFF
--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -1106,6 +1106,18 @@ async function testCatchallRoute(page: Page, _options: { js: boolean }) {
   await expect(page.getByLabel("test state")).not.toBeChecked();
 }
 
+test("optional catch-all", async ({ page }) => {
+  checkNoError(page);
+  await page.goto("/test/catchall-opt");
+  await page.getByText('{"slug":""}').click();
+  await page
+    .getByRole("link", { name: "• /test/catchall-opt/x", exact: true })
+    .click();
+  await page.getByText('{"slug":"x"}').click();
+  await page.getByRole("link", { name: "• /test/catchall-opt/x/y" }).click();
+  await page.getByText('{"slug":"x/y"}').click();
+});
+
 test("useSelectedLayoutSegments", async ({ page }) => {
   await page.goto("/test/dynamic/selected");
   await page.getByText("/layout.tsx: []").click();

--- a/packages/react-server/examples/basic/src/routes/test/catchall-opt/[[...slug]]/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/catchall-opt/[[...slug]]/page.tsx
@@ -1,0 +1,5 @@
+import type { PageProps } from "@hiogawa/react-server/server";
+
+export default function Page(props: PageProps) {
+  return <pre className="text-sm">{JSON.stringify(props.params)}</pre>;
+}

--- a/packages/react-server/examples/basic/src/routes/test/catchall-opt/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/catchall-opt/layout.tsx
@@ -1,0 +1,15 @@
+import type { LayoutProps } from "@hiogawa/react-server/server";
+import { NavMenu } from "../../../components/nav-menu";
+
+export default function Layout(props: LayoutProps) {
+  return (
+    <div className="flex flex-col gap-2 p-2 border">
+      <h1>Optional Catch-all</h1>
+      <NavMenu
+        className="grid grid-cols-3 gap-1"
+        links={["/test/catchall-opt/x", "/test/catchall-opt/x/y"]}
+      />
+      {props.children}
+    </div>
+  );
+}

--- a/packages/react-server/examples/basic/src/routes/test/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/layout.tsx
@@ -30,6 +30,7 @@ export default async function Layout(props: LayoutProps) {
           "/test/template",
           "/test/api",
           "/test/group",
+          "/test/catchall-opt",
         ]}
       />
       <div className="flex items-center gap-2 text-sm">

--- a/packages/react-server/src/features/router/__snapshots__/tree.test.ts.snap
+++ b/packages/react-server/src/features/router/__snapshots__/tree.test.ts.snap
@@ -2395,36 +2395,7 @@ exports[`matchRouteTree > catch-all opitonal 3`] = `
 exports[`matchRouteTree > catch-all strict 1`] = `
 {
   "__pathname": "/a",
-  "matches": [
-    {
-      "node": {},
-      "segment": {
-        "type": "static",
-        "value": "",
-      },
-    },
-    {
-      "node": {},
-      "segment": {
-        "type": "static",
-        "value": "a",
-      },
-    },
-    {
-      "node": {},
-      "segment": {
-        "key": "any",
-        "type": "catchall",
-        "value": "",
-      },
-    },
-    {
-      "node": {},
-      "segment": {
-        "type": "page",
-      },
-    },
-  ],
+  "matches": undefined,
 }
 `;
 

--- a/packages/react-server/src/features/router/__snapshots__/tree.test.ts.snap
+++ b/packages/react-server/src/features/router/__snapshots__/tree.test.ts.snap
@@ -2284,6 +2284,222 @@ exports[`matchRouteTree > basic 4`] = `
 }
 `;
 
+exports[`matchRouteTree > catch-all opitonal 1`] = `
+{
+  "__pathname": "/a",
+  "matches": [
+    {
+      "node": {},
+      "segment": {
+        "type": "static",
+        "value": "",
+      },
+    },
+    {
+      "node": {},
+      "segment": {
+        "type": "static",
+        "value": "a",
+      },
+    },
+    {
+      "node": {},
+      "segment": {
+        "key": "any",
+        "type": "catchall-optional",
+        "value": "",
+      },
+    },
+    {
+      "node": {},
+      "segment": {
+        "type": "page",
+      },
+    },
+  ],
+}
+`;
+
+exports[`matchRouteTree > catch-all opitonal 2`] = `
+{
+  "__pathname": "/a/b",
+  "matches": [
+    {
+      "node": {},
+      "segment": {
+        "type": "static",
+        "value": "",
+      },
+    },
+    {
+      "node": {},
+      "segment": {
+        "type": "static",
+        "value": "a",
+      },
+    },
+    {
+      "node": {},
+      "segment": {
+        "key": "any",
+        "type": "catchall-optional",
+        "value": "b",
+      },
+    },
+    {
+      "node": {},
+      "segment": {
+        "type": "page",
+      },
+    },
+  ],
+}
+`;
+
+exports[`matchRouteTree > catch-all opitonal 3`] = `
+{
+  "__pathname": "/a/b/c",
+  "matches": [
+    {
+      "node": {},
+      "segment": {
+        "type": "static",
+        "value": "",
+      },
+    },
+    {
+      "node": {},
+      "segment": {
+        "type": "static",
+        "value": "a",
+      },
+    },
+    {
+      "node": {},
+      "segment": {
+        "key": "any",
+        "type": "catchall-optional",
+        "value": "b/c",
+      },
+    },
+    {
+      "node": {},
+      "segment": {
+        "type": "page",
+      },
+    },
+  ],
+}
+`;
+
+exports[`matchRouteTree > catch-all strict 1`] = `
+{
+  "__pathname": "/a",
+  "matches": [
+    {
+      "node": {},
+      "segment": {
+        "type": "static",
+        "value": "",
+      },
+    },
+    {
+      "node": {},
+      "segment": {
+        "type": "static",
+        "value": "a",
+      },
+    },
+    {
+      "node": {},
+      "segment": {
+        "key": "any",
+        "type": "catchall",
+        "value": "",
+      },
+    },
+    {
+      "node": {},
+      "segment": {
+        "type": "page",
+      },
+    },
+  ],
+}
+`;
+
+exports[`matchRouteTree > catch-all strict 2`] = `
+{
+  "__pathname": "/a/b",
+  "matches": [
+    {
+      "node": {},
+      "segment": {
+        "type": "static",
+        "value": "",
+      },
+    },
+    {
+      "node": {},
+      "segment": {
+        "type": "static",
+        "value": "a",
+      },
+    },
+    {
+      "node": {},
+      "segment": {
+        "key": "any",
+        "type": "catchall",
+        "value": "b",
+      },
+    },
+    {
+      "node": {},
+      "segment": {
+        "type": "page",
+      },
+    },
+  ],
+}
+`;
+
+exports[`matchRouteTree > catch-all strict 3`] = `
+{
+  "__pathname": "/a/b/c",
+  "matches": [
+    {
+      "node": {},
+      "segment": {
+        "type": "static",
+        "value": "",
+      },
+    },
+    {
+      "node": {},
+      "segment": {
+        "type": "static",
+        "value": "a",
+      },
+    },
+    {
+      "node": {},
+      "segment": {
+        "key": "any",
+        "type": "catchall",
+        "value": "b/c",
+      },
+    },
+    {
+      "node": {},
+      "segment": {
+        "type": "page",
+      },
+    },
+  ],
+}
+`;
+
 exports[`matchRouteTree > dynamic not-found 1`] = `
 {
   "children": {

--- a/packages/react-server/src/features/router/tree.test.ts
+++ b/packages/react-server/src/features/router/tree.test.ts
@@ -184,6 +184,22 @@ describe(matchRouteTree, () => {
       expect(tester.match(e)).matchSnapshot();
     }
   });
+
+  it("catch-all strict", async () => {
+    const tester = createMatchTester(["/a/[...any]/page.js"]);
+    const testCases = ["/a", "/a/b", "/a/b/c"];
+    for (const e of testCases) {
+      expect(tester.match(e)).matchSnapshot();
+    }
+  });
+
+  it("catch-all opitonal", async () => {
+    const tester = createMatchTester(["/a/[[...any]]/page.js"]);
+    const testCases = ["/a", "/a/b", "/a/b/c"];
+    for (const e of testCases) {
+      expect(tester.match(e)).matchSnapshot();
+    }
+  });
 });
 
 describe(parseRoutePath, () => {

--- a/packages/react-server/src/features/router/tree.ts
+++ b/packages/react-server/src/features/router/tree.ts
@@ -70,9 +70,9 @@ export function toMatchParams(segments: MatchSegment[]): MatchParams {
   for (const s of segments) {
     switch (s.type) {
       case "dynamic":
-      case "catchall": {
+      case "catchall":
+      case "catchall-optional":
         params[s.key] = s.value;
-      }
     }
   }
   return params;
@@ -85,6 +85,7 @@ export function toMatchValues(segments: MatchSegment[]): string[] {
       case "static":
       case "dynamic":
       case "catchall":
+      case "catchall-optional":
       case "group":
       case "not-found":
         values.push(s.value);
@@ -223,6 +224,7 @@ function scoreBranch<T>(branch: MatchEntry<T>[]) {
   // static = group < dynamic < catchall
   if (first === "dynamic") score += 2;
   if (first === "catchall") score += 3;
+  if (first === "catchall-optional") score += 4;
   return score;
 }
 

--- a/packages/react-server/src/features/router/tree.ts
+++ b/packages/react-server/src/features/router/tree.ts
@@ -246,7 +246,7 @@ function matchChildren<T>(node: TreeNode<T>, segments: string[]) {
       });
     }
     const matchCatchAll = key.match(CATCH_ALL_RE);
-    if (matchCatchAll) {
+    if (matchCatchAll && segments.length > 0) {
       candidates.push({
         match: {
           node: child,

--- a/packages/react-server/src/features/router/tree.ts
+++ b/packages/react-server/src/features/router/tree.ts
@@ -43,6 +43,11 @@ export type MatchSegment =
       value: string;
     }
   | {
+      type: "catchall-optional";
+      key: string;
+      value: string;
+    }
+  | {
       type: "group";
       value: string;
     }
@@ -254,6 +259,20 @@ function matchChildren<T>(node: TreeNode<T>, segments: string[]) {
         nextSegments: [],
       });
     }
+    const matchCatchAllOpt = key.match(CATCH_ALL_OPTIONAL_RE);
+    if (matchCatchAllOpt) {
+      candidates.push({
+        match: {
+          node: child,
+          segment: {
+            type: "catchall-optional",
+            key: matchCatchAllOpt[1]!,
+            value: segments.join("/"),
+          },
+        },
+        nextSegments: [],
+      });
+    }
     const matchDynamic = key.match(DYNAMIC_RE);
     if (matchDynamic) {
       candidates.push({
@@ -286,6 +305,7 @@ function matchChildren<T>(node: TreeNode<T>, segments: string[]) {
 
 const DYNAMIC_RE = /^\[(\w*)\]$/;
 const CATCH_ALL_RE = /^\[\.\.\.(\w*)\]$/;
+const CATCH_ALL_OPTIONAL_RE = /^\[\[\.\.\.(\w*)\]\]$/;
 const GROUP_RE = /^\((\w+)\)$/;
 
 export function parseRoutePath(pathname: string) {
@@ -297,6 +317,7 @@ export function parseRoutePath(pathname: string) {
       // strip off group segment
       pathname = pathname.replace(`/${segment}`, "");
     }
+    // TODO: optional catch-all
     const mAll = segment.match(CATCH_ALL_RE);
     if (mAll) {
       tinyassert(1 in mAll);


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/vite-plugins/issues/515

Well, it turned out our catch-all `[...any]` works already as optional... So we need to find a way to make the current one strict.

## todo

- [x] fix
- [x] test