### PR TITLE
feat: support middleware

### DIFF
--- a/packages/react-server-next/src/compat/server.tsx
+++ b/packages/react-server-next/src/compat/server.tsx
@@ -1,7 +1,1 @@
-/** @todo */
-export class NextRequest extends Request {
-  nextUrl!: URL;
-}
-
-/** @todo */
-export class NextResponse extends Response {}
+export { NextRequest, NextResponse } from "@hiogawa/react-server/server";

--- a/packages/react-server/examples/next/e2e/basic.test.ts
+++ b/packages/react-server/examples/next/e2e/basic.test.ts
@@ -96,3 +96,29 @@ testNoJs("image preload", async ({ page }) => {
     page.locator('link[href="https://nextjs.org/icons/vercel.svg"]'),
   ).not.toHaveAttribute("fetchPriority", "high");
 });
+
+test("middleware", async ({ request }) => {
+  {
+    const res = await request.get("/test/middleware/response");
+    expect(res.status()).toBe(200);
+    expect(await res.json()).toEqual({
+      hello: ["from", "middleware"],
+    });
+  }
+
+  {
+    const res = await request.get("/test/middleware/headers");
+    expect(res.status()).toBe(404);
+    expect(res.headers()).toMatchObject({
+      "x-hello": "world",
+    });
+  }
+
+  {
+    const res = await request.get("/test/middleware/cookies");
+    expect(res.status()).toBe(404);
+    expect(res.headers()).toMatchObject({
+      "set-cookie": "x-hello=world; Path=/",
+    });
+  }
+});

--- a/packages/react-server/examples/next/middleware.ts
+++ b/packages/react-server/examples/next/middleware.ts
@@ -1,9 +1,9 @@
-import { NextResponse } from "next/server";
+import { type NextRequest, NextResponse } from "next/server";
 
