### PR TITLE
fix: normalize reference id

### DIFF
--- a/packages/react-server/src/features/assets/plugin.ts
+++ b/packages/react-server/src/features/assets/plugin.ts
@@ -105,7 +105,7 @@ export function vitePluginServerAssets({
         collectStyle($__global.dev.server, [
           entryBrowser,
           // TODO: dev should also use RouteManifest to manage client css
-          ...manager.clientReferenceIds,
+          ...manager.clientReferenceMap.keys(),
         ]),
       ]);
       return styles.join("\n\n");

--- a/packages/react-server/src/features/client-component/plugin.ts
+++ b/packages/react-server/src/features/client-component/plugin.ts
@@ -17,7 +17,6 @@ import {
   USE_CLIENT,
   USE_CLIENT_RE,
   createVirtualPlugin,
-  hashString,
 } from "../../plugin/utils";
 
 const debug = createDebug("react-server:plugin:use-client");

--- a/packages/react-server/src/features/server-action/plugin.tsx
+++ b/packages/react-server/src/features/server-action/plugin.tsx
@@ -88,11 +88,11 @@ export function vitePluginServerUseServer({
   const transformPlugin: Plugin = {
     name: vitePluginServerUseServer.name,
     async transform(code, id, _options) {
-      const serverId = manager.normalizeReferenceId(id);
       manager.serverReferenceMap.delete(id);
       if (!code.includes(USE_SERVER)) {
         return;
       }
+      const serverId = manager.normalizeReferenceId(id);
       const ast = await parseAstAsync(code);
       const { output } = await transformServerActionServer(code, ast, {
         id: serverId,

--- a/packages/react-server/src/features/server-action/plugin.tsx
+++ b/packages/react-server/src/features/server-action/plugin.tsx
@@ -5,11 +5,7 @@ import {
 import { createDebug, tinyassert } from "@hiogawa/utils";
 import { type Plugin, type PluginOption, parseAstAsync } from "vite";
 import type { PluginStateManager } from "../../plugin";
-import {
-  USE_SERVER,
-  createVirtualPlugin,
-  hashString,
-} from "../../plugin/utils";
+import { USE_SERVER, createVirtualPlugin } from "../../plugin/utils";
 
 const debug = createDebug("react-server:plugin:server-action");
 
@@ -41,13 +37,13 @@ export function vitePluginClientUseServer({
       const ast = await parseAstAsync(code);
       const output = await transformDirectiveProxyExport(ast, {
         directive: USE_SERVER,
-        id: manager.buildType ? hashString(id) : id,
+        id: manager.normalizeReferenceId(id),
         runtime: "$$proxy",
       });
       if (!output) {
         return;
       }
-      if (manager.buildType && !manager.serverReferenceIds.has(id)) {
+      if (manager.buildType && !manager.serverReferenceMap.has(id)) {
         throw new Error(
           `client imported undiscovered server reference '${id}'`,
         );
@@ -87,17 +83,18 @@ export function vitePluginServerUseServer({
   const transformPlugin: Plugin = {
     name: vitePluginServerUseServer.name,
     async transform(code, id, _options) {
-      manager.serverReferenceIds.delete(id);
+      const serverId = manager.normalizeReferenceId(id);
+      manager.serverReferenceMap.delete(id);
       if (!code.includes(USE_SERVER)) {
         return;
       }
       const ast = await parseAstAsync(code);
       const { output } = await transformServerActionServer(code, ast, {
-        id: manager.buildType ? hashString(id) : id,
+        id: serverId,
         runtime: "$$register",
       });
       if (output.hasChanged()) {
-        manager.serverReferenceIds.add(id);
+        manager.serverReferenceMap.set(id, serverId);
         output.prepend(
           `import { registerServerReference as $$register } from "${runtimePath}";\n`,
         );
@@ -118,8 +115,8 @@ export function vitePluginServerUseServer({
     }
     tinyassert(manager.buildType === "server");
     let result = `export default {\n`;
-    for (const id of manager.serverReferenceIds) {
-      result += `"${hashString(id)}": () => import("${id}"),\n`;
+    for (const [id, serverId] of manager.serverReferenceMap) {
+      result += `"${serverId}": () => import("${id}"),\n`;
     }
     result += "};\n";
     debug("[virtual:server-references]", result);

--- a/packages/react-server/src/features/server-action/server.tsx
+++ b/packages/react-server/src/features/server-action/server.tsx
@@ -68,7 +68,7 @@ export function initializeReactServer() {
 async function importServerReference(id: string): Promise<unknown> {
   if (import.meta.env.DEV) {
     const file = findMapInverse($__global.dev.manager.serverReferenceMap, id);
-    tinyassert(file);
+    tinyassert(file, `server reference not found '${id}'`);
     return await import(/* @vite-ignore */ file);
   } else {
     const mod = await import("virtual:server-references" as string);

--- a/packages/react-server/src/features/server-action/server.tsx
+++ b/packages/react-server/src/features/server-action/server.tsx
@@ -1,7 +1,9 @@
 import { memoize, tinyassert } from "@hiogawa/utils";
 import ReactServer from "react-server-dom-webpack/server.edge";
+import { $__global } from "../../global";
 import type { ReactServerErrorContext } from "../../server";
 import type { BundlerConfig, ImportManifestEntry } from "../../types/react";
+import { findMapInverse } from "../../utils/misc";
 
 // https://github.com/facebook/react/blob/c8a035036d0f257c514b3628e927dd9dd26e5a09/packages/react-server-dom-webpack/src/ReactFlightWebpackReferences.js#L87
 
@@ -65,7 +67,9 @@ export function initializeReactServer() {
 
 async function importServerReference(id: string): Promise<unknown> {
   if (import.meta.env.DEV) {
-    return await import(/* @vite-ignore */ id);
+    const file = findMapInverse($__global.dev.manager.serverReferenceMap, id);
+    tinyassert(file);
+    return await import(/* @vite-ignore */ file);
   } else {
     const mod = await import("virtual:server-references" as string);
     const dynImport = mod.default[id];

--- a/packages/react-server/src/global.ts
+++ b/packages/react-server/src/global.ts
@@ -1,4 +1,5 @@
 import type { ViteDevServer } from "vite";
+import type { PluginStateManager } from "./plugin";
 import type { CallServerCallback } from "./types/react";
 
 // centeralize quick global hacks...
@@ -7,6 +8,7 @@ export const $__global: {
   dev: {
     server: ViteDevServer;
     reactServer: ViteDevServer;
+    manager: PluginStateManager;
   };
   callServer: CallServerCallback;
 } = ((globalThis as any).__REACT_SERVER_GLOBAL ??= {});

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -46,6 +46,7 @@ import {
   ENTRY_BROWSER_WRAPPER,
   ENTRY_SERVER_WRAPPER,
   createVirtualPlugin,
+  hashString,
   vitePluginSilenceDirectiveBuildWarning,
 } from "./utils";
 
@@ -91,13 +92,21 @@ class PluginStateManager {
   serverIds = new Set<string>();
   // "use client" files
   clientReferenceIds = new Set<string>();
+  // TODO
+  clientReferenceMap = new Map<string, string>();
+
   // "use server" files
-  serverReferenceIds = new Set<string>();
+  serverReferenceMap = new Map<string, string>();
 
   shouldReloadRsc(id: string) {
     const ok = this.serverIds.has(id) && !this.clientReferenceIds.has(id);
     debug("[RscManager.shouldReloadRsc]", { ok, id });
     return ok;
+  }
+
+  normalizeReferenceId(id: string) {
+    id = path.relative(this.config.root, id);
+    return this.buildType ? hashString(id) : id;
   }
 }
 
@@ -320,6 +329,7 @@ export function vitePluginReactServer(options?: {
         $__global.dev = {
           server: manager.server,
           reactServer: reactServer,
+          manager,
         };
       }
     },

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -91,15 +91,13 @@ class PluginStateManager {
   // all files in rsc server
   serverIds = new Set<string>();
   // "use client" files
-  clientReferenceIds = new Set<string>();
-  // TODO
   clientReferenceMap = new Map<string, string>();
 
   // "use server" files
   serverReferenceMap = new Map<string, string>();
 
   shouldReloadRsc(id: string) {
-    const ok = this.serverIds.has(id) && !this.clientReferenceIds.has(id);
+    const ok = this.serverIds.has(id) && !this.clientReferenceMap.has(id);
     debug("[RscManager.shouldReloadRsc]", { ok, id });
     return ok;
   }
@@ -397,7 +395,7 @@ export function vitePluginReactServer(options?: {
         );
         console.log("▶▶▶ REACT SERVER BUILD (server) [2/4]");
         manager.buildType = "server";
-        manager.clientReferenceIds.clear();
+        manager.clientReferenceMap.clear();
         await build(reactServerViteConfig);
         console.log("▶▶▶ REACT SERVER BUILD (browser) [3/4]");
         manager.buildType = "browser";

--- a/packages/react-server/src/plugin/utils.tsx
+++ b/packages/react-server/src/plugin/utils.tsx
@@ -27,7 +27,8 @@ export function hashString(v: string) {
     .createHash("sha256")
     .update(v)
     .digest()
-    .toString("base64url");
+    .toString("hex")
+    .slice(0, 10);
 }
 
 export function createVirtualPlugin(name: string, load: Plugin["load"]) {

--- a/packages/react-server/src/utils/misc.ts
+++ b/packages/react-server/src/utils/misc.ts
@@ -1,0 +1,6 @@
+export function findMapInverse<K, V>(map: Map<K, V>, v: V): K | undefined {
+  for (const [k, v_] of map) {
+    if (v === v_) return k;
+  }
+  return;
+}


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/vite-plugins/issues/527

Mostly trying to back port this one from webpack-rsc, but it's actually trickier since we need a different machinery during dev.
- https://github.com/hi-ogawa/experiments/pull/41

Also, just remembered we want to port this one in Vite 6 example too
- https://github.com/hi-ogawa/vite-environment-examples/pull/84

## todo

- [x] server reference
- [x] client reference
- [ ] port this (later)
  - https://github.com/hi-ogawa/vite-environment-examples/pull/84