### PR TITLE
feat: support wasm module asset

### DIFF
--- a/packages/react-server-next/src/vite/adapters/cloudflare/build.ts
+++ b/packages/react-server-next/src/vite/adapters/cloudflare/build.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { PrerenderManifest } from "@hiogawa/react-server/plugin";
-import { bundleEdge } from "../shared";
+import { bundleEntry } from "../shared";
 
 export async function build({ outDir }: { outDir: string }) {
   const buildDir = join(process.cwd(), outDir);
@@ -51,7 +51,7 @@ export async function build({ outDir }: { outDir: string }) {
 
   // worker
   // https://developers.cloudflare.com/pages/functions/advanced-mode/
-  await bundleEdge(buildDir, {
+  await bundleEntry(buildDir, {
     entryPoints: [join(buildDir, "server/index.js")],
     outfile: join(adapterOutDir, "_worker.js"),
   });

--- a/packages/react-server-next/src/vite/adapters/cloudflare/build.ts
+++ b/packages/react-server-next/src/vite/adapters/cloudflare/build.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { PrerenderManifest } from "@hiogawa/react-server/plugin";
+import { bundleEdge } from "../shared";
 
 export async function build({ outDir }: { outDir: string }) {
   const buildDir = join(process.cwd(), outDir);
@@ -50,27 +51,10 @@ export async function build({ outDir }: { outDir: string }) {
 
   // worker
   // https://developers.cloudflare.com/pages/functions/advanced-mode/
-  const esbuild = await import("esbuild");
-  const result = await esbuild.build({
+  await bundleEdge(buildDir, {
     entryPoints: [join(buildDir, "server/index.js")],
     outfile: join(adapterOutDir, "_worker.js"),
-    bundle: true,
-    minify: true,
-    metafile: true,
-    format: "esm",
-    platform: "browser",
-    external: ["node:async_hooks"],
-    define: {
-      "process.env.NODE_ENV": `"production"`,
-    },
-    logOverride: {
-      "ignored-bare-import": "silent",
-    },
   });
-  await writeFile(
-    join(buildDir, "esbuild-metafile.json"),
-    JSON.stringify(result.metafile),
-  );
 }
 
 async function getPrerenderPaths(buildDir: string) {

--- a/packages/react-server-next/src/vite/adapters/shared.ts
+++ b/packages/react-server-next/src/vite/adapters/shared.ts
@@ -5,7 +5,7 @@ import type { BuildOptions } from "esbuild";
 // cf.
 // https://github.com/sveltejs/kit/blob/144fb75c8280695d8aeb3228904bebb262e171a7/packages/adapter-cloudflare/index.js
 
-export async function bundleEdge(buildDir: string, options: BuildOptions) {
+export async function bundleEntry(buildDir: string, options: BuildOptions) {
   const esbuild = await import("esbuild");
   const result = await esbuild.build({
     bundle: true,

--- a/packages/react-server-next/src/vite/adapters/shared.ts
+++ b/packages/react-server-next/src/vite/adapters/shared.ts
@@ -1,0 +1,32 @@
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { BuildOptions } from "esbuild";
+
+// cf.
+// https://github.com/sveltejs/kit/blob/144fb75c8280695d8aeb3228904bebb262e171a7/packages/adapter-cloudflare/index.js
+
+export async function bundleEdge(buildDir: string, options: BuildOptions) {
+  const esbuild = await import("esbuild");
+  const result = await esbuild.build({
+    bundle: true,
+    minify: true,
+    metafile: true,
+    format: "esm",
+    platform: "browser",
+    external: ["node:async_hooks"],
+    define: {
+      "process.env.NODE_ENV": `"production"`,
+    },
+    logOverride: {
+      "ignored-bare-import": "silent",
+    },
+    loader: {
+      ".wasm": "copy",
+    },
+    ...options,
+  });
+  await writeFile(
+    join(buildDir, "esbuild-metafile.json"),
+    JSON.stringify(result.metafile),
+  );
+}

--- a/packages/react-server-next/src/vite/adapters/vercel/build.ts
+++ b/packages/react-server-next/src/vite/adapters/vercel/build.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { PrerenderManifest } from "@hiogawa/react-server/plugin";
+import { bundleEdge } from "../shared";
 
 const configJson = {
   version: 3,
@@ -93,27 +94,10 @@ export async function build({
   );
 
   // bundle function
-  const esbuild = await import("esbuild");
-  const result = await esbuild.build({
+  await bundleEdge(buildDir, {
     entryPoints: [join(buildDir, "server/index.js")],
-    outfile: join(adapterOutDir, "functions/index.func/index.mjs"),
-    metafile: true,
-    bundle: true,
-    minify: true,
-    format: "esm",
-    platform: runtime === "node" ? "node" : "browser",
-    external: ["node:async_hooks"],
-    define: {
-      "process.env.NODE_ENV": `"production"`,
-    },
-    logOverride: {
-      "ignored-bare-import": "silent",
-    },
+    outfile: join(adapterOutDir, "functions/index.func/index.js"),
   });
-  await writeFile(
-    join(buildDir, "esbuild-metafile.json"),
-    JSON.stringify(result.metafile),
-  );
 }
 
 async function getPrerenderManifest(buildDir: string) {

--- a/packages/react-server-next/src/vite/adapters/vercel/build.ts
+++ b/packages/react-server-next/src/vite/adapters/vercel/build.ts
@@ -97,6 +97,7 @@ export async function build({
   await bundleEdge(buildDir, {
     entryPoints: [join(buildDir, "server/index.js")],
     outfile: join(adapterOutDir, "functions/index.func/index.js"),
+    platform: runtime === "node" ? "node" : "browser",
   });
 }
 

--- a/packages/react-server-next/src/vite/adapters/vercel/build.ts
+++ b/packages/react-server-next/src/vite/adapters/vercel/build.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { PrerenderManifest } from "@hiogawa/react-server/plugin";
-import { bundleEdge } from "../shared";
+import { bundleEntry } from "../shared";
 
 const configJson = {
   version: 3,
@@ -94,7 +94,7 @@ export async function build({
   );
 
   // bundle function
-  await bundleEdge(buildDir, {
+  await bundleEntry(buildDir, {
     entryPoints: [join(buildDir, "server/index.js")],
     outfile: join(adapterOutDir, "functions/index.func/index.js"),
     platform: runtime === "node" ? "node" : "browser",

--- a/packages/react-server/examples/wasm/README.md
+++ b/packages/react-server/examples/wasm/README.md
@@ -1,0 +1,1 @@
+minimal template for testing

--- a/packages/react-server/examples/wasm/app/layout.tsx
+++ b/packages/react-server/examples/wasm/app/layout.tsx
@@ -1,0 +1,12 @@
+import type React from "react";
+
+export default function Layout(props: React.PropsWithChildren) {
+  return (
+    <html>
+      <body>
+        <div>[Layout]</div>
+        {props.children}
+      </body>
+    </html>
+  );
+}

--- a/packages/react-server/examples/wasm/app/page.tsx
+++ b/packages/react-server/examples/wasm/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>[Page]</div>;
+}

--- a/packages/react-server/examples/wasm/app/wasm/route.tsx
+++ b/packages/react-server/examples/wasm/app/wasm/route.tsx
@@ -1,0 +1,13 @@
+// import someWasm from "./test.wasm";
+// TODO:
+// - dev: replace with
+//     export default WebAssembly.compile(...)
+// - build: need esbuild-like copy loader for all three steps
+//     server build
+//     ssr build
+//     adapter bundle
+
+export function GET(request: Request) {
+  request;
+  return new Response("hello");
+}

--- a/packages/react-server/examples/wasm/package.json
+++ b/packages/react-server/examples/wasm/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@hiogawa/react-server-example-wasm",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@hiogawa/react-server": "workspace:*",
+    "next": "link:../../../react-server-next",
+    "react": "rc",
+    "react-dom": "rc",
+    "react-server-dom-webpack": "rc"
+  },
+  "devDependencies": {
+    "@types/react": "latest",
+    "@types/react-dom": "latest",
+    "vite": "latest"
+  }
+}

--- a/packages/react-server/examples/wasm/tsconfig.json
+++ b/packages/react-server/examples/wasm/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "include": ["**/*.ts", "**/*.tsx"],
+  "compilerOptions": {
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "moduleResolution": "Bundler",
+    "module": "ESNext",
+    "target": "ESNext",
+    "lib": ["ESNext", "DOM"],
+    "types": ["next"],
+    "jsx": "react-jsx"
+  }
+}

--- a/packages/react-server/examples/wasm/vite.config.ts
+++ b/packages/react-server/examples/wasm/vite.config.ts
@@ -1,0 +1,6 @@
+import next from "next/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [next()],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -500,14 +500,14 @@ importers:
         specifier: link:../../../react-server-next
         version: link:../../../react-server-next
       react:
-        specifier: 19.0.0-rc-c21bcd627b-20240624
-        version: 19.0.0-rc-c21bcd627b-20240624
+        specifier: 19.0.0-rc-df5f2736-20240712
+        version: 19.0.0-rc-df5f2736-20240712
       react-dom:
-        specifier: 19.0.0-rc-c21bcd627b-20240624
-        version: 19.0.0-rc-c21bcd627b-20240624(react@19.0.0-rc-c21bcd627b-20240624)
+        specifier: 19.0.0-rc-df5f2736-20240712
+        version: 19.0.0-rc-df5f2736-20240712(react@19.0.0-rc-df5f2736-20240712)
       react-server-dom-webpack:
-        specifier: 19.0.0-rc-c21bcd627b-20240624
-        version: 19.0.0-rc-c21bcd627b-20240624(react-dom@19.0.0-rc-c21bcd627b-20240624(react@19.0.0-rc-c21bcd627b-20240624))(react@19.0.0-rc-c21bcd627b-20240624)(webpack@5.92.1(esbuild@0.23.0))
+        specifier: 19.0.0-rc-df5f2736-20240712
+        version: 19.0.0-rc-df5f2736-20240712(react-dom@19.0.0-rc-df5f2736-20240712(react@19.0.0-rc-df5f2736-20240712))(react@19.0.0-rc-df5f2736-20240712)(webpack@5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.12))(esbuild@0.23.0))
     devDependencies:
       '@types/react':
         specifier: 18.3.3
@@ -517,7 +517,7 @@ importers:
         version: 18.3.0
       vite:
         specifier: ^5.3.3
-        version: 5.3.3(@types/node@20.14.10)(terser@5.31.1)
+        version: 5.3.3(@types/node@20.14.10)(terser@5.31.2)
 
   packages/ssr-css:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -491,6 +491,34 @@ importers:
         specifier: ^5.3.3
         version: 5.3.3(@types/node@20.14.10)(terser@5.31.2)
 
+  packages/react-server/examples/wasm:
+    dependencies:
+      '@hiogawa/react-server':
+        specifier: workspace:*
+        version: link:../..
+      next:
+        specifier: link:../../../react-server-next
+        version: link:../../../react-server-next
+      react:
+        specifier: 19.0.0-rc-c21bcd627b-20240624
+        version: 19.0.0-rc-c21bcd627b-20240624
+      react-dom:
+        specifier: 19.0.0-rc-c21bcd627b-20240624
+        version: 19.0.0-rc-c21bcd627b-20240624(react@19.0.0-rc-c21bcd627b-20240624)
+      react-server-dom-webpack:
+        specifier: 19.0.0-rc-c21bcd627b-20240624
+        version: 19.0.0-rc-c21bcd627b-20240624(react-dom@19.0.0-rc-c21bcd627b-20240624(react@19.0.0-rc-c21bcd627b-20240624))(react@19.0.0-rc-c21bcd627b-20240624)(webpack@5.92.1(esbuild@0.23.0))
+    devDependencies:
+      '@types/react':
+        specifier: 18.3.3
+        version: 18.3.3
+      '@types/react-dom':
+        specifier: 18.3.0
+        version: 18.3.0
+      vite:
+        specifier: ^5.3.3
+        version: 5.3.3(@types/node@20.14.10)(terser@5.31.1)
+
   packages/ssr-css:
     dependencies:
       vite:


### PR DESCRIPTION
- part of https://github.com/hi-ogawa/vite-plugins/pull/547
  - https://developers.cloudflare.com/pages/functions/module-support/#webassembly-modules

This already doesn't looks so trivial and I'm not sure if sveltekit (or any Vite framework) actually supports this pattern for both dev and build.

Clearly this is harder than basic binary assets, so maybe we should try that first:
- https://developers.cloudflare.com/pages/functions/module-support/#binary-modules

---

Also I'm not sure how Next.js is actually deploying edge assets, so we need to research that first.