### PR TITLE
fix: rethrow action error on client

### DIFF
--- a/packages/react-server/examples/basic/src/routes/test/redirect/_action.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/redirect/_action.tsx
@@ -5,6 +5,5 @@ import { sleep } from "@hiogawa/utils";
 
 export async function testRedirect() {
   await sleep(500);
-  // TODO: redirection within same path is broken?
   throw redirect("/test/redirect?ok=server-action");
 }

--- a/packages/react-server/examples/basic/src/routes/test/redirect/_action.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/redirect/_action.tsx
@@ -5,5 +5,6 @@ import { sleep } from "@hiogawa/utils";
 
 export async function testRedirect() {
   await sleep(500);
+  // TODO: redirection within same path is broken?
   throw redirect("/test/redirect?ok=server-action");
 }

--- a/packages/react-server/src/entry/browser.tsx
+++ b/packages/react-server/src/entry/browser.tsx
@@ -65,8 +65,8 @@ async function start() {
     });
     $__startActionTransition(() => $__setFlight(result));
     const actionResult = (await result).action;
-    // TODO: rethrow?
     // TODO: isPending and isActionPending are true forever after the redirection
+    // TODO: do we even need to render node when action error?
     if (actionResult?.error) {
       throw createError(actionResult?.error);
     }
