### PR TITLE
fix: use ssr `transformRequest` for css crawling on server

### DIFF
--- a/packages/react-server/src/features/assets/css.ts
+++ b/packages/react-server/src/features/assets/css.ts
@@ -4,8 +4,11 @@ import type { ViteDevServer } from "vite";
 // https://github.com/hi-ogawa/vite-plugins/blob/3c496fa1bb5ac66d2880986877a37ed262f1d2a6/packages/vite-glob-routes/examples/demo/vite-plugin-ssr-css.ts
 // https://github.com/remix-run/remix/blob/dev/packages/remix-dev/vite/styles.ts
 
-export async function collectStyle(server: ViteDevServer, entries: string[]) {
-  const urls = await collectStyleUrls(server, entries);
+export async function collectStyle(
+  server: ViteDevServer,
+  options: { entries: string[]; ssr: boolean },
+) {
+  const urls = await collectStyleUrls(server, options);
   const styles = await Promise.all(
     urls.map(async (url) => {
       const res = await server.transformRequest(url + "?direct");
@@ -17,7 +20,7 @@ export async function collectStyle(server: ViteDevServer, entries: string[]) {
 
 export async function collectStyleUrls(
   server: ViteDevServer,
-  entries: string[],
+  { entries, ssr }: { entries: string[]; ssr: boolean },
 ) {
   const visited = new Set<string>();
 
@@ -37,7 +40,7 @@ export async function collectStyleUrls(
   }
 
   // ensure import analysis is ready for top entries
-  await Promise.all(entries.map((e) => server.transformRequest(e)));
+  await Promise.all(entries.map((e) => server.transformRequest(e, { ssr })));
 
   // traverse
   await Promise.all(entries.map((url) => traverse(url)));

--- a/packages/react-server/src/features/assets/plugin.ts
+++ b/packages/react-server/src/features/assets/plugin.ts
@@ -97,16 +97,19 @@ export function vitePluginServerAssets({
       tinyassert(!manager.buildType);
       const styles = await Promise.all([
         `/******* react-server ********/`,
-        collectStyle($__global.dev.reactServer, [
-          entryServer,
-          "virtual:server-routes",
-        ]),
+        collectStyle($__global.dev.reactServer, {
+          entries: [entryServer, "virtual:server-routes"],
+          ssr: true,
+        }),
         `/******* client **************/`,
-        collectStyle($__global.dev.server, [
-          entryBrowser,
-          // TODO: dev should also use RouteManifest to manage client css
-          ...manager.clientReferenceMap.keys(),
-        ]),
+        collectStyle($__global.dev.server, {
+          entries: [
+            entryBrowser,
+            // TODO: dev should also use RouteManifest to manage client css
+            ...manager.clientReferenceMap.keys(),
+          ],
+          ssr: false,
+        }),
       ]);
       return styles.join("\n\n");
     }),
@@ -115,10 +118,10 @@ export function vitePluginServerAssets({
       // virtual module to proxy css imports from react server to client
       // TODO: invalidate + full reload when add/remove css file?
       if (!manager.buildType) {
-        const urls = await collectStyleUrls($__global.dev.reactServer, [
-          entryServer,
-          "virtual:server-routes",
-        ]);
+        const urls = await collectStyleUrls($__global.dev.reactServer, {
+          entries: [entryServer, "virtual:server-routes"],
+          ssr: true,
+        });
         const code = urls.map((url) => `import "${url}";\n`).join("");
         // ensure hmr boundary since css module doesn't have `import.meta.hot.accept`
         return code + `if (import.meta.hot) { import.meta.hot.accept() }`;


### PR DESCRIPTION
Probably this is the cause of the warning in https://github.com/hi-ogawa/lucia-auth-examples/pull/1. Without ssr, server transform request is resolving a browser entry.

```
5:42:28 PM [react-server] Pre-transform error: Failed to resolve import "@node-rs/argon2-wasm32-wasi" from "node_modules/.pnpm/@node-rs+argon2@1.8.3/node_modules/@node-rs/argon2/browser.js?v=1e8f26d9". Does the file exist?
```

Eventually we'll need to rework all this, but for now this can go first. Related PRs:
- https://github.com/hi-ogawa/vite-plugins/pull/496
- https://github.com/hi-ogawa/vite-plugins/pull/494