### PR TITLE
chore: fix og test bundle script

### DIFF
--- a/packages/react-server/examples/og/package.json
+++ b/packages/react-server/examples/og/package.json
@@ -21,6 +21,9 @@
     "react-server-dom-webpack": "rc"
   },
   "devDependencies": {
+    "@rollup/plugin-commonjs": "^26.0.1",
+    "@rollup/plugin-node-resolve": "^15.2.3",
+    "@rollup/plugin-replace": "^5.0.7",
     "@types/react": "latest",
     "@types/react-dom": "latest",
     "@vercel/ncc": "^0.38.1",

--- a/packages/react-server/examples/og/package.json
+++ b/packages/react-server/examples/og/package.json
@@ -25,7 +25,7 @@
     "@types/react-dom": "latest",
     "@vercel/ncc": "^0.38.1",
     "@vercel/nft": "^0.27.3",
-    "rolldown": "^0.11.1",
+    "rolldown": "^0.12.1",
     "rollup": "^4.18.1",
     "vite": "latest"
   }

--- a/packages/react-server/examples/og/test-bundle.js
+++ b/packages/react-server/examples/og/test-bundle.js
@@ -75,16 +75,14 @@ async function main() {
     const rollup = await import("rollup");
     const bundle = await rollup.rollup({
       input: entry,
-      output: {
-        // bundle dynamic import like esbuild without splitting
-        // inlineDynamicImports: true,
-      },
     });
     const outDir = path.join(import.meta.dirname, "dist/rollup");
     await rm(outDir, { recursive: true, force: true });
     await mkdir(outDir, { recursive: true });
     await bundle.write({
       dir: outDir,
+      // bundle dynamic import like esbuild without splitting
+      // inlineDynamicImports: true,
     });
   }
 }

