### PR TITLE
feat(next): vercel node runtime adapter

### DIFF
--- a/packages/react-server-next/src/vite/adapters/index.ts
+++ b/packages/react-server-next/src/vite/adapters/index.ts
@@ -1,6 +1,6 @@
 import type { Plugin } from "vite";
 
-export type AdapterType = "node" | "vercel" | "cloudflare";
+export type AdapterType = "node" | "vercel" | "vercel-edge" | "cloudflare";
 
 export function adapterPlugin(options: {
   adapter?: AdapterType;
@@ -35,7 +35,11 @@ export function adapterPlugin(options: {
         }
         if (adapter === "vercel") {
           const { build } = await import("./vercel/build");
-          await build();
+          await build({ runtime: "node" });
+        }
+        if (adapter === "vercel-edge") {
+          const { build } = await import("./vercel/build");
+          await build({ runtime: "edge" });
         }
       },
     },

--- a/packages/react-server-next/src/vite/adapters/vercel-edge/entry.ts
+++ b/packages/react-server-next/src/vite/adapters/vercel-edge/entry.ts
@@ -1,0 +1,3 @@
+import { handler } from "@hiogawa/react-server/entry/ssr";
+
+export default handler;

--- a/packages/react-server-next/src/vite/adapters/vercel/build.ts
+++ b/packages/react-server-next/src/vite/adapters/vercel/build.ts
@@ -27,7 +27,7 @@ const configJson = {
 const vcConfig = {
   edge: {
     runtime: "edge",
-    entrypoint: "index.js",
+    entrypoint: "index.mjs",
   },
   node: {
     runtime: "nodejs20.x",
@@ -81,7 +81,7 @@ export async function build({ runtime }: { runtime: VercelRuntime }) {
   const esbuild = await import("esbuild");
   const result = await esbuild.build({
     entryPoints: [join(buildDir, "server/index.js")],
-    outfile: join(outDir, "functions/index.func/index.js"),
+    outfile: join(outDir, "functions/index.func/index.mjs"),
     metafile: true,
     bundle: true,
     minify: true,

--- a/packages/react-server-next/src/vite/adapters/vercel/entry.ts
+++ b/packages/react-server-next/src/vite/adapters/vercel/entry.ts
@@ -1,1 +1,1 @@
-export * from "../../entry-ssr";
+export { default } from "../../entry-ssr";

--- a/packages/react-server-next/src/vite/adapters/vercel/entry.ts
+++ b/packages/react-server-next/src/vite/adapters/vercel/entry.ts
@@ -1,3 +1,1 @@
-import { handler } from "@hiogawa/react-server/entry/ssr";
-
-export default handler;
+export * from "../../entry-ssr";

--- a/packages/react-server-next/tsup.config.ts
+++ b/packages/react-server-next/tsup.config.ts
@@ -8,6 +8,7 @@ export default defineConfig([
       "src/vite/entry-ssr.tsx",
       "src/vite/adapters/cloudflare/entry.ts",
       "src/vite/adapters/vercel/entry.ts",
+      "src/vite/adapters/vercel-edge/entry.ts",
       "src/compat/index.tsx",
       "src/compat/link.tsx",
       "src/compat/navigation.tsx",

--- a/packages/react-server/examples/next/package.json
+++ b/packages/react-server/examples/next/package.json
@@ -13,6 +13,7 @@
     "cf-preview": "wrangler pages dev ./dist/cloudflare --compatibility-date=2024-01-01 --compatibility-flags=nodejs_compat",
     "cf-release": "wrangler pages deploy ./dist/cloudflare --commit-dirty --branch main --project-name test-next-vite",
     "vc-build": "VERCEL=1 pnpm build",
+    "vc-release-staging": "vercel deploy --prebuilt",
     "vc-release": "vercel deploy --prod --prebuilt"
   },
   "dependencies": {


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/vite-plugins/issues/550

## todo

- [x] test `examples/next` deploy
  - [x] node https://test-next-vite-7kcjxlj5j-hiroshi-ogawas-projects.vercel.app/
  - [x] edge https://test-next-vite-g9qgcsttf-hiroshi-ogawas-projects.vercel.app