### PR TITLE
fix: rethrow action error on client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 .wrangler
 *.log
 *.tgz
+test-results

--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -708,6 +708,26 @@ async function testHigherOrderAction(page: Page) {
   await expect(page.getByTestId("higher-order-result")).toHaveText("(none)");
 }
 
+test("action error caught by try/catch", async ({ page }) => {
+  await page.goto("/test/action");
+  await waitForHydration(page);
+  await expect(page.getByTestId("action-error-result")).toHaveText(
+    "Result: (none)",
+  );
+  await page.getByRole("button", { name: "TestActionErrorTryCatch" }).click();
+  await expect(page.getByTestId("action-error-result")).toContainText(
+    "Result: Error: ReactServerError",
+  );
+});
+
+test("action error triggers boundary", async ({ page }) => {
+  await page.goto("/test/action");
+  await waitForHydration(page);
+  await page.getByRole("button", { name: "TestActionErrorBoundary" }).click();
+  await page.getByRole("heading", { name: "ErrorPage" }).click();
+  await page.getByText('server error: {"status":500}').click();
+});
+
 test("use client > virtual module", async ({ page }) => {
   await page.goto("/test/deps");
   await page.getByText("TestVirtualUseClient").click();

--- a/packages/react-server/examples/basic/src/routes/test/action/_client.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/action/_client.tsx
@@ -226,3 +226,29 @@ export function TestActionReturnComponent() {
     </div>
   );
 }
+
+export function TestActionError(props: { action: () => Promise<void> }) {
+  const [error, setError] = React.useState<unknown>();
+  return (
+    <div className="flex flex-col gap-2 items-start">
+      <div className="flex items-center gap-2">
+        <form
+          action={async () => {
+            try {
+              await props.action();
+            } catch (e) {
+              setError(e);
+            }
+          }}
+        >
+          <button className="antd-btn antd-btn-default px-2">
+            TestActionError
+          </button>
+        </form>
+        <div data-testid="action-error-result">
+          Result: {error ? String(error) : "(none)"}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/react-server/examples/basic/src/routes/test/action/_client.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/action/_client.tsx
@@ -227,7 +227,9 @@ export function TestActionReturnComponent() {
   );
 }
 
-export function TestActionError(props: { action: () => Promise<void> }) {
+export function TestActionErrorTryCatch(props: {
+  action: () => Promise<void>;
+}) {
   const [error, setError] = React.useState<unknown>();
   return (
     <div className="flex flex-col gap-2 items-start">
@@ -242,7 +244,7 @@ export function TestActionError(props: { action: () => Promise<void> }) {
           }}
         >
           <button className="antd-btn antd-btn-default px-2">
-            TestActionError
+            TestActionErrorTryCatch
           </button>
         </form>
         <div data-testid="action-error-result">

--- a/packages/react-server/examples/basic/src/routes/test/action/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/action/page.tsx
@@ -11,6 +11,7 @@ import {
   ClientActionBindTest,
   FormStateTest,
   NonFormActionTest,
+  TestActionError,
   TestActionReturnComponent,
 } from "./_client";
 
@@ -34,6 +35,13 @@ export default async function Page() {
       <TestActionReturnComponent />
       <div className="border-t" />
       <TestHigherOrder />
+      <div className="border-t" />
+      <TestActionError
+        action={async () => {
+          "use server";
+          throw new Error("boom!");
+        }}
+      />
     </div>
   );
 }

--- a/packages/react-server/examples/basic/src/routes/test/action/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/action/page.tsx
@@ -11,7 +11,7 @@ import {
   ClientActionBindTest,
   FormStateTest,
   NonFormActionTest,
-  TestActionError,
+  TestActionErrorTryCatch,
   TestActionReturnComponent,
 } from "./_client";
 
@@ -36,12 +36,33 @@ export default async function Page() {
       <div className="border-t" />
       <TestHigherOrder />
       <div className="border-t" />
-      <TestActionError
+      <TestActionErrorTryCatch
         action={async () => {
           "use server";
           throw new Error("boom!");
         }}
       />
+      <div className="border-t" />
+      <TestActionErrorBoundary />
+    </div>
+  );
+}
+
+function TestActionErrorBoundary() {
+  return (
+    <div className="flex flex-col gap-2 items-start">
+      <div className="flex items-center gap-2">
+        <form
+          action={async () => {
+            "use server";
+            throw new Error("boom!");
+          }}
+        >
+          <button className="antd-btn antd-btn-default px-2">
+            TestActionErrorBoundary
+          </button>
+        </form>
+      </div>
     </div>
   );
 }

--- a/packages/react-server/src/entry/browser.tsx
+++ b/packages/react-server/src/entry/browser.tsx
@@ -25,6 +25,7 @@ import type { FlightData } from "../features/router/utils";
 import { ACTION_REDIRECT_LOCATION } from "../features/server-action/redirect";
 import { createStreamRequest } from "../features/server-component/utils";
 import { $__global } from "../global";
+import { createError } from "../server";
 import type { CallServerCallback } from "../types/react";
 import { getFlightStreamBrowser } from "../utils/stream-script";
 
@@ -70,8 +71,12 @@ async function start() {
             Promise.resolve(response),
             { callServer },
           );
+          const actionResult = (await result).action;
+          if (actionResult?.error) {
+            throw createError(actionResult?.error);
+          }
           $__setFlight(result);
-          return (await result).action?.data;
+          return actionResult?.data;
         })().then(resolve, reject);
       });
     });

--- a/packages/react-server/src/entry/browser.tsx
+++ b/packages/react-server/src/entry/browser.tsx
@@ -71,7 +71,8 @@ async function start() {
             Promise.resolve(response),
             { callServer },
           );
-          // TODO: similar to redirection, we can also skip flight stream and return error json directly
+          // TODO: similar to redirection, we could also skip flight stream
+          // and return serialized error only.
           const actionResult = (await result).action;
           if (actionResult?.error) {
             throw createError(actionResult?.error);

--- a/packages/react-server/src/entry/browser.tsx
+++ b/packages/react-server/src/entry/browser.tsx
@@ -71,6 +71,7 @@ async function start() {
             Promise.resolve(response),
             { callServer },
           );
+          // TODO: similar to redirection, we can also skip flight stream and return error json directly
           const actionResult = (await result).action;
           if (actionResult?.error) {
             throw createError(actionResult?.error);


### PR DESCRIPTION
- alternative of https://github.com/hi-ogawa/vite-plugins/pull/529
- closes https://github.com/hi-ogawa/vite-plugins/issues/387

## todo

- [x] add test
  - [x] client try/catch
  - [x] closest error boundary
    - how to handle nojs action SSR? Currently error is completely silenced and it simply re-render SSR.
- [ ] we should actually skip flight render for all errors?
  - we cannot do this if we want nojs action SSR.