### PR TITLE
fix: handle middleware redirection of flight request

### DIFF
--- a/packages/react-server/examples/next/app/test/page.tsx
+++ b/packages/react-server/examples/next/app/test/page.tsx
@@ -25,4 +25,5 @@ const links = [
   "/navigation/redirect/servercomponent",
   "/navigation/redirect/servercomponent2",
   "/navigation/not-found/servercomponent",
+  "/test/middleware/redirect",
 ];

--- a/packages/react-server/examples/next/e2e/basic.test.ts
+++ b/packages/react-server/examples/next/e2e/basic.test.ts
@@ -97,7 +97,7 @@ testNoJs("image preload", async ({ page }) => {
   ).not.toHaveAttribute("fetchPriority", "high");
 });
 
-test("middleware", async ({ request }) => {
+test("middleware basic", async ({ request }) => {
   {
     const res = await request.get("/test/middleware/response");
     expect(res.status()).toBe(200);
@@ -121,4 +121,19 @@ test("middleware", async ({ request }) => {
       "set-cookie": "x-hello=world; Path=/",
     });
   }
+});
+
+test("middleware flight redirect @js", async ({ page }) => {
+  await page.goto("/test");
+  await waitForHydration(page);
+  await page.getByRole("link", { name: "/test/middleware/redirect" }).click();
+  await page.waitForURL("/?ok=redirect");
+  await page.getByRole("img", { name: "Next.js logo" }).click();
+});
+
+testNoJs("middleware flight redirect @nojs", async ({ page }) => {
+  await page.goto("/test");
+  await page.getByRole("link", { name: "/test/middleware/redirect" }).click();
+  await page.waitForURL("/?ok=redirect");
+  await page.getByRole("img", { name: "Next.js logo" }).click();
 });

--- a/packages/react-server/examples/next/middleware.ts
+++ b/packages/react-server/examples/next/middleware.ts
@@ -1,3 +1,4 @@
+import { redirect } from "@hiogawa/react-server/server";
 import { type NextRequest, NextResponse } from "next/server";
 
 export default function middleware(request: NextRequest) {
@@ -14,6 +15,9 @@ export default function middleware(request: NextRequest) {
     const response = NextResponse.next();
     response.cookies.set("x-hello", "world");
     return response;
+  }
+  if (url.pathname == "/test/middleware/redirect") {
+    return Response.redirect(new URL("/?ok=redirect", url));
   }
   return NextResponse.next();
 }

--- a/packages/react-server/src/entry/browser.tsx
+++ b/packages/react-server/src/entry/browser.tsx
@@ -159,17 +159,35 @@ async function start() {
         lastPathname,
         revalidate: location.state[ROUTER_REVALIDATE_KEY],
       });
-      startTransition(async () => {
+      // TODO: how bad is this...?
+      // probably fine if we have a way to abort startTransition when two effects come in.
+      // maybe needs to move `lastLocation.current = location` to just before `startTransition`.
+      (async () => {
         const response = await fetch(request);
         if (handleFlightRedirectResponse(history, response)) {
           return;
         }
-        $__setFlight(
-          ReactClient.createFromFetch<FlightData>(Promise.resolve(response), {
-            callServer,
-          }),
-        );
-      });
+        startTransition(() => {
+          $__setFlight(
+            ReactClient.createFromFetch<FlightData>(Promise.resolve(response), {
+              callServer,
+            }),
+          );
+        });
+      })();
+      // startTransition(async () => {
+      //   const response = await fetch(request);
+      //   if (handleFlightRedirectResponse(history, response)) {
+      //     return;
+      //   }
+      //   startTransition(() => {
+      //     $__setFlight(
+      //       ReactClient.createFromFetch<FlightData>(Promise.resolve(response), {
+      //         callServer,
+      //       }),
+      //     );
+      //   })
+      // });
     }, [location]);
 
     return (

--- a/packages/react-server/src/entry/browser.tsx
+++ b/packages/react-server/src/entry/browser.tsx
@@ -159,35 +159,17 @@ async function start() {
         lastPathname,
         revalidate: location.state[ROUTER_REVALIDATE_KEY],
       });
