### PR TITLE
refactor: use own `useSyncExternalStoreWithSelector`

### DIFF
--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -45,12 +45,10 @@
     "@hiogawa/transforms": "workspace:*",
     "@tanstack/history": "^1.15.13",
     "es-module-lexer": "^1.4.1",
-    "fast-glob": "^3.3.2",
-    "use-sync-external-store": "^1.2.0"
+    "fast-glob": "^3.3.2"
   },
   "devDependencies": {
-    "@types/estree": "^1.0.5",
-    "@types/use-sync-external-store": "^0.0.6"
+    "@types/estree": "^1.0.5"
   },
   "peerDependencies": {
     "react": "*",

--- a/packages/react-server/src/features/router/client/store-utils.tsx
+++ b/packages/react-server/src/features/router/client/store-utils.tsx
@@ -1,4 +1,4 @@
-import { useSyncExternalStoreWithSelector } from "use-sync-external-store/shim/with-selector.js";
+import React from "react";
 
 // tanstack-style selectable store
 // https://github.com/TanStack/router/blob/876b887589b14fb4bce0773eb520417682a741e2/packages/react-router/src/useRouterState.tsx
@@ -14,9 +14,8 @@ export function useStore<T, U = T>(
   store: ReadableStore<T>,
   select: (v: T) => U = (v: T) => v as any,
 ): U {
-  const v = useSyncExternalStoreWithSelector(
+  const v = useSyncExternalStoreWithSelectorDIY(
     store.subscribe,
-    store.get,
     store.get,
     select as any,
     isEqualShallow,
@@ -67,4 +66,17 @@ function isEqualShallow(x: object, y: object): boolean {
     }
   }
   return true;
+}
+
+// https://github.com/facebook/react/blob/f09e1599d631051a559974578a6d4c06effd95eb/packages/use-sync-external-store/src/useSyncExternalStoreWithSelector.js
+function useSyncExternalStoreWithSelectorDIY<Snapshot, Selection>(
+  subscribe: (onStoreChange: () => void) => () => void,
+  getSnapshot: () => Snapshot,
+  selector: (snapshot: Snapshot) => Selection,
+  isEqual: (a: Selection, b: Selection) => boolean,
+): Selection {
+  subscribe;
+  isEqual;
+  React.useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  return selector(getSnapshot());
 }

--- a/packages/react-server/src/features/router/client/store-utils.tsx
+++ b/packages/react-server/src/features/router/client/store-utils.tsx
@@ -3,7 +3,6 @@ import React from "react";
 // tanstack-style selectable store
 // https://github.com/TanStack/router/blob/876b887589b14fb4bce0773eb520417682a741e2/packages/react-router/src/useRouterState.tsx
 // https://github.com/TanStack/store/blob/8d6faa0c8eb54b5b1070148311e43bb011a929f9/packages/react-store/src/index.ts
-// https://github.com/facebook/react/blob/f09e1599d631051a559974578a6d4c06effd95eb/packages/use-sync-external-store/src/useSyncExternalStoreWithSelector.js
 
 interface ReadableStore<T> {
   get: () => T;

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -289,7 +289,6 @@ export function vitePluginReactServer(
             "react-dom/client",
             "react-server-dom-webpack/client.browser",
             "@hiogawa/react-server > @tanstack/history",
-            "@hiogawa/react-server > use-sync-external-store/shim/with-selector.js",
             "@hiogawa/react-server > @edge-runtime/cookies",
           ],
         },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,9 +116,6 @@ importers:
       react-server-dom-webpack:
         specifier: 19.0.0-rc-c21bcd627b-20240624
         version: 19.0.0-rc-c21bcd627b-20240624(react-dom@19.0.0-rc-c21bcd627b-20240624(react@19.0.0-rc-c21bcd627b-20240624))(react@19.0.0-rc-c21bcd627b-20240624)(webpack@5.92.1(esbuild@0.23.0))
-      use-sync-external-store:
-        specifier: ^1.2.0
-        version: 1.2.0(react@19.0.0-rc-c21bcd627b-20240624)
       vite:
         specifier: ^5.3.3
         version: 5.3.3(@types/node@20.14.10)(terser@5.31.1)
@@ -126,9 +123,6 @@ importers:
       '@types/estree':
         specifier: ^1.0.5
         version: 1.0.5
-      '@types/use-sync-external-store':
-        specifier: ^0.0.6
-        version: 0.0.6
 
   packages/react-server-next:
     dependencies:
@@ -2405,9 +2399,6 @@ packages:
 
   '@types/unist@2.0.10':
     resolution: {integrity: sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA==}
-
-  '@types/use-sync-external-store@0.0.6':
-    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@unocss/astro@0.58.6':
     resolution: {integrity: sha512-0BvbhEp5Ln6wFNnhISusB2hcfycWkdgnjlFMcLT69efvj4G39MzB6JYT/1qiidLfpj35HcqkpBz7TfZ4bUmOAw==}
@@ -4951,11 +4942,6 @@ packages:
   urlpattern-polyfill@10.0.0:
     resolution: {integrity: sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==}
 
-  use-sync-external-store@1.2.0:
-    resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
-    peerDependencies:
-      react: 19.0.0-rc-c21bcd627b-20240624
-
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -6609,8 +6595,6 @@ snapshots:
       '@types/node': 20.11.28
 
   '@types/unist@2.0.10': {}
-
-  '@types/use-sync-external-store@0.0.6': {}
 
   '@unocss/astro@0.58.6(rollup@4.18.1)(vite@5.3.3(@types/node@20.14.10)(terser@5.31.1))':
     dependencies:
@@ -9616,10 +9600,6 @@ snapshots:
       punycode: 2.3.1
 
   urlpattern-polyfill@10.0.0: {}
-
-  use-sync-external-store@1.2.0(react@19.0.0-rc-c21bcd627b-20240624):
-    dependencies:
-      react: 19.0.0-rc-c21bcd627b-20240624
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/vite-plugins/issues/542

Just created a mini version and hopefully this works fine.