-export function middleware(request: Request) {
+export function middleware(request: NextRequest) {
   const url = new URL(request.url);
   if (url.pathname == "/test-middleware") {
-    return new Response("hello");
+    return NextResponse.json({ hello: ["from", "middleware"] });
   }
   return NextResponse.next();
 }

--- a/packages/react-server/examples/next/middleware.ts
+++ b/packages/react-server/examples/next/middleware.ts
@@ -1,0 +1,15 @@
+// https://nextjs.org/docs/app/api-reference/file-conventions/middleware
+
+// TODO
+// - server request interception
+// - matcher
+// - NextResponse.next
+// - NextRequest
+
+export function middleware(_request: Request) {
+  return new Response("hello");
+}
+
+export const config = {
+  matcher: "/about/:path*",
+};

--- a/packages/react-server/examples/next/middleware.ts
+++ b/packages/react-server/examples/next/middleware.ts
@@ -1,7 +1,9 @@
-export function middleware(_request: Request) {
-  return new Response("hello");
-}
+import { NextResponse } from "next/server";
 
-export const config = {
-  matcher: "/about/:path*",
-};
+export function middleware(request: Request) {
+  const url = new URL(request.url);
+  if (url.pathname == "/test-middleware") {
+    return new Response("hello");
+  }
+  return NextResponse.next();
+}

--- a/packages/react-server/examples/next/middleware.ts
+++ b/packages/react-server/examples/next/middleware.ts
@@ -1,11 +1,3 @@
-// https://nextjs.org/docs/app/api-reference/file-conventions/middleware
-
-// TODO
-// - server request interception
-// - matcher
-// - NextResponse.next
-// - NextRequest
-
 export function middleware(_request: Request) {
   return new Response("hello");
 }

--- a/packages/react-server/examples/next/middleware.ts
+++ b/packages/react-server/examples/next/middleware.ts
@@ -1,9 +1,19 @@
 import { type NextRequest, NextResponse } from "next/server";
 
-export function middleware(request: NextRequest) {
+export default function middleware(request: NextRequest) {
   const url = new URL(request.url);
-  if (url.pathname == "/test-middleware") {
+  if (url.pathname == "/test/middleware/response") {
     return NextResponse.json({ hello: ["from", "middleware"] });
+  }
+  if (url.pathname == "/test/middleware/headers") {
+    const response = NextResponse.next();
+    response.headers.set("x-hello", "world");
+    return response;
+  }
+  if (url.pathname == "/test/middleware/cookies") {
+    const response = NextResponse.next();
+    response.cookies.set("x-hello", "world");
+    return response;
   }
   return NextResponse.next();
 }

--- a/packages/react-server/src/entry/server.tsx
+++ b/packages/react-server/src/entry/server.tsx
@@ -64,7 +64,12 @@ export const handler: ReactServerHandler = async (ctx) => {
   const requestContext = new RequestContext(ctx.request.headers);
 
   if (serverRoutes.middleware) {
-    await handleMiddleware(serverRoutes.middleware, requestContext);
+    const response = await handleMiddleware(
+      serverRoutes.middleware,
+      ctx.request,
+      requestContext,
+    );
+    if (response) return response;
   }
 
   const handledApi = await handleApiRoutes(

--- a/packages/react-server/src/entry/server.tsx
+++ b/packages/react-server/src/entry/server.tsx
@@ -44,6 +44,7 @@ export interface ReactServerHandlerContext {
 export interface ReactServerHandlerStreamResult {
   stream: ReadableStream<Uint8Array>;
   status: number;
+  requestContext: RequestContext;
   actionResult?: ActionResult;
 }
 
@@ -136,13 +137,18 @@ export const handler: ReactServerHandler = async (ctx) => {
   if (isStream) {
     return new Response(stream, {
       headers: {
-        ...actionResult?.responseHeaders,
+        ...requestContext.getResponseHeaders(),
         "content-type": "text/x-component; charset=utf-8",
       },
     });
   }
 
-  return { stream, actionResult, status: result.notFound ? 404 : 200 };
+  return {
+    stream,
+    actionResult,
+    requestContext,
+    status: result.notFound ? 404 : 200,
+  };
 };
 
 const reactServerOnError: RenderToReadableStreamOptions["onError"] = (
@@ -207,11 +213,9 @@ async function actionHandler({
     result.data = await requestContext.run(() => boundAction());
   } catch (e) {
     result.error = getErrorContext(e) ?? DEFAULT_ERROR_CONTEXT;
-  } finally {
-    result.responseHeaders = {
-      ...result.error?.headers,
-      "set-cookie": requestContext.getSetCookie(),
-    };
+  }
+  if (result.error?.headers) {
+    requestContext.mergeResponseHeaders(new Headers(result.error?.headers));
   }
   return result;
 }

--- a/packages/react-server/src/entry/ssr.tsx
+++ b/packages/react-server/src/entry/ssr.tsx
@@ -184,7 +184,12 @@ export async function renderHtml(
   } catch (e) {
     const ctx = getErrorContext(e) ?? DEFAULT_ERROR_CONTEXT;
     if (isRedirectError(ctx)) {
-      return new Response(null, { status: ctx.status, headers: ctx.headers });
+      return result.requestContext.injectResponseHeaders(
+        new Response(null, {
+          status: ctx.status,
+          headers: ctx.headers,
+        }),
+      );
     }
     status = ctx.status;
     // render empty as error fallback and
@@ -218,7 +223,7 @@ export async function renderHtml(
   return new Response(htmlStream, {
     status,
     headers: {
-      ...result.actionResult?.responseHeaders,
+      ...result.requestContext.getResponseHeaders(),
       "content-type": "text/html;charset=utf-8",
     },
   });

--- a/packages/react-server/src/features/next/cookie.ts
+++ b/packages/react-server/src/features/next/cookie.ts
@@ -22,25 +22,16 @@ export function createNextCookies(requestHeaders: Headers) {
     return responseCookies;
   }
 
-  return { cookies, toResponseCookies };
-}
+  function mergeSetCookie(headers: Headers) {
+    const newCookies = new ResponseCookies(headers);
+    for (const cookie of newCookies.getAll()) {
+      cookies.set(cookie);
+    }
+  }
 
-export function injectResponseCookies(
-  response: Response,
-  cookies: ResponseCookies,
-): Response {
-  const entries = cookies.getAll();
-  if (entries.length === 0) {
-    return response;
+  function toSetCookie() {
+    return toResponseCookies().toString();
   }
-  const responseCookies = new ResponseCookies(response.headers);
-  for (const entry of entries) {
-    responseCookies.set(entry);
-  }
-  const headers = new Headers(response.headers);
-  headers.set("set-cookie", responseCookies.toString());
-  return new Response(response.body, {
-    ...response,
-    headers,
-  });
+
+  return { cookies, mergeSetCookie, toSetCookie };
 }

--- a/packages/react-server/src/features/next/middleware.ts
+++ b/packages/react-server/src/features/next/middleware.ts
@@ -1,14 +1,23 @@
 import type { RequestContext } from "../request-context/server";
-import { NEXT_HANDLER_KEY, NextRequest, NextResponse } from "./request";
+import {
+  NEXT_HANDLER_KEY,
+  type NextFetchEvent,
+  NextRequest,
+  NextResponse,
+} from "./request";
 
 // https://nextjs.org/docs/app/api-reference/file-conventions/middleware
+// https://nextjs.org/docs/app/building-your-application/routing/middleware
 
 // first goal is to support next-auth
 // https://github.com/nextauthjs/next-auth/blob/a3d3d4bab3e037a5359ed22de8b1fff0b5557523/packages/next-auth/src/index.ts#L86
 // https://github.com/nextauthjs/next-auth/blob/a3d3d4bab3e037a5359ed22de8b1fff0b5557523/packages/next-auth/src/lib/index.ts#L3
 
 export type MiddlewareModule = {
-  middleware: (request: NextRequest) => Promise<Response>;
+  middleware: (
+    request: NextRequest,
+    event: NextFetchEvent,
+  ) => Promise<Response | undefined>;
   config?: { matcher: string };
 };
 
@@ -26,14 +35,15 @@ export async function handleMiddleware(
     headers: request.headers,
   });
 
-  const response = await middleware(nextRequest);
+  const response = await middleware(nextRequest, { waitUntil: () => {} });
+  if (!response) return;
+
   if (response instanceof NextResponse) {
     response.headers.set("set-cookie", response.cookies.toString());
   }
 
-  // add up headers to context if `NextResponse.next()`
+  // TODO: add up headers to context if `NextResponse.next()`
   if (response.headers.has(NEXT_HANDLER_KEY)) {
-    // TODO
     requestContext;
     return;
   }

--- a/packages/react-server/src/features/next/middleware.ts
+++ b/packages/react-server/src/features/next/middleware.ts
@@ -9,7 +9,7 @@ import type { NextRequest, NextResponse } from "./request";
 
 export type MiddlewareModule = {
   middleware: (request: NextRequest) => Promise<NextResponse>;
-  config: { matcher: string };
+  config?: { matcher: string };
 };
 
 export async function handleMiddleware(
@@ -17,7 +17,7 @@ export async function handleMiddleware(
   requestContext: RequestContext,
 ) {
   // TODO: matcher
-  config.matcher;
+  config?.matcher;
 
   // TODO
   // NextRequest

--- a/packages/react-server/src/features/next/middleware.ts
+++ b/packages/react-server/src/features/next/middleware.ts
@@ -1,0 +1,16 @@
+import type { RequestContext } from "../request-context/server";
+import type { NextRequest, NextResponse } from "./request";
+
+export type MiddlewareModule = {
+  middleware: (request: NextRequest) => Promise<NextResponse>;
+  config: { matcher: string };
+};
+
+export async function handleMiddleware(
+  module: MiddlewareModule,
+  requestContext: RequestContext,
+) {
+  module.config.matcher;
+  module.middleware;
+  requestContext;
+}

--- a/packages/react-server/src/features/next/middleware.ts
+++ b/packages/react-server/src/features/next/middleware.ts
@@ -1,6 +1,6 @@
 import type { RequestContext } from "../request-context/server";
 import {
-  NEXT_HANDLER_KEY,
+  MIDDLEWARE_NEXT_KEY,
   type NextFetchEvent,
   NextRequest,
   NextResponse,
@@ -43,7 +43,7 @@ export async function handleMiddleware(
   }
 
   // TODO: add up headers to context if `NextResponse.next()`
-  if (response.headers.has(NEXT_HANDLER_KEY)) {
+  if (response.headers.has(MIDDLEWARE_NEXT_KEY)) {
     requestContext;
     return;
   }

--- a/packages/react-server/src/features/next/middleware.ts
+++ b/packages/react-server/src/features/next/middleware.ts
@@ -9,10 +9,6 @@ import {
 // https://nextjs.org/docs/app/api-reference/file-conventions/middleware
 // https://nextjs.org/docs/app/building-your-application/routing/middleware
 
-// first goal is to support next-auth
-// https://github.com/nextauthjs/next-auth/blob/a3d3d4bab3e037a5359ed22de8b1fff0b5557523/packages/next-auth/src/index.ts#L86
-// https://github.com/nextauthjs/next-auth/blob/a3d3d4bab3e037a5359ed22de8b1fff0b5557523/packages/next-auth/src/lib/index.ts#L3
-
 export type MiddlewareModule = {
   default: (
     request: NextRequest,

--- a/packages/react-server/src/features/next/middleware.ts
+++ b/packages/react-server/src/features/next/middleware.ts
@@ -14,37 +14,36 @@ import {
 // https://github.com/nextauthjs/next-auth/blob/a3d3d4bab3e037a5359ed22de8b1fff0b5557523/packages/next-auth/src/lib/index.ts#L3
 
 export type MiddlewareModule = {
-  middleware: (
+  default: (
     request: NextRequest,
     event: NextFetchEvent,
   ) => Promise<Response | undefined>;
+  // TODO: matcher
   config?: { matcher: string };
 };
 
 export async function handleMiddleware(
-  { middleware, config }: MiddlewareModule,
+  mod: MiddlewareModule,
   request: Request,
   requestContext: RequestContext,
 ): Promise<Response | undefined> {
-  // TODO: matcher
-  config?.matcher;
-
   // TODO: POST body
   const nextRequest = new NextRequest(request.url, {
     method: request.method,
     headers: request.headers,
   });
 
-  const response = await middleware(nextRequest, { waitUntil: () => {} });
+  const response = await mod.default(nextRequest, { waitUntil: () => {} });
   if (!response) return;
 
   if (response instanceof NextResponse) {
     response.headers.set("set-cookie", response.cookies.toString());
   }
 
-  // TODO: add up headers to context if `NextResponse.next()`
+  // add up headers to context when `NextResponse.next()`
   if (response.headers.has(MIDDLEWARE_NEXT_KEY)) {
-    requestContext;
+    response.headers.delete(MIDDLEWARE_NEXT_KEY);
+    requestContext.mergeResponseHeaders(response.headers);
     return;
   }
 

--- a/packages/react-server/src/features/next/middleware.ts
+++ b/packages/react-server/src/features/next/middleware.ts
@@ -1,16 +1,27 @@
 import type { RequestContext } from "../request-context/server";
 import type { NextRequest, NextResponse } from "./request";
 
+// https://nextjs.org/docs/app/api-reference/file-conventions/middleware
+
+// first goal is to support next-auth
+// https://github.com/nextauthjs/next-auth/blob/a3d3d4bab3e037a5359ed22de8b1fff0b5557523/packages/next-auth/src/index.ts#L86
+// https://github.com/nextauthjs/next-auth/blob/a3d3d4bab3e037a5359ed22de8b1fff0b5557523/packages/next-auth/src/lib/index.ts#L3
+
 export type MiddlewareModule = {
   middleware: (request: NextRequest) => Promise<NextResponse>;
   config: { matcher: string };
 };
 
 export async function handleMiddleware(
-  module: MiddlewareModule,
+  { middleware, config }: MiddlewareModule,
   requestContext: RequestContext,
 ) {
-  module.config.matcher;
-  module.middleware;
+  // TODO: matcher
+  config.matcher;
+
+  // TODO
+  // NextRequest
+  // NextResponse (redirect, next)
+  middleware;
   requestContext;
 }

--- a/packages/react-server/src/features/next/request.ts
+++ b/packages/react-server/src/features/next/request.ts
@@ -30,13 +30,13 @@ export class NextResponse extends Response {
   }) {
     return new NextResponse(null, {
       headers: {
-        [NEXT_HANDLER_KEY]: "1",
+        [MIDDLEWARE_NEXT_KEY]: "1",
       },
     });
   }
 }
 
-export const NEXT_HANDLER_KEY = "x-middleware-next";
+export const MIDDLEWARE_NEXT_KEY = "x-middleware-next";
 
 /** @todo */
 export type NextFetchEvent = {

--- a/packages/react-server/src/features/next/request.ts
+++ b/packages/react-server/src/features/next/request.ts
@@ -19,13 +19,18 @@ export class NextResponse extends Response {
     this.cookies = new ResponseCookies(this.headers);
   }
 
-  static next() {
+  static next(_options?: {
+    request?: {
+      /** @todo */
+      headers?: Headers;
+    };
+  }) {
     return new NextResponse(null, {
       headers: {
-        [NEXT_RESPONSE_KEY]: "1",
+        [NEXT_HANDLER_KEY]: "1",
       },
     });
   }
 }
 
-export const NEXT_RESPONSE_KEY = "x-middleware-next";
+export const NEXT_HANDLER_KEY = "x-middleware-next";

--- a/packages/react-server/src/features/next/request.ts
+++ b/packages/react-server/src/features/next/request.ts
@@ -3,12 +3,12 @@ import { RequestCookies, ResponseCookies } from "@edge-runtime/cookies";
 // https://github.com/vercel/next.js/blob/48f62e059317f78f07d71541a20e81d68f78e298/packages/next/src/server/web/spec-extension/request.ts
 export class NextRequest extends Request {
   cookies: RequestCookies;
-  nextUrl: URL;
+  nextUrl: NextURL;
 
   constructor(...args: ConstructorParameters<typeof Request>) {
     super(...args);
     this.cookies = new RequestCookies(this.headers);
-    this.nextUrl = new URL(this.url);
+    this.nextUrl = new NextURL(this.url);
   }
 }
 
@@ -39,6 +39,12 @@ export class NextResponse extends Response {
 }
 
 export const MIDDLEWARE_NEXT_KEY = "x-middleware-next";
+
+class NextURL extends URL {
+  clone() {
+    return new NextURL(this);
+  }
+}
 
 /** @todo */
 export type NextFetchEvent = {

--- a/packages/react-server/src/features/next/request.ts
+++ b/packages/react-server/src/features/next/request.ts
@@ -1,9 +1,21 @@
-// initial target is to support next-auth
-// https://github.com/nextauthjs/next-auth/blob/a3d3d4bab3e037a5359ed22de8b1fff0b5557523/packages/next-auth/src/index.ts#L86
-// https://github.com/nextauthjs/next-auth/blob/a3d3d4bab3e037a5359ed22de8b1fff0b5557523/packages/next-auth/src/lib/index.ts#L3
+import { RequestCookies, ResponseCookies } from "@edge-runtime/cookies";
 
 // https://github.com/vercel/next.js/blob/48f62e059317f78f07d71541a20e81d68f78e298/packages/next/src/server/web/spec-extension/request.ts
-export class NextRequest extends Request {}
+export class NextRequest extends Request {
+  cookies: RequestCookies;
+
+  constructor(...args: ConstructorParameters<typeof Request>) {
+    super(...args);
+    this.cookies = new RequestCookies(this.headers);
+  }
+}
 
 // https://github.com/vercel/next.js/blob/48f62e059317f78f07d71541a20e81d68f78e298/packages/next/src/server/web/spec-extension/response.ts
-export class NextResponse extends Response {}
+export class NextResponse extends Response {
+  cookies: ResponseCookies;
+
+  constructor(...args: ConstructorParameters<typeof Response>) {
+    super(...args);
+    this.cookies = new ResponseCookies(this.headers);
+  }
+}

--- a/packages/react-server/src/features/next/request.ts
+++ b/packages/react-server/src/features/next/request.ts
@@ -3,10 +3,12 @@ import { RequestCookies, ResponseCookies } from "@edge-runtime/cookies";
 // https://github.com/vercel/next.js/blob/48f62e059317f78f07d71541a20e81d68f78e298/packages/next/src/server/web/spec-extension/request.ts
 export class NextRequest extends Request {
   cookies: RequestCookies;
+  nextUrl: URL;
 
   constructor(...args: ConstructorParameters<typeof Request>) {
     super(...args);
     this.cookies = new RequestCookies(this.headers);
+    this.nextUrl = new URL(this.url);
   }
 }
 

--- a/packages/react-server/src/features/next/request.ts
+++ b/packages/react-server/src/features/next/request.ts
@@ -1,0 +1,9 @@
+// initial target is to support next-auth
+// https://github.com/nextauthjs/next-auth/blob/a3d3d4bab3e037a5359ed22de8b1fff0b5557523/packages/next-auth/src/index.ts#L86
+// https://github.com/nextauthjs/next-auth/blob/a3d3d4bab3e037a5359ed22de8b1fff0b5557523/packages/next-auth/src/lib/index.ts#L3
+
+// https://github.com/vercel/next.js/blob/48f62e059317f78f07d71541a20e81d68f78e298/packages/next/src/server/web/spec-extension/request.ts
+export class NextRequest extends Request {}
+
+// https://github.com/vercel/next.js/blob/48f62e059317f78f07d71541a20e81d68f78e298/packages/next/src/server/web/spec-extension/response.ts
+export class NextResponse extends Response {}

--- a/packages/react-server/src/features/next/request.ts
+++ b/packages/react-server/src/features/next/request.ts
@@ -18,4 +18,14 @@ export class NextResponse extends Response {
     super(...args);
     this.cookies = new ResponseCookies(this.headers);
   }
+
+  static next() {
+    return new NextResponse(null, {
+      headers: {
+        [NEXT_RESPONSE_KEY]: "1",
+      },
+    });
+  }
 }
+
+export const NEXT_RESPONSE_KEY = "x-middleware-next";

--- a/packages/react-server/src/features/next/request.ts
+++ b/packages/react-server/src/features/next/request.ts
@@ -19,6 +19,9 @@ export class NextResponse extends Response {
     this.cookies = new ResponseCookies(this.headers);
   }
 
+  /** @todo */
+  static rewrite(..._args: unknown[]) {}
+
   static next(_options?: {
     request?: {
       /** @todo */
@@ -34,3 +37,8 @@ export class NextResponse extends Response {
 }
 
 export const NEXT_HANDLER_KEY = "x-middleware-next";
+
+/** @todo */
+export type NextFetchEvent = {
+  waitUntil(promise: Promise<unknown>): void;
+};

--- a/packages/react-server/src/features/router/api-route.ts
+++ b/packages/react-server/src/features/router/api-route.ts
@@ -1,4 +1,3 @@
-import { injectResponseCookies } from "../next/cookie";
 import type { RequestContext } from "../request-context/server";
 import type { RouteModuleTree } from "./server";
 import { type MatchParams, matchRouteTree, toMatchParams } from "./tree";
@@ -39,10 +38,7 @@ export async function handleApiRoutes(
       const response = await requestContext.run(() =>
         handler(request, { params }),
       );
-      return injectResponseCookies(
-        response,
-        requestContext.nextCookies.toResponseCookies(),
-      );
+      return requestContext.injectResponseHeaders(response);
     }
   }
   return;

--- a/packages/react-server/src/features/server-action/redirect.ts
+++ b/packages/react-server/src/features/server-action/redirect.ts
@@ -23,10 +23,7 @@ export function createActionRedirectResponse({
   const error = actionResult.error;
   const redirect = error && isRedirectError(error);
   if (redirect) {
-    const headers = new Headers({
-      ...actionResult.responseHeaders,
-      ...error.headers,
-    });
+    const headers = new Headers(requestContext.getResponseHeaders());
     if (isStream) {
       headers.delete("location");
       headers.set(

--- a/packages/react-server/src/features/server-action/server.tsx
+++ b/packages/react-server/src/features/server-action/server.tsx
@@ -22,7 +22,6 @@ export function registerServerReference(
 export type ActionResult = {
   error?: ReactServerErrorContext;
   data?: unknown;
-  responseHeaders?: Record<string, string>;
 };
 
 const REFERENCE_SEP = "#";

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -195,6 +195,9 @@ export function vitePluginReactServer(
               ([k, v]) => [k.slice("/${routeDir}".length), v]
             )
           );
+
+          const globMiddleware = import.meta.glob("/middleware.(js|jsx|ts|tsx)");
+          export const middleware = Object.values(globMiddleware)[0];
         `;
       }),
 

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -196,7 +196,7 @@ export function vitePluginReactServer(
             )
           );
 
-          const globMiddleware = import.meta.glob("/middleware.(js|jsx|ts|tsx)");
+          const globMiddleware = import.meta.glob("/middleware.(js|jsx|ts|tsx)", { eager: true });
           export const middleware = Object.values(globMiddleware)[0];
         `;
       }),

--- a/packages/react-server/src/plugin/virtual.d.ts
+++ b/packages/react-server/src/plugin/virtual.d.ts
@@ -1,4 +1,8 @@
 declare module "virtual:server-routes" {
   const $default: Record<string, any>;
   export default $default;
+
+  export const middleware:
+    | import("../features/next/middleware").MiddlewareModule
+    | undefined;
 }

--- a/packages/react-server/src/server.ts
+++ b/packages/react-server/src/server.ts
@@ -14,3 +14,4 @@ export {
   cookies,
   revalidatePath,
 } from "./features/request-context/server";
+export { NextRequest, NextResponse } from "./features/next/request";


### PR DESCRIPTION
## todo

- [x] basic interception, NextRequest, NextResponse
- [x] `NextResponse.redirect`
- [x] `NextResponse.next + cookies`
- [x] `NextRequest.nextUrl`
  - `clone`
- [x] test
- [x] test next-auth on https://github.com/hi-ogawa/next-learn/pull/1
  - [x] next-auth is adding `__Secure`. Probably we missed something in our next compat and thinking the request is https.
    - it was just next-auth config issue... https://github.com/hi-ogawa/next-learn/pull/1/commits/376b361c98d9aff79bfc40d116e60d12bdcb2f74
  - [x] handle redirection of flight data request https://github.com/hi-ogawa/vite-plugins/pull/564