-      // TODO: how bad is this...?
-      // probably fine if we have a way to abort startTransition when two effects come in.
-      // maybe needs to move `lastLocation.current = location` to just before `startTransition`.
-      (async () => {
+      startTransition(async () => {
         const response = await fetch(request);
         if (handleFlightRedirectResponse(history, response)) {
           return;
         }
-        startTransition(() => {
-          $__setFlight(
-            ReactClient.createFromFetch<FlightData>(Promise.resolve(response), {
-              callServer,
-            }),
-          );
-        });
-      })();
-      // startTransition(async () => {
-      //   const response = await fetch(request);
-      //   if (handleFlightRedirectResponse(history, response)) {
-      //     return;
-      //   }
-      //   startTransition(() => {
-      //     $__setFlight(
-      //       ReactClient.createFromFetch<FlightData>(Promise.resolve(response), {
-      //         callServer,
-      //       }),
-      //     );
-      //   })
-      // });
+        $__setFlight(
+          ReactClient.createFromFetch<FlightData>(Promise.resolve(response), {
+            callServer,
+          }),
+        );
+      });
     }, [location]);
 
     return (

--- a/packages/react-server/src/entry/server.tsx
+++ b/packages/react-server/src/entry/server.tsx
@@ -19,7 +19,10 @@ import {
   renderRouteMap,
 } from "../features/router/server";
 import { type FlightData, handleTrailingSlash } from "../features/router/utils";
-import { createActionRedirectResponse } from "../features/server-action/redirect";
+import {
+  createActionRedirectResponse,
+  createFlightRedirectResponse,
+} from "../features/server-action/redirect";
 import {
   type ActionResult,
   createActionBundlerConfig,
@@ -76,7 +79,7 @@ export const handler: ReactServerHandler = async (ctx) => {
     );
     if (response) {
       if (isStream && isRedirectStatus(response.status)) {
-        // createFlightRedirectResponse(response);
+        return createFlightRedirectResponse(response, requestContext);
       }
       return response;
     }

--- a/packages/react-server/src/entry/server.tsx
+++ b/packages/react-server/src/entry/server.tsx
@@ -65,7 +65,7 @@ export const handler: ReactServerHandler = async (ctx) => {
 
   const requestContext = new RequestContext(ctx.request.headers);
 
-  // extract stream request details
+  // normalize stream requesnt and extract details
   const { request, isStream, streamParam } = unwrapStreamRequest(ctx.request);
 
   if (serverRoutes.middleware) {

--- a/packages/react-server/src/entry/server.tsx
+++ b/packages/react-server/src/entry/server.tsx
@@ -68,7 +68,7 @@ export const handler: ReactServerHandler = async (ctx) => {
 
   const requestContext = new RequestContext(ctx.request.headers);
 
-  // normalize stream requesnt and extract details
+  // normalize stream request and extract metadata
   const { request, isStream, streamParam } = unwrapStreamRequest(ctx.request);
 
   if (serverRoutes.middleware) {

--- a/packages/react-server/src/features/error/error-boundary.tsx
+++ b/packages/react-server/src/features/error/error-boundary.tsx
@@ -133,12 +133,11 @@ export function RedirectHandler(props: {
   tinyassert(!import.meta.env.SSR);
 
   // trigger client navigation once and suspend until router fixes this up
-  const history = useRouter((s) => s.history);
   let suspension = redirectSuspensionMap.get(props.suspensionKey);
   if (!suspension) {
     suspension = new Promise(() => {});
     redirectSuspensionMap.set(props.suspensionKey, suspension);
-    setTimeout(() => history.replace(props.redirectLocation));
+    window.location.href = props.redirectLocation;
   }
   return React.use(suspension);
 }

--- a/packages/react-server/src/features/error/error-boundary.tsx
+++ b/packages/react-server/src/features/error/error-boundary.tsx
@@ -132,7 +132,9 @@ export function RedirectHandler(props: {
 }) {
   tinyassert(!import.meta.env.SSR);
 
-  // trigger client navigation once and suspend until router fixes this up
+  // trigger browser full-reload for simplicity until we figure out the mystery of react transition.
+  // note that, in practice, such server component redirection is (hopefullly) fairly unlikely
+  // since it means that app has a client navigation Link which redirects to somewhere else.
   let suspension = redirectSuspensionMap.get(props.suspensionKey);
   if (!suspension) {
     suspension = new Promise(() => {});

--- a/packages/react-server/src/features/error/shared.ts
+++ b/packages/react-server/src/features/error/shared.ts
@@ -36,6 +36,10 @@ export function isRedirectError(ctx: ReactServerErrorContext) {
   return false;
 }
 
+export function isRedirectStatus(status: number) {
+  return 300 <= status && status <= 399;
+}
+
 export function isNotFoundError(ctx: ReactServerErrorContext) {
   return ctx.status === 404;
 }

--- a/packages/react-server/src/features/server-action/redirect.ts
+++ b/packages/react-server/src/features/server-action/redirect.ts
@@ -5,9 +5,9 @@ import type { ActionResult } from "./server";
 
 // TODO: generalize to any flight request redirection e.g. by middleware
 
-const ACTION_REDIRECT_KEY = "x-action-redirect";
+const FLIGHT_REDIRECT_KEY = "x-flight-redirect";
 
-type ActionRedirectMeta = {
+type FlightRedirectMeta = {
   location: string;
   revalidate?: RevalidationType;
 };
@@ -29,11 +29,11 @@ export function createActionRedirectResponse({
     if (isStream) {
       headers.delete("location");
       headers.set(
-        ACTION_REDIRECT_KEY,
+        FLIGHT_REDIRECT_KEY,
         JSON.stringify({
           location: redirect.location,
           revalidate: requestContext.revalidate,
-        } satisfies ActionRedirectMeta),
+        } satisfies FlightRedirectMeta),
       );
       return new Response(null, {
         status: 200,
@@ -48,10 +48,12 @@ export function createActionRedirectResponse({
   return;
 }
 
-export function parseActionRedirectResponse(response: Response) {
-  const raw = response.headers.get(ACTION_REDIRECT_KEY);
+export function createFlightRedirectResponse() {}
+
+export function parseFlightRedirectResponse(response: Response) {
+  const raw = response.headers.get(FLIGHT_REDIRECT_KEY);
   if (raw) {
-    return JSON.parse(raw) as ActionRedirectMeta;
+    return JSON.parse(raw) as FlightRedirectMeta;
   }
   return;
 }

--- a/packages/react-server/src/features/server-action/redirect.ts
+++ b/packages/react-server/src/features/server-action/redirect.ts
@@ -3,6 +3,8 @@ import type { RequestContext } from "../request-context/server";
 import type { RevalidationType } from "../server-component/utils";
 import type { ActionResult } from "./server";
 
+// TODO: generalize to any flight request redirection e.g. by middleware
+
 const ACTION_REDIRECT_KEY = "x-action-redirect";
 
 type ActionRedirectMeta = {


### PR DESCRIPTION
We need to generalize action redirection to any flight request redirection for `next-auth` https://github.com/hi-ogawa/next-learn/pull/1

## todo

- [x] test 