### PR TITLE
fix: handle server component redirection by browser full reload

### DIFF
--- a/packages/react-server/src/features/error/error-boundary.tsx
+++ b/packages/react-server/src/features/error/error-boundary.tsx
@@ -132,13 +132,14 @@ export function RedirectHandler(props: {
 }) {
   tinyassert(!import.meta.env.SSR);
 
-  // trigger client navigation once and suspend until router fixes this up
-  const history = useRouter((s) => s.history);
+  // trigger browser full-reload for simplicity until we figure out the mystery of react transition.
+  // (note that, in practice, this server component redirection is fairly unlikely
+  // since it means that app has a client navigation Link which is destined to redirect
+  // somewhere else.)
   let suspension = redirectSuspensionMap.get(props.suspensionKey);
   if (!suspension) {
     suspension = new Promise(() => {});
-    redirectSuspensionMap.set(props.suspensionKey, suspension);
-    setTimeout(() => history.replace(props.redirectLocation));
+    window.location.href = props.redirectLocation;
   }
   return React.use(suspension);
 }

--- a/packages/react-server/src/features/error/error-boundary.tsx
+++ b/packages/react-server/src/features/error/error-boundary.tsx
@@ -139,6 +139,7 @@ export function RedirectHandler(props: {
   let suspension = redirectSuspensionMap.get(props.suspensionKey);
   if (!suspension) {
     suspension = new Promise(() => {});
+    redirectSuspensionMap.set(props.suspensionKey, suspension);
     window.location.href = props.redirectLocation;
   }
   return React.use(suspension);


### PR DESCRIPTION
After some thinking in https://github.com/hi-ogawa/vite-plugins/pull/564#discussion_r1677091050, https://github.com/hi-ogawa/vite-plugins/pull/566, this is a fairly reasonable solution to allow async transition to hopefully simplify many things.