### PR TITLE
fix: match dynamic page over not-found

### DIFF
--- a/packages/react-server/src/features/router/__snapshots__/tree.test.ts.snap
+++ b/packages/react-server/src/features/router/__snapshots__/tree.test.ts.snap
@@ -2383,15 +2383,29 @@ exports[`matchRouteTree > dynamic not-found 3`] = `
     {
       "node": {},
       "segment": {
-        "type": "static",
+        "key": "x",
+        "type": "dynamic",
         "value": "a",
       },
     },
     {
       "node": {},
       "segment": {
-        "type": "not-found",
-        "value": "b/d",
+        "type": "static",
+        "value": "b",
+      },
+    },
+    {
+      "node": {},
+      "segment": {
+        "type": "static",
+        "value": "d",
+      },
+    },
+    {
+      "node": {},
+      "segment": {
+        "type": "page",
       },
     },
   ],
@@ -2442,8 +2456,15 @@ exports[`matchRouteTree > dynamic vs not-found 1`] = `
     {
       "node": {},
       "segment": {
-        "type": "not-found",
+        "key": "x",
+        "type": "dynamic",
         "value": "a",
+      },
+    },
+    {
+      "node": {},
+      "segment": {
+        "type": "page",
       },
     },
   ],

--- a/packages/react-server/src/features/router/__snapshots__/tree.test.ts.snap
+++ b/packages/react-server/src/features/router/__snapshots__/tree.test.ts.snap
@@ -2428,6 +2428,28 @@ exports[`matchRouteTree > dynamic not-found 4`] = `
 }
 `;
 
+exports[`matchRouteTree > dynamic vs not-found 1`] = `
+{
+  "__pathname": "/a",
+  "matches": [
+    {
+      "node": {},
+      "segment": {
+        "type": "static",
+        "value": "",
+      },
+    },
+    {
+      "node": {},
+      "segment": {
+        "type": "not-found",
+        "value": "a",
+      },
+    },
+  ],
+}
+`;
+
 exports[`matchRouteTree > group routes basic 1`] = `
 {
   "children": {

--- a/packages/react-server/src/features/router/__snapshots__/tree.test.ts.snap
+++ b/packages/react-server/src/features/router/__snapshots__/tree.test.ts.snap
@@ -2799,3 +2799,54 @@ exports[`matchRouteTree > group routes not-found 4`] = `
   ],
 }
 `;
+
+exports[`matchRouteTree > tie-break not-found dynamic 1`] = `
+{
+  "__pathname": "/a/b",
+  "matches": [
+    {
+      "node": {},
+      "segment": {
+        "type": "static",
+        "value": "",
+      },
+    },
+    {
+      "node": {},
+      "segment": {
+        "type": "not-found",
+        "value": "a/b",
+      },
+    },
+  ],
+}
+`;
+
+exports[`matchRouteTree > tie-break not-found static 1`] = `
+{
+  "__pathname": "/a/b",
+  "matches": [
+    {
+      "node": {},
+      "segment": {
+        "type": "static",
+        "value": "",
+      },
+    },
+    {
+      "node": {},
+      "segment": {
+        "type": "static",
+        "value": "a",
+      },
+    },
+    {
+      "node": {},
+      "segment": {
+        "type": "not-found",
+        "value": "b",
+      },
+    },
+  ],
+}
+`;

--- a/packages/react-server/src/features/router/__snapshots__/tree.test.ts.snap
+++ b/packages/react-server/src/features/router/__snapshots__/tree.test.ts.snap
@@ -2814,8 +2814,16 @@ exports[`matchRouteTree > tie-break not-found dynamic 1`] = `
     {
       "node": {},
       "segment": {
+        "key": "a",
+        "type": "dynamic",
+        "value": "a",
+      },
+    },
+    {
+      "node": {},
+      "segment": {
         "type": "not-found",
-        "value": "a/b",
+        "value": "b",
       },
     },
   ],

