### PR TITLE
chore: remove unused deps

### DIFF
--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -43,14 +43,12 @@
   "dependencies": {
     "@edge-runtime/cookies": "^4.1.1",
     "@hiogawa/transforms": "workspace:*",
-    "@hiogawa/vite-plugin-ssr-middleware": "workspace:*",
     "@tanstack/history": "^1.15.13",
     "es-module-lexer": "^1.4.1",
     "fast-glob": "^3.3.2",
     "use-sync-external-store": "^1.2.0"
   },
   "devDependencies": {
-    "@hiogawa/utils-node": "^0.0.1",
     "@types/estree": "^1.0.5",
     "@types/use-sync-external-store": "^0.0.6"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,9 +98,6 @@ importers:
       '@hiogawa/transforms':
         specifier: workspace:*
         version: link:../transforms
-      '@hiogawa/vite-plugin-ssr-middleware':
-        specifier: workspace:*
-        version: link:../vite-plugin-ssr-middleware
       '@tanstack/history':
         specifier: ^1.15.13
         version: 1.15.13
@@ -126,9 +123,6 @@ importers:
         specifier: ^5.3.3
         version: 5.3.3(@types/node@20.14.10)(terser@5.31.1)
     devDependencies:
-      '@hiogawa/utils-node':
-        specifier: ^0.0.1
-        version: 0.0.1
       '@types/estree':
         specifier: ^1.0.5
         version: 1.0.5


### PR DESCRIPTION
Forgot to remove these deps when they are moved to `react-server-next` compat package
- https://github.com/hi-ogawa/vite-plugins/pull/413
- https://github.com/hi-ogawa/vite-plugins/pull/418