### PR TITLE
fix: rework browser `optimizeDeps.entries`

### DIFF
--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -261,12 +261,12 @@ export function vitePluginReactServer(
         optimizeDeps: {
           // this can potentially include unnecessary server only deps for client,
           // but there should be no issues except making deps optimization slightly slower.
-          entries: [
-            path.posix.join(
-              routeDir,
-              `**/(page|layout|error|not-found|loading|template).(js|jsx|ts|tsx)`,
-            ),
-          ],
+          // entries: [
+          //   path.posix.join(
+          //     routeDir,
+          //     `**/(page|layout|error|not-found|loading|template).(js|jsx|ts|tsx)`,
+          //   ),
+          // ],
           exclude: ["@hiogawa/react-server"],
           include: [
             "react",


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/vite-plugins/issues/562

I thought having this is safe, but in practice, it looks like this would cause pre-bundling error (or just warning?) since it goes through a lot of server only dependencies whose resolutions somehow fail on browser resolver.

One example is when crawling `@node-rs/argon2` https://github.com/hi-ogawa/lucia-auth-examples/pull/1#discussion_r1675537887

Not having this is okay since this is only to prevent dev full reload on late dep discovery (also users still have a way to configure it on their own), but there might be still a cheap attempt to mitigate this.

---

Some ideas:
- remove automatic `optimizeDeps.entries` and let users configure it (with `optimizeDeps.exclude` to counter against if they need)
- custom esbuild plugin to crawl only `"use client"` files?
  - we don't probably have to go deep and we can only check direct dependency of all `routes/**/*` files
- can we push to `optimizeDeps.entries` after we collected `clientReferenceMap` by loading server routes