--- a/packages/react-server/examples/og/test-bundle.js
+++ b/packages/react-server/examples/og/test-bundle.js
@@ -5,11 +5,11 @@ import path from "node:path";
 
 async function main() {
   const [arg = "esbuild"] = process.argv.slice(2);
-
   const entry = path.join(import.meta.dirname, "dist/server/index.js");
 
   if (arg === "nft") {
     const { nodeFileTrace } = await import("@vercel/nft");
+
     const result = await nodeFileTrace([entry], {
       // set pnpm project root to correctly traverse dependency
       base: path.join(import.meta.dirname, "../../../.."),
@@ -25,6 +25,7 @@ async function main() {
   if (arg === "ncc") {
     /** @type {any} */
     const { default: ncc } = await import("@vercel/ncc");
+
     const result = await ncc(entry, {
       filterAssetBase: path.join(import.meta.dirname, "../../../.."),
     });
@@ -59,9 +60,20 @@ async function main() {
 
   if (arg === "rolldown") {
     const rolldown = await import("rolldown");
+    const { default: replace } = await import("@rollup/plugin-replace");
+
     const bundle = await rolldown.rolldown({
       input: entry,
       platform: "node",
+      plugins: [
+        // @ts-ignore rollup/rolldown plugin type
+        replace({
+          preventAssignment: true,
+          values: {
+            "process.env.NODE_ENV": `"production"`,
+          },
+        }),
+      ],
     });
     const outDir = path.join(import.meta.dirname, "dist/rolldown");
     await rm(outDir, { recursive: true, force: true });
@@ -73,8 +85,24 @@ async function main() {
 
   if (arg === "rollup") {
     const rollup = await import("rollup");
+    const { default: replace } = await import("@rollup/plugin-replace");
+    const { default: nodeResolve } = await import(
+      "@rollup/plugin-node-resolve"
+    );
+    const { default: commonjs } = await import("@rollup/plugin-commonjs");
+
     const bundle = await rollup.rollup({
       input: entry,
+      plugins: [
+        replace({
+          preventAssignment: true,
+          values: {
+            "process.env.NODE_ENV": `"production"`,
+          },
+        }),
+        nodeResolve(),
+        commonjs(),
+      ],
     });
     const outDir = path.join(import.meta.dirname, "dist/rollup");
     await rm(outDir, { recursive: true, force: true });

--- a/packages/react-server/examples/og/test-bundle.js
+++ b/packages/react-server/examples/og/test-bundle.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 async function main() {
@@ -48,6 +48,8 @@ async function main() {
       define: {
         "process.env.NODE_ENV": `"production"`,
       },
+      // split dynamic import like rollup/down
+      // splitting: true,
       logLevel: "info",
       logOverride: {
         "ignored-bare-import": "silent",
@@ -62,6 +64,7 @@ async function main() {
       platform: "node",
     });
     const outDir = path.join(import.meta.dirname, "dist/rolldown");
+    await rm(outDir, { recursive: true, force: true });
     await mkdir(outDir, { recursive: true });
     await bundle.write({
       dir: outDir,
@@ -72,8 +75,13 @@ async function main() {
     const rollup = await import("rollup");
     const bundle = await rollup.rollup({
       input: entry,
+      output: {
+        // bundle dynamic import like esbuild without splitting
+        // inlineDynamicImports: true,
+      },
     });
     const outDir = path.join(import.meta.dirname, "dist/rollup");
+    await rm(outDir, { recursive: true, force: true });
     await mkdir(outDir, { recursive: true });
     await bundle.write({
       dir: outDir,

--- a/packages/react-server/examples/og/test-bundle.js
+++ b/packages/react-server/examples/og/test-bundle.js
@@ -41,7 +41,7 @@ async function main() {
 
     await esbuild.build({
       entryPoints: [entry],
-      outfile: path.join(import.meta.dirname, "dist/esbuild"),
+      outdir: path.join(import.meta.dirname, "dist/esbuild"),
       bundle: true,
       format: "esm",
       platform: "node",
@@ -59,7 +59,7 @@ async function main() {
     const rolldown = await import("rolldown");
     const bundle = await rolldown.rolldown({
       input: entry,
-      cwd: import.meta.dirname,
+      platform: "node",
     });
     const outDir = path.join(import.meta.dirname, "dist/rolldown");
     await mkdir(outDir, { recursive: true });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,8 +327,8 @@ importers:
         specifier: ^0.27.3
         version: 0.27.3
       rolldown:
-        specifier: ^0.11.1
-        version: 0.11.1
+        specifier: ^0.12.1
+        version: 0.12.1
       rollup:
         specifier: ^4.18.1
         version: 4.18.1
@@ -2144,58 +2144,58 @@ packages:
     resolution: {integrity: sha512-C7c51Nn4yTxXFKvgh2txJFNweaVcfUPQxwEUFw4aWsCmfiBDJsTSwviIF8EcwjQ6k8bPyMWCl1vw4BdxE569Cg==}
     engines: {node: '>= 10'}
 
-  '@rolldown/binding-darwin-arm64@0.11.1':
-    resolution: {integrity: sha512-T7l/ysbl0I1uDk8xSHbtZDVsfKvLzpHqbYhpC/ML93yWLJ8zRiAFhH2dF0I5UqKZN5dNphOku/8CnXbwC+ie5g==}
+  '@rolldown/binding-darwin-arm64@0.12.1':
+    resolution: {integrity: sha512-NWtxYWEb7Nd40WQHW/Fp3OolqxkwmfL/OJ2GWPOSBEmE7c6/iEgLROy+enkGkBKXdF6epsc+UUQGN5Mp03vaFw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@0.11.1':
-    resolution: {integrity: sha512-CGQjbkkHQsCqn+EdRJt7fjTeDyIwGWSDROp/e6M6A71EsPJ1KI7TLcgzjWpi7lvB998wXzSyNBoym7Kz9xDbjA==}
+  '@rolldown/binding-darwin-x64@0.12.1':
+    resolution: {integrity: sha512-9MVhdXaCUHBpuTRZWGrB4ptUd2cYkg56KdcHL6fLL9LtMnCRmsJ5s2QNIOyzF3lgDNt3ic3iHcKoPex0TNRtpg==}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-linux-arm-gnueabihf@0.11.1':
-    resolution: {integrity: sha512-tJrzkATOl9jwNq4tkJRw7bxZ6eMtT39KYCMzwuj6b8HUZb6RTIRFQNvEQu3LMwLrziLYF8xSS7TV/LpMNfVkmw==}
+  '@rolldown/binding-linux-arm-gnueabihf@0.12.1':
+    resolution: {integrity: sha512-IS8zyitSUquGjGFK7T5VQwhkyWIsJ/kVj9fKKBg5+ejZiMCkUFbBj03Cm6WDyIBakLeA2Wjgwuvy1hSzsrKPJw==}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@0.11.1':
-    resolution: {integrity: sha512-5SJs8qvGzFx9T2E7G9G4NZVG9h44te8mxvGUF1a4ULB4hLEkWXteZQtaCOkPBX15zvFYcDxpv1Z67E2xGv/SUg==}
+  '@rolldown/binding-linux-arm64-gnu@0.12.1':
+    resolution: {integrity: sha512-zbO53A0NXGvigsNXGBnxc1LtLynqGR31dLSqF8LT4/vdJHYJOK5nKr9bzKErELeYaseZfA/jV8+whImB0F/3ow==}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-musl@0.11.1':
-    resolution: {integrity: sha512-VVcRvxW4azA2WA6xFDQaDPUsfP8eFruXoPSBUMRkQdK705tRQVkewQLVvGLP5DhsKTeLDd74WoyWv47mb/IJSQ==}
+  '@rolldown/binding-linux-arm64-musl@0.12.1':
+    resolution: {integrity: sha512-1V7ms7bG8T5Ob0jrIl0AZOU6UQxC/QDvqo9+ZUTEI5vVBYZPvTEAzEpYXKAn/pVPKwmh80epsaRL5D3Rc3WNWQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-gnu@0.11.1':
-    resolution: {integrity: sha512-4tGYNgNYwXZVVXMlLft+OVXKgwaR6YWsv3low9JZ74Mb8l6MtclcObdl2EDMEhdu+SpDH20xjKSoGv0VLeKT5g==}
+  '@rolldown/binding-linux-x64-gnu@0.12.1':
+    resolution: {integrity: sha512-rTFRH8ezlStxFvB33F4DodoFAIsGgCv0wRbs9965duMqWSYMlMHg4yFLOW6GNf1t86V7reG59rGPNbWn2evyVA==}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-musl@0.11.1':
-    resolution: {integrity: sha512-HcVRAXvZk60zisPJaTufrlE4oWtPkjR5Ttvpcocx27+Qn7kIZVVsYqhUOYOjjr1Igr6BLF0eJQG+yj0O6OKujg==}
+  '@rolldown/binding-linux-x64-musl@0.12.1':
+    resolution: {integrity: sha512-fwIv3777FBj3Wztc59B7/7mVW/Fm38keslyr6Op8UVPQy604qHYaztzQYjBzZcbxCTeJKdXWoNz/3ddn53+zeA==}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-wasm32-wasi@0.11.1':
-    resolution: {integrity: sha512-zGF9clT7D2BvHQ3+eTQ8apcHBvw+MtzmnGZeJLVQeciae4JGV0Bf9Mpsi41pGQY/iB3KOzwRlPkxdqwPer035Q==}
+  '@rolldown/binding-wasm32-wasi@0.12.1':
+    resolution: {integrity: sha512-AzbfEXik1+t+guVIFQJ92O/W5jyq/+BFsXSlb5rYL7ZzxOjLEXL0IRizY/rIqxF43KnsO7lf51qKH6g+E5VRNA==}
     engines: {node: '>=14.21.3'}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@0.11.1':
-    resolution: {integrity: sha512-CgsPbPFt9ivjgQIfQztzgJoMQotAis847HJlt4Wb+y9heeC6AlM2DWO7PzJwTRakwCfDnlGLS4ss7fBwKszaYg==}
+  '@rolldown/binding-win32-arm64-msvc@0.12.1':
+    resolution: {integrity: sha512-U//wRnkk4Bm8VjRD1hWkpxO36M4ZXekBxciNLZbW7wKGIs1zkMBc77nA93iOQZgbE6a1JvJQT4/aPoqNg0JfpA==}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-ia32-msvc@0.11.1':
-    resolution: {integrity: sha512-R1uaW88UePfX3qg9X8Iz4jravUkNuxG3gDOC0zIxZNcYRzDUXQjReFOd4JiRySDgvBv0AVN/GI7Oertwlze4mA==}
+  '@rolldown/binding-win32-ia32-msvc@0.12.1':
+    resolution: {integrity: sha512-79oEmO35sQXl4nnd9WdZLbxcSCtCrUO9zMr75S49Ol+aiPOCgOx9ObyilLO8sWYFX56VFow3271JKTeY6b4eXQ==}
     cpu: [ia32]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@0.11.1':
-    resolution: {integrity: sha512-PDkSAgXXageNMZp2aRTkdPxNWX2WnGvXVgFOYUHQ3Pgum4u9c8oq+jvTKxLXfY5j1DZcAl2UK1PPRT1SiUrV4Q==}
+  '@rolldown/binding-win32-x64-msvc@0.12.1':
+    resolution: {integrity: sha512-zjGS/TgiwPNA3Wkadww9EMQ/1DHjj2J4KsPOmew5y8jYydtMM3iOYUlymbPFuVd5SL7FP6nlHSGWJL+d4na4bA==}
     cpu: [x64]
     os: [win32]
 
@@ -4628,8 +4628,8 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
-  rolldown@0.11.1:
-    resolution: {integrity: sha512-hjY0gklGPuDwkTECjqalYmZX3EQdMQWd5vNGBu++a/+cNvrNan5DZTu47h0NGApYhcOH9iV4Hu3V22kSAIiCCg==}
+  rolldown@0.12.1:
+    resolution: {integrity: sha512-KHcX/FPdkCmJX3j2C6VaSd2pRmleQ720rtOAL5IciP2oCQ8+DKS7G/UAezV+bOLExXwB4GR8M+hGjE2XxzFV0g==}
     hasBin: true
 
   rollup-plugin-inject@3.0.2:
@@ -6504,39 +6504,39 @@ snapshots:
 
   '@resvg/resvg-wasm@2.4.0': {}
 
-  '@rolldown/binding-darwin-arm64@0.11.1':
+  '@rolldown/binding-darwin-arm64@0.12.1':
     optional: true
 
-  '@rolldown/binding-darwin-x64@0.11.1':
+  '@rolldown/binding-darwin-x64@0.12.1':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@0.11.1':
+  '@rolldown/binding-linux-arm-gnueabihf@0.12.1':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@0.11.1':
+  '@rolldown/binding-linux-arm64-gnu@0.12.1':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@0.11.1':
+  '@rolldown/binding-linux-arm64-musl@0.12.1':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@0.11.1':
+  '@rolldown/binding-linux-x64-gnu@0.12.1':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@0.11.1':
+  '@rolldown/binding-linux-x64-musl@0.12.1':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@0.11.1':
+  '@rolldown/binding-wasm32-wasi@0.12.1':
     dependencies:
       '@napi-rs/wasm-runtime': 0.2.4
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@0.11.1':
+  '@rolldown/binding-win32-arm64-msvc@0.12.1':
     optional: true
 
-  '@rolldown/binding-win32-ia32-msvc@0.11.1':
+  '@rolldown/binding-win32-ia32-msvc@0.12.1':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@0.11.1':
+  '@rolldown/binding-win32-x64-msvc@0.12.1':
     optional: true
 
   '@rollup/pluginutils@4.2.1':
@@ -9345,21 +9345,21 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
-  rolldown@0.11.1:
+  rolldown@0.12.1:
     dependencies:
       zod: 3.23.8
     optionalDependencies:
-      '@rolldown/binding-darwin-arm64': 0.11.1
-      '@rolldown/binding-darwin-x64': 0.11.1
-      '@rolldown/binding-linux-arm-gnueabihf': 0.11.1
-      '@rolldown/binding-linux-arm64-gnu': 0.11.1
-      '@rolldown/binding-linux-arm64-musl': 0.11.1
-      '@rolldown/binding-linux-x64-gnu': 0.11.1
-      '@rolldown/binding-linux-x64-musl': 0.11.1
-      '@rolldown/binding-wasm32-wasi': 0.11.1
-      '@rolldown/binding-win32-arm64-msvc': 0.11.1
-      '@rolldown/binding-win32-ia32-msvc': 0.11.1
-      '@rolldown/binding-win32-x64-msvc': 0.11.1
+      '@rolldown/binding-darwin-arm64': 0.12.1
+      '@rolldown/binding-darwin-x64': 0.12.1
+      '@rolldown/binding-linux-arm-gnueabihf': 0.12.1
+      '@rolldown/binding-linux-arm64-gnu': 0.12.1
+      '@rolldown/binding-linux-arm64-musl': 0.12.1
+      '@rolldown/binding-linux-x64-gnu': 0.12.1
+      '@rolldown/binding-linux-x64-musl': 0.12.1
+      '@rolldown/binding-wasm32-wasi': 0.12.1
+      '@rolldown/binding-win32-arm64-msvc': 0.12.1
+      '@rolldown/binding-win32-ia32-msvc': 0.12.1
+      '@rolldown/binding-win32-x64-msvc': 0.12.1
 
   rollup-plugin-inject@3.0.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,6 +314,15 @@ importers:
         specifier: 19.0.0-rc-df5f2736-20240712
         version: 19.0.0-rc-df5f2736-20240712(react-dom@19.0.0-rc-df5f2736-20240712(react@19.0.0-rc-df5f2736-20240712))(react@19.0.0-rc-df5f2736-20240712)(webpack@5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.12))(esbuild@0.23.0))
     devDependencies:
+      '@rollup/plugin-commonjs':
+        specifier: ^26.0.1
+        version: 26.0.1(rollup@4.18.1)
+      '@rollup/plugin-node-resolve':
+        specifier: ^15.2.3
+        version: 15.2.3(rollup@4.18.1)
+      '@rollup/plugin-replace':
+        specifier: ^5.0.7
+        version: 5.0.7(rollup@4.18.1)
       '@types/react':
         specifier: 18.3.3
         version: 18.3.3
@@ -2199,6 +2208,33 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rollup/plugin-commonjs@26.0.1':
+    resolution: {integrity: sha512-UnsKoZK6/aGIH6AdkptXhNvhaqftcjq3zZdT+LY5Ftms6JR06nADcDsYp5hTU9E2lbJUEOhdlY5J4DNTneM+jQ==}
+    engines: {node: '>=16.0.0 || 14 >= 14.17'}
+    peerDependencies:
+      rollup: ^2.68.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/plugin-node-resolve@15.2.3':
+    resolution: {integrity: sha512-j/lym8nf5E21LwBT4Df1VD6hRO2L2iwUeUmP7litikRsVp1H6NWx20NEp0Y7su+7XGc476GnXXc4kFeZNGmaSQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.78.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/plugin-replace@5.0.7':
+    resolution: {integrity: sha512-PqxSfuorkHz/SPpyngLyg5GCEkOcee9M1bkxiVDr41Pd61mqP1PLOoDPbpl44SB2mQGKwV/In74gqQmGITOhEQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
   '@rollup/pluginutils@4.2.1':
     resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
     engines: {node: '>= 8.0.0'}
@@ -2494,6 +2530,9 @@ packages:
 
   '@types/react@18.3.3':
     resolution: {integrity: sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==}
+
+  '@types/resolve@1.20.2':
+    resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
 
   '@types/send@0.17.4':
     resolution: {integrity: sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==}
@@ -2889,6 +2928,10 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
+  builtin-modules@3.3.0:
+    resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
+    engines: {node: '>=6'}
+
   builtins@5.0.1:
     resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
 
@@ -3032,6 +3075,9 @@ packages:
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
+
+  commondir@1.0.1:
+    resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -3664,6 +3710,10 @@ packages:
     resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
     engines: {node: '>=4'}
 
+  is-builtin-module@3.2.1:
+    resolution: {integrity: sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==}
+    engines: {node: '>=6'}
+
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
@@ -3705,6 +3755,9 @@ packages:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
     engines: {node: '>=8'}
 
+  is-module@1.0.0:
+    resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
+
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
@@ -3716,6 +3769,9 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
+
+  is-reference@1.2.1:
+    resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
 
   is-reference@3.0.2:
     resolution: {integrity: sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==}
@@ -6539,6 +6595,35 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@0.12.1':
     optional: true
 
+  '@rollup/plugin-commonjs@26.0.1(rollup@4.18.1)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@4.18.1)
+      commondir: 1.0.1
+      estree-walker: 2.0.2
+      glob: 10.4.4
+      is-reference: 1.2.1
+      magic-string: 0.30.10
+    optionalDependencies:
+      rollup: 4.18.1
+
+  '@rollup/plugin-node-resolve@15.2.3(rollup@4.18.1)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@4.18.1)
+      '@types/resolve': 1.20.2
+      deepmerge: 4.3.1
+      is-builtin-module: 3.2.1
+      is-module: 1.0.0
+      resolve: 1.22.8
+    optionalDependencies:
+      rollup: 4.18.1
+
+  '@rollup/plugin-replace@5.0.7(rollup@4.18.1)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@4.18.1)
+      magic-string: 0.30.10
+    optionalDependencies:
+      rollup: 4.18.1
+
   '@rollup/pluginutils@4.2.1':
     dependencies:
       estree-walker: 2.0.2
@@ -6800,6 +6885,8 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.12
       csstype: 3.1.3
+
+  '@types/resolve@1.20.2': {}
 
   '@types/send@0.17.4':
     dependencies:
@@ -7366,6 +7453,8 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  builtin-modules@3.3.0: {}
+
   builtins@5.0.1:
     dependencies:
       semver: 7.6.0
@@ -7505,6 +7594,8 @@ snapshots:
   commander@2.20.3: {}
 
   commander@4.1.1: {}
+
+  commondir@1.0.1: {}
 
   concat-map@0.0.1: {}
 
@@ -8244,6 +8335,10 @@ snapshots:
 
   is-buffer@2.0.5: {}
 
+  is-builtin-module@3.2.1:
+    dependencies:
+      builtin-modules: 3.3.0
+
   is-callable@1.2.7: {}
 
   is-core-module@2.14.0:
@@ -8272,11 +8367,17 @@ snapshots:
 
   is-interactive@1.0.0: {}
 
+  is-module@1.0.0: {}
+
   is-number@7.0.0: {}
 
   is-plain-obj@3.0.0: {}
 
   is-plain-obj@4.1.0: {}
+
+  is-reference@1.2.1:
+    dependencies:
+      '@types/estree': 1.0.5
 
   is-reference@3.0.2:
     dependencies:


### PR DESCRIPTION
rolldown was crashing, but It looks like `platform: "node"` is needed. Also added a few rollup plugins to bundle similar to esbuild.