--- a/packages/react-server/src/features/router/tree.test.ts
+++ b/packages/react-server/src/features/router/tree.test.ts
@@ -112,7 +112,8 @@ describe(matchRouteTree, () => {
 
     const testCases = [
       "/a/b/c",
-      "/a/b/d", // -> /a/not-found.js
+      // TODO: shoud trigger /a/not-found?
+      "/a/b/d", // -> /[x]/not-found.js
       "/x/b/e", // -> /[x]/not-found.js
     ];
     for (const e of testCases) {
@@ -157,11 +158,9 @@ describe(matchRouteTree, () => {
 
     const testCases = [
       "/a/u",
-      // TODO
-      // maybe this should trigger /(x)/a/c/not-found.js
-      // but Next.js doesn't seem to do it
-      "/a/c/u",
-      "/p/u",
+      // TODO: should trigger /(x)/a/c/not-found?
+      "/a/c/u", // -> /a/not-found
+      "/p/u", // -> /(x)/p/not-found
     ];
     for (const e of testCases) {
       expect(tester.match(e)).matchSnapshot();

--- a/packages/react-server/src/features/router/tree.test.ts
+++ b/packages/react-server/src/features/router/tree.test.ts
@@ -120,6 +120,14 @@ describe(matchRouteTree, () => {
     }
   });
 
+  it("dynamic vs not-found", async () => {
+    const tester = createMatchTester(["/not-found.js", "/[x]/page.js"]);
+    const testCases = ["/a"];
+    for (const e of testCases) {
+      expect(tester.match(e)).matchSnapshot();
+    }
+  });
+
   it("group routes basic", async () => {
     const tester = createMatchTester([
       "/a/page.js",

--- a/packages/react-server/src/features/router/tree.test.ts
+++ b/packages/react-server/src/features/router/tree.test.ts
@@ -121,6 +121,27 @@ describe(matchRouteTree, () => {
     }
   });
 
+  it("tie-break not-found static", async () => {
+    const tester = createMatchTester(["/not-found.js", "/a/not-found.js"]);
+
+    const testCases = ["/a/b"];
+    for (const e of testCases) {
+      expect(tester.match(e)).matchSnapshot();
+    }
+  });
+
+  it("tie-break not-found dynamic", async () => {
+    const tester = createMatchTester(["/not-found.js", "/[a]/not-found.js"]);
+
+    const testCases = [
+      // TODO: should trigger /[a]/not-found
+      "/a/b", // -> /not-found
+    ];
+    for (const e of testCases) {
+      expect(tester.match(e)).matchSnapshot();
+    }
+  });
+
   it("dynamic vs not-found", async () => {
     const tester = createMatchTester(["/not-found.js", "/[x]/page.js"]);
     const testCases = ["/a"];

--- a/packages/react-server/src/features/router/tree.test.ts
+++ b/packages/react-server/src/features/router/tree.test.ts
@@ -133,10 +133,7 @@ describe(matchRouteTree, () => {
   it("tie-break not-found dynamic", async () => {
     const tester = createMatchTester(["/not-found.js", "/[a]/not-found.js"]);
 
-    const testCases = [
-      // TODO: should trigger /[a]/not-found
-      "/a/b", // -> /not-found
-    ];
+    const testCases = ["/a/b"];
     for (const e of testCases) {
       expect(tester.match(e)).matchSnapshot();
     }

--- a/packages/react-server/src/features/router/tree.ts
+++ b/packages/react-server/src/features/router/tree.ts
@@ -217,6 +217,7 @@ function scoreBranch<T>(branch: MatchEntry<T>[]) {
   if (first === "dynamic") score += 2;
   if (first === "catchall") score += 3;
   // de-prioritize not-found
+  // TODO: use branch length to tie-break?
   if (last === "not-found") score += 10;
   return score;
 }

--- a/packages/react-server/src/features/router/tree.ts
+++ b/packages/react-server/src/features/router/tree.ts
@@ -212,15 +212,13 @@ function scoreBranch<T>(branch: MatchEntry<T>[]) {
   const first = branch[0]?.segment.type;
   const last = branch.at(-1)!.segment.type;
   tinyassert(first && last);
-  // static = group < dynamic < catchall
-  if (first === "dynamic") return 2;
-  if (first === "catchall") return 3;
-  // static < group if not-found
-  if (last === "not-found") {
-    if (first === "group") return 1.5;
-    return 1;
-  }
-  return 0;
+  let score = 0;
+  // static = group < dynamic < catchall < not-found
+  if (first === "dynamic") score += 2;
+  if (first === "catchall") score += 3;
+  // de-prioritize not-found
+  if (last === "not-found") score += 10;
+  return score;
 }
 
 function matchChildren<T>(node: TreeNode<T>, segments: string[]) {

--- a/packages/react-server/src/features/router/tree.ts
+++ b/packages/react-server/src/features/router/tree.ts
@@ -191,8 +191,8 @@ export function matchRouteTree<T extends AnyRouteModule>(
     }
 
     // check not-found
-    if (node.value?.["not-found"]) {
-      branches.push([
+    if (branches.length === 0 && node.value?.["not-found"]) {
+      return [
         {
           node,
           segment: {
@@ -200,7 +200,7 @@ export function matchRouteTree<T extends AnyRouteModule>(
             value: segments.join("/"),
           },
         },
-      ]);
+      ];
     }
 
     // tie break branches

--- a/packages/react-server/src/features/router/tree.ts
+++ b/packages/react-server/src/features/router/tree.ts
@@ -210,15 +210,14 @@ export function matchRouteTree<T extends AnyRouteModule>(
 
 function scoreBranch<T>(branch: MatchEntry<T>[]) {
   const first = branch[0]?.segment.type;
-  const last = branch.at(-1)!.segment.type;
+  const last = branch.at(-1)?.segment.type;
   tinyassert(first && last);
   let score = 0;
-  // static = group < dynamic < catchall < not-found
+  // TODO: research and rework not-found tie-break
+  if (last === "not-found") score += 10;
+  // static = group < dynamic < catchall
   if (first === "dynamic") score += 2;
   if (first === "catchall") score += 3;
-  // de-prioritize not-found
-  // TODO: use branch length to tie-break?
-  if (last === "not-found") score += 10;
   return score;
 }
 


### PR DESCRIPTION
Found out this is broken when testing it on https://app-router-vite.vercel.app/error-handling/electronics

---

OK, I remember why not-found handling is tricky, so stripping off `processNotFound` wasn't probably correct https://github.com/hi-ogawa/vite-plugins/pull/517/commits/41c9204d39e91de9e8c01eac8e02a67657341649

At this point, I'm not even sure what's most "natural", so we can probably just postpone tie-break between multiple "not-found" for the sake of fixing "page > not-found" tie-break, which is a way more crucial.