### PR TITLE
feat(next)!: expose `ReactServerPluginOptions`

### DIFF
--- a/packages/react-server-next/src/vite/index.ts
+++ b/packages/react-server-next/src/vite/index.ts
@@ -24,6 +24,7 @@ export default function vitePluginReactServerNext(
     react(),
     tsconfigPaths(),
     vitePluginReactServer({
+      ...options,
       routeDir: options?.routeDir ?? "app",
       plugins: [
         tsconfigPaths(),
@@ -37,7 +38,6 @@ export default function vitePluginReactServerNext(
         },
         ...(options?.plugins ?? []),
       ],
-      prerender: options?.prerender,
     }),
     vitePluginLogger(),
     vitePluginSsrMiddleware({

--- a/packages/react-server-next/src/vite/index.ts
+++ b/packages/react-server-next/src/vite/index.ts
@@ -1,6 +1,9 @@
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
-import { vitePluginReactServer } from "@hiogawa/react-server/plugin";
+import {
+  type ReactServerPluginOptions,
+  vitePluginReactServer,
+} from "@hiogawa/react-server/plugin";
 import {
   vitePluginLogger,
   vitePluginSsrMiddleware,
@@ -10,15 +13,18 @@ import type { Plugin, PluginOption } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 import { type AdapterType, adapterPlugin } from "./adapters";
 
-export default function vitePluginReactServerNext(options?: {
-  plugins?: PluginOption[];
+export type ReactServerNextPluginOptions = {
   adapter?: AdapterType;
-}): PluginOption {
+};
+
+export default function vitePluginReactServerNext(
+  options?: ReactServerNextPluginOptions & ReactServerPluginOptions,
+): PluginOption {
   return [
     react(),
     tsconfigPaths(),
     vitePluginReactServer({
-      routeDir: "app",
+      routeDir: options?.routeDir ?? "app",
       plugins: [
         tsconfigPaths(),
         {
@@ -31,9 +37,7 @@ export default function vitePluginReactServerNext(options?: {
         },
         ...(options?.plugins ?? []),
       ],
-      // for now, we only enable generateStaticParams for the app route demo
-      // https://github.com/hi-ogawa/next-app-router-playground/pull/1
-      prerender: (_manifest, presets) => presets.generateStaticParams(),
+      prerender: options?.prerender,
     }),
     vitePluginLogger(),
     vitePluginSsrMiddleware({

--- a/packages/react-server-next/src/vite/index.ts
+++ b/packages/react-server-next/src/vite/index.ts
@@ -18,7 +18,7 @@ export type ReactServerNextPluginOptions = {
 };
 
 export default function vitePluginReactServerNext(
-  options?: ReactServerNextPluginOptions & ReactServerPluginOptions,
+  options?: ReactServerPluginOptions & ReactServerNextPluginOptions,
 ): PluginOption {
   return [
     react(),

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -116,14 +116,18 @@ const manager: PluginStateManager = ((
   globalThis as any
 ).__VITE_REACT_SERVER_MANAGER ??= new PluginStateManager());
 
-export function vitePluginReactServer(options?: {
+export type ReactServerPluginOptions = {
   plugins?: PluginOption[];
   prerender?: PrerenderFn;
   entryBrowser?: string;
   entryServer?: string;
   routeDir?: string;
   noAsyncLocalStorage?: boolean;
-}): Plugin[] {
+};
+
+export function vitePluginReactServer(
+  options?: ReactServerPluginOptions,
+): Plugin[] {
   const entryBrowser =
     options?.entryBrowser ?? "@hiogawa/react-server/entry/browser";
   const entryServer =


### PR DESCRIPTION
Minor cleanup to properly structure `ReactServerPluginOptions` and `ReactServerNextPluginOptions` so that it allows `routeDir: "src/app"` for example.

Technically breaking since I need to manually add `prerender: (_manifest, presets) => presets.generateStaticParams()` in https://github.com/hi-ogawa/next-app-router-playground/pull/1