### PR TITLE
wip: debug router transition

### DIFF
--- a/packages/react-server/src/entry/browser.tsx
+++ b/packages/react-server/src/entry/browser.tsx
@@ -150,7 +150,7 @@ async function start() {
 
     React.useEffect(() => {
       console.log(
-        `[location effect] ${lastLocation.current.pathname} ==> ${location.pathname}`,
+        `[location effect] ${lastLocation.current.href} ==> ${location.href}`,
       );
       if (location === lastLocation.current) {
         return;
@@ -174,6 +174,13 @@ async function start() {
           }),
         );
       });
+      // startTransition(() => {
+      //   $__setFlight(
+      //     ReactClient.createFromFetch<FlightData>(fetch(request), {
+      //       callServer,
+      //     }),
+      //   );
+      // });
     }, [location]);
 
     return (

--- a/packages/react-server/src/entry/browser.tsx
+++ b/packages/react-server/src/entry/browser.tsx
@@ -149,6 +149,7 @@ async function start() {
     const lastLocation = React.useRef(location);
 
     React.useEffect(() => {
+      console.log("[location]", { location, lastLocation });
       if (location === lastLocation.current) {
         return;
       }

--- a/packages/react-server/src/entry/browser.tsx
+++ b/packages/react-server/src/entry/browser.tsx
@@ -164,8 +164,9 @@ async function start() {
         revalidate: location.state[ROUTER_REVALIDATE_KEY],
       });
       startTransition(async () => {
+        const response = await fetch(request);
         $__setFlight(
-          ReactClient.createFromFetch<FlightData>(fetch(request), {
+          ReactClient.createFromFetch<FlightData>(Promise.resolve(response), {
             callServer,
           }),
         );

--- a/packages/react-server/src/entry/browser.tsx
+++ b/packages/react-server/src/entry/browser.tsx
@@ -149,7 +149,9 @@ async function start() {
     const lastLocation = React.useRef(location);
 
     React.useEffect(() => {
-      console.log("[location]", { location, lastLocation });
+      console.log(
+        `[location effect] ${lastLocation.current.pathname} ==> ${location.pathname}`,
+      );
       if (location === lastLocation.current) {
         return;
       }

--- a/packages/react-server/src/entry/browser.tsx
+++ b/packages/react-server/src/entry/browser.tsx
@@ -163,7 +163,7 @@ async function start() {
         lastPathname,
         revalidate: location.state[ROUTER_REVALIDATE_KEY],
       });
-      startTransition(() => {
+      startTransition(async () => {
         $__setFlight(
           ReactClient.createFromFetch<FlightData>(fetch(request), {
             callServer,

--- a/packages/react-server/src/features/error/error-boundary.tsx
+++ b/packages/react-server/src/features/error/error-boundary.tsx
@@ -149,23 +149,24 @@ export function RedirectHandler(props: {
   tinyassert(!import.meta.env.SSR);
 
   // trigger client navigation once and suspend until router fixes this up
-  const history = useRouter((s) => s.history);
+  // const history = useRouter((s) => s.history);
   let suspension = redirectSuspensionMap.get(props.suspensionKey);
   console.log("[RedirectHandler]", { props, suspension });
   if (!suspension) {
     suspension = createManualPromise();
     redirectSuspensionMap.set(props.suspensionKey, suspension);
-    setTimeout(() => {
-      // suspension?.resolve(null);
-      history.replace(props.redirectLocation);
-      // props.reset();
-      // React.startTransition(() => {
-      //   props.reset();
-      // });
-    });
+    window.location.href = props.redirectLocation;
+    // setTimeout(() => {
+    //   // suspension?.resolve(null);
+    //   history.replace(props.redirectLocation);
+    //   // props.reset();
+    //   // React.startTransition(() => {
+    //   //   props.reset();
+    //   // });
+    // });
   }
-  return null;
-  // return React.use(suspension.promise);
+  // return null;
+  return React.use(suspension.promise);
 }
 
 export class NotFoundBoundary extends React.Component<{


### PR DESCRIPTION
We need to investigate this first for
- https://github.com/hi-ogawa/vite-plugins/pull/564#discussion_r1677091050

We don't have to preserve exact transition semantics (something related to interruptibility which you can observe in the demo http://localhost:5173/test/transition), but we need to make sure server component redirect to work at least.

---

It looks like `RedirectBoundary` is stuck without being reset after `history.replace`, which is due to `useEffect(() => {}, [location])` not firing at all after `history.replace` so there's no new node to replace the boundary.
Maybe we should rework `RedirectBoundary` as it was designed long time ago before recent refactoring https://github.com/hi-ogawa/vite-plugins/pull/530

---

I would expect the same would happen for other error boundaries from server component error (e.g. not found, unexpected). Need to check that too.

---

Practically speaking, it's unlikely to redirect from flight request server component since that would mean having a client side navigation link which is destined to redirect somewhere. So, not having an ideal solution is probably okay (e.g. showing blank without suspending, or maybe even browser full-reload, etc...).