@@ -193,7 +193,7 @@ async function start() {
     ReactDOMClient.createRoot(document).render(reactRootEl);
   } else {
     const actionResult = (await initialFlight).action;
-    // TODO: rethrow from where?
+    // TODO: should rethrow action error from where?
     actionResult?.error;
     const formState = actionResult?.data;
     ReactDOMClient.hydrateRoot(document, reactRootEl, {

--- a/packages/react-server/src/entry/browser.tsx
+++ b/packages/react-server/src/entry/browser.tsx
@@ -60,7 +60,10 @@ async function start() {
       callServer,
     });
     $__startActionTransition(() => $__setFlight(result));
-    return (await result).action?.data;
+    const actionResult = (await result).action;
+    // TODO: rethrow?
+    actionResult?.error;
+    return actionResult?.data;
   };
 
   // expose as global to be used for createServerReference
@@ -180,7 +183,10 @@ async function start() {
   if (document.documentElement.dataset["noHydrate"]) {
     ReactDOMClient.createRoot(document).render(reactRootEl);
   } else {
-    const formState = (await initialFlight).action?.data;
+    const actionResult = (await initialFlight).action;
+    // TODO: rethrow from where?
+    actionResult?.error;
+    const formState = actionResult?.data;
     ReactDOMClient.hydrateRoot(document, reactRootEl, {
       formState,
     });

--- a/packages/react-server/src/entry/browser.tsx
+++ b/packages/react-server/src/entry/browser.tsx
@@ -66,6 +66,7 @@ async function start() {
     $__startActionTransition(() => $__setFlight(result));
     const actionResult = (await result).action;
     // TODO: rethrow?
+    // TODO: isPending and isActionPending are true forever after the redirection
     if (actionResult?.error) {
       throw createError(actionResult?.error);
     }

--- a/packages/react-server/src/features/error/error-boundary.tsx
+++ b/packages/react-server/src/features/error/error-boundary.tsx
@@ -91,24 +91,28 @@ function DefaultRootErrorPage(props: ErrorPageProps) {
 }
 
 export class RedirectBoundary extends React.Component<React.PropsWithChildren> {
-  override state: { redirectLocation?: string } = {};
+  override state: { error: null } | { error: Error; redirectLocation: string } =
+    { error: null };
 
   static getDerivedStateFromError(error: Error) {
     if (!import.meta.env.SSR) {
       const ctx = getErrorContext(error);
       const redirect = ctx && isRedirectError(ctx);
       if (redirect) {
-        return { redirectLocation: redirect.location };
+        return {
+          error,
+          redirectLocation: redirect.location,
+        } satisfies RedirectBoundary["state"];
       }
     }
     throw error;
   }
 
   override render() {
-    if (this.state.redirectLocation) {
+    if (this.state.error) {
       return (
         <RedirectHandler
-          suspensionKey={this.state}
+          suspensionKey={this.state.error}
           redirectLocation={this.state.redirectLocation}
         />
       );

--- a/packages/react-server/src/features/error/error-boundary.tsx
+++ b/packages/react-server/src/features/error/error-boundary.tsx
@@ -24,6 +24,11 @@ export class ErrorBoundary extends React.Component<Props, State> {
   }
 
   static getDerivedStateFromError(error: Error) {
+    // fallthrough "known" errors
+    const ctx = getErrorContext(error);
+    if (ctx && (ctx?.status === 404 || isRedirectError(ctx))) {
+      throw error;
+    }
     return { error };
   }
 

--- a/packages/react-server/src/features/error/error-boundary.tsx
+++ b/packages/react-server/src/features/error/error-boundary.tsx
@@ -120,7 +120,7 @@ export class RedirectBoundary extends React.Component<React.PropsWithChildren> {
 // trigger client navigation once and suspend forever
 const redirectSuspensionMap = new WeakMap<object, Promise<null>>();
 
-export function RedirectHandler(props: {
+function RedirectHandler(props: {
   suspensionKey: object;
   redirectLocation: string;
 }) {

--- a/packages/react-server/src/features/router/__snapshots__/server.test.tsx.snap
+++ b/packages/react-server/src/features/router/__snapshots__/server.test.tsx.snap
@@ -94,11 +94,9 @@ exports[`generateRouteModuleTree > basic 2`] = `
         <NotFoundBoundary
           fallback={<DefaultNotFoundPage />}
         >
-          <RedirectBoundary>
-            <LayoutContent
-              name="/:layout"
-            />
-          </RedirectBoundary>
+          <LayoutContent
+            name="/:layout"
+          />
         </NotFoundBoundary>
       <//LAYOUT.TSX>
     </LayoutMatchProvider>,
@@ -122,11 +120,9 @@ exports[`generateRouteModuleTree > basic 2`] = `
         <ErrorBoundary
           errorComponent="/X/ERROR.TSX"
         >
-          <RedirectBoundary>
-            <LayoutContent
-              name="/x:layout"
-            />
-          </RedirectBoundary>
+          <LayoutContent
+            name="/x:layout"
+          />
         </ErrorBoundary>
       </React.Fragment>
     </LayoutMatchProvider>,
@@ -224,11 +220,9 @@ exports[`generateRouteModuleTree > basic 3`] = `
         <NotFoundBoundary
           fallback={<DefaultNotFoundPage />}
         >
-          <RedirectBoundary>
-            <LayoutContent
-              name="/:layout"
-            />
-          </RedirectBoundary>
+          <LayoutContent
+            name="/:layout"
+          />
         </NotFoundBoundary>
       <//LAYOUT.TSX>
     </LayoutMatchProvider>,
@@ -277,11 +271,9 @@ exports[`generateRouteModuleTree > basic 3`] = `
           }
         }
       >
-        <RedirectBoundary>
-          <LayoutContent
-            name="/x/y:layout"
-          />
-        </RedirectBoundary>
+        <LayoutContent
+          name="/x/y:layout"
+        />
       <//X/Y/LAYOUT.TSX>
     </LayoutMatchProvider>,
     "/x/y:page": </X/Y/PAGE.TSX
@@ -329,11 +321,9 @@ exports[`generateRouteModuleTree > basic 3`] = `
         <ErrorBoundary
           errorComponent="/X/ERROR.TSX"
         >
-          <RedirectBoundary>
-            <LayoutContent
-              name="/x:layout"
-            />
-          </RedirectBoundary>
+          <LayoutContent
+            name="/x:layout"
+          />
         </ErrorBoundary>
       </React.Fragment>
     </LayoutMatchProvider>,
@@ -408,11 +398,9 @@ exports[`generateRouteModuleTree > basic 4`] = `
         <NotFoundBoundary
           fallback={<DefaultNotFoundPage />}
         >
-          <RedirectBoundary>
-            <LayoutContent
-              name="/:layout"
-            />
-          </RedirectBoundary>
+          <LayoutContent
+            name="/:layout"
+          />
         </NotFoundBoundary>
       <//LAYOUT.TSX>
     </LayoutMatchProvider>,

--- a/packages/react-server/src/features/router/client.tsx
+++ b/packages/react-server/src/features/router/client.tsx
@@ -32,7 +32,7 @@ export function LayoutRoot() {
   return (
     <>
       <LayoutContent name={LAYOUT_ROOT_NAME} />
-      <ActionRedirectHandler />
+      {false && <ActionRedirectHandler />}
       <MetadataRenderer />
     </>
   );

--- a/packages/react-server/src/features/router/server.tsx
+++ b/packages/react-server/src/features/router/server.tsx
@@ -83,7 +83,7 @@ async function renderLayout(
 ) {
   const {
     ErrorBoundary,
-    RedirectBoundary,
+    // RedirectBoundary,
     NotFoundBoundary,
     RemountRoute,
     LayoutContent,
@@ -93,8 +93,8 @@ async function renderLayout(
   let acc = <LayoutContent name={id} />;
   // TODO: do we need this in each layer?
   // - just let our ErrorBoundary skip redirect error
-  // - and add global RedirectBoundary at the root.
-  acc = <RedirectBoundary>{acc}</RedirectBoundary>;
+  // - and add global RedirectBoundary at the root. (only for browser root?)
+  // acc = <RedirectBoundary>{acc}</RedirectBoundary>;
 
   const NotFoundPage = node.value?.["not-found"]?.default;
   if (NotFoundPage) {

--- a/packages/react-server/src/features/router/server.tsx
+++ b/packages/react-server/src/features/router/server.tsx
@@ -91,6 +91,9 @@ async function renderLayout(
   } = await importRuntimeClient();
 
   let acc = <LayoutContent name={id} />;
+  // TODO: do we need this in each layer?
+  // - just let our ErrorBoundary skip redirect error
+  // - and add global RedirectBoundary at the root.
   acc = <RedirectBoundary>{acc}</RedirectBoundary>;
 
   const NotFoundPage = node.value?.["not-found"]?.default;


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/vite-plugins/issues/387

## todo

- [ ] js (stream)
  - [x] rethrow in browser `callServer`
  - [x] skip "known errors" (redirect error and not found error) from our general `ErrorBoundary`
  - [ ] fix broken `isPending` and `isActionPending`
- [ ] nojs (ssr)
  - redirect is already handled as direct redirect response
  - nothing to handle for other errors, so actually we don't need to do anything? for now, let's just add a test case to demonstrate current behavior.
- [ ] test

---

~So, another more canonical approach is that to inject `<RethrowActionError />` somewhere in server route tree and let it replay the error on client.~ Well, we would wish to do that, but then that won't make it possible to try/catch action error on userland...

But, we should double check what Next.js really does since try/catch isn't probably advocated method to handle server error anyways. https://nextjs.org/docs/app/building-your-application/routing/error-handling#handling-server-errors

It feels this is a shaky area, so let's postpone dealing with this for now.

---

It looks like Next.js handles redirection with a different mechanism than just "server error" https://github.com/vercel/next.js/blob/8f93430080f1c18b3f25a0b9c842063f6dc9c9e8/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts#L82 and probably this is an easier and concise way to do it.

Probably relevant PRs
- https://github.com/vercel/next.js/pull/61588