### PR TITLE
fix: don't catch known errors from general ErrorBoundary

### DIFF
--- a/packages/react-server/examples/basic/src/routes/test/error/boundary/dir/[id]/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/error/boundary/dir/[id]/page.tsx
@@ -1,0 +1,24 @@
+import {
+  type PageProps,
+  createError,
+  redirect,
+} from "@hiogawa/react-server/server";
+
+export default function Page(props: PageProps) {
+  const id = props.params["id"];
+  if (id === "redirect") {
+    throw redirect("/test/error/boundary/dir/ok");
+  }
+  if (id === "not-found") {
+    throw createError({ status: 404 });
+  }
+  if (id === "unexpected") {
+    throw new Error("boom!");
+  }
+  return (
+    <>
+      <div>boundary/dir/[id]/page.tsx</div>
+      <pre>{JSON.stringify(props.params)}</pre>
+    </>
+  );
+}

--- a/packages/react-server/examples/basic/src/routes/test/error/boundary/dir/error.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/error/boundary/dir/error.tsx
@@ -1,0 +1,5 @@
+"use client";
+
+export default function ErrorPage() {
+  return <div>boundary/dir/error.tsx</div>;
+}

--- a/packages/react-server/examples/basic/src/routes/test/error/boundary/dir/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/error/boundary/dir/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>boundary/dir/page.tsx</div>;
+}

--- a/packages/react-server/examples/basic/src/routes/test/error/boundary/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/error/boundary/layout.tsx
@@ -1,0 +1,20 @@
+import type { LayoutProps } from "@hiogawa/react-server/server";
+import { NavMenu } from "../../../../components/nav-menu";
+
+export default function Layout(props: LayoutProps) {
+  return (
+    <div className="flex flex-col gap-2 p-2 border">
+      <h3>Error Boundary</h3>
+      <NavMenu
+        links={[
+          "/test/error/boundary",
+          "/test/error/boundary/dir",
+          "/test/error/boundary/dir/redirect",
+          "/test/error/boundary/dir/not-found",
+          "/test/error/boundary/dir/unexpected",
+        ]}
+      />
+      {props.children}
+    </div>
+  );
+}

--- a/packages/react-server/examples/basic/src/routes/test/error/boundary/not-found.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/error/boundary/not-found.tsx
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <div>boundary/not-found.tsx</div>;
+}

--- a/packages/react-server/examples/basic/src/routes/test/error/boundary/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/error/boundary/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>boundary/page.tsx</div>;
+}

--- a/packages/react-server/examples/basic/src/routes/test/error/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/error/layout.tsx
@@ -15,6 +15,7 @@ export default function Layout(props: LayoutProps) {
           "/test/error/use-client",
           "/test/error/use-server",
           "/test/error/hydration",
+          "/test/error/boundary",
         ]}
       />
       <div>{props.children}</div>

--- a/packages/react-server/src/features/error/error-boundary.tsx
+++ b/packages/react-server/src/features/error/error-boundary.tsx
@@ -99,16 +99,13 @@ export class RedirectBoundary extends React.Component<React.PropsWithChildren> {
     { error: null };
 
   static getDerivedStateFromError(error: Error) {
-    // TODO: can remove?
-    if (!import.meta.env.SSR) {
-      const ctx = getErrorContext(error);
-      const redirect = ctx && isRedirectError(ctx);
-      if (redirect) {
-        return {
-          error,
-          redirectLocation: redirect.location,
-        } satisfies RedirectBoundary["state"];
-      }
+    const ctx = getErrorContext(error);
+    const redirect = ctx && isRedirectError(ctx);
+    if (redirect) {
+      return {
+        error,
+        redirectLocation: redirect.location,
+      } satisfies RedirectBoundary["state"];
     }
     throw error;
   }

--- a/packages/react-server/src/features/error/shared.ts
+++ b/packages/react-server/src/features/error/shared.ts
@@ -36,6 +36,10 @@ export function isRedirectError(ctx: ReactServerErrorContext) {
   return false;
 }
 
+export function isNotFoundError(ctx: ReactServerErrorContext) {
+  return ctx.status === 404;
+}
+
 export function getErrorContext(
   error: unknown,
 ): ReactServerErrorContext | undefined {


### PR DESCRIPTION
Now that we have a special semantics for redirect error and not found error, our general `ErrorBoundary` shouldn't catch those.

## todo

- [x] test