### PR TITLE
chore: fix rolldown exit

### DIFF
--- a/packages/react-server/examples/og/test-bundle.js
+++ b/packages/react-server/examples/og/test-bundle.js
@@ -62,7 +62,6 @@ async function main() {
     const rolldown = await import("rolldown");
     const { default: replace } = await import("@rollup/plugin-replace");
 
-    console.time("[rolldown]");
     const bundle = await rolldown.rolldown({
       input: entry,
       platform: "node",
@@ -76,15 +75,12 @@ async function main() {
         }),
       ],
     });
-    console.timeEnd("[rolldown]");
     const outDir = path.join(import.meta.dirname, "dist/rolldown");
     await rm(outDir, { recursive: true, force: true });
     await mkdir(outDir, { recursive: true });
-    console.time("[bundle.write]");
     await bundle.write({
       dir: outDir,
     });
-    console.timeEnd("[bundle.write]");
     await bundle.destroy();
     // seems necessary to force exit
     // https://github.com/rolldown/rolldown/pull/1097

--- a/packages/react-server/examples/og/test-bundle.js
+++ b/packages/react-server/examples/og/test-bundle.js
@@ -62,6 +62,7 @@ async function main() {
     const rolldown = await import("rolldown");
     const { default: replace } = await import("@rollup/plugin-replace");
 
+    console.time("[rolldown]");
     const bundle = await rolldown.rolldown({
       input: entry,
       platform: "node",
@@ -75,12 +76,20 @@ async function main() {
         }),
       ],
     });
+    console.timeEnd("[rolldown]");
     const outDir = path.join(import.meta.dirname, "dist/rolldown");
     await rm(outDir, { recursive: true, force: true });
     await mkdir(outDir, { recursive: true });
+    console.time("[bundle.write]");
     await bundle.write({
       dir: outDir,
     });
+    console.timeEnd("[bundle.write]");
+    await bundle.destroy();
+    // seems necessary to force exit
+    // https://github.com/rolldown/rolldown/pull/1097
+    // https://github.com/rolldown/rolldown/pull/985
+    process.exit(0);
   }
 
   if (arg === "rollup") {


### PR DESCRIPTION
I thought rolldown is slow, but it turned out node was just hanging. It looks like force-exit is necessary for now:
- https://github.com/rolldown/rolldown/pull/1097