### PR TITLE
fix: `ignoreExportAllDeclaration` during client/server transform

### DIFF
--- a/packages/react-server/examples/basic/deps/use-client/index.d.ts
+++ b/packages/react-server/examples/basic/deps/use-client/index.d.ts
@@ -1,3 +1,3 @@
-declare function TestDepUseClient(): string;
+declare function TestDepUseClient(): JSX.Element;
 
 export { TestDepUseClient };

--- a/packages/react-server/examples/basic/deps/use-client/package.json
+++ b/packages/react-server/examples/basic/deps/use-client/package.json
@@ -3,8 +3,14 @@
   "private": true,
   "type": "module",
   "exports": {
-    "types": "./index.d.ts",
-    "default": "./index.js"
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    },
+    "./re-export": {
+      "types": "./re-export/index.d.ts",
+      "default": "./re-export/index.js"
+    }
   },
   "dependencies": {
     "react": "*"

--- a/packages/react-server/examples/basic/deps/use-client/re-export/all.js
+++ b/packages/react-server/examples/basic/deps/use-client/re-export/all.js
@@ -1,0 +1,1 @@
+export function notWork() {}

--- a/packages/react-server/examples/basic/deps/use-client/re-export/explicit.js
+++ b/packages/react-server/examples/basic/deps/use-client/re-export/explicit.js
@@ -1,0 +1,10 @@
+import React from "react";
+
+export function TestDepReExportExplicit() {
+  const [count, setCount] = React.useState(0);
+  return React.createElement(
+    "button",
+    { onClick: () => setCount((v) => v + 1) },
+    `TestDepReExportExplicit: ${count}`,
+  );
+}

--- a/packages/react-server/examples/basic/deps/use-client/re-export/index.d.ts
+++ b/packages/react-server/examples/basic/deps/use-client/re-export/index.d.ts
@@ -1,0 +1,3 @@
+declare function TestDepReExportExplicit(): JSX.Element;
+
+export { TestDepReExportExplicit };

--- a/packages/react-server/examples/basic/deps/use-client/re-export/index.js
+++ b/packages/react-server/examples/basic/deps/use-client/re-export/index.js
@@ -1,0 +1,6 @@
+"use client";
+
+export { TestDepReExportExplicit } from "./explicit.js";
+
+// currently silently ignored (see https://github.com/hi-ogawa/vite-plugins/pull/579)
+export * from "./all.js";

--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -824,8 +824,20 @@ test("server compnoent > fixture", async ({ page }) => {
 test("server-client-mixed package", async ({ page }) => {
   await page.goto("/test/deps");
   await page.getByText("TestDepMixed(Server)").click();
+  await waitForHydration(page);
   await page.getByRole("button", { name: "TestDepMixed(Client): 0" }).click();
   await page.getByRole("button", { name: "TestDepMixed(Client): 1" }).click();
+});
+
+test("tolerate export all with use client", async ({ page }) => {
+  await page.goto("/test/deps");
+  await waitForHydration(page);
+  await page
+    .getByRole("button", { name: "TestDepReExportExplicit: 0" })
+    .click();
+  await page
+    .getByRole("button", { name: "TestDepReExportExplicit: 1" })
+    .click();
 });
 
 test("client module used at boundary and non-boundary basic", async ({

--- a/packages/react-server/examples/basic/src/routes/test/deps/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/deps/page.tsx
@@ -2,6 +2,7 @@ import { TestVirtualUseClient } from "virtual:test-use-client";
 import { TestDepMixed } from "@hiogawa/test-dep-mixed";
 import { TestDepServerComponent } from "@hiogawa/test-dep-server-component";
 import { TestDepUseClient } from "@hiogawa/test-dep-use-client";
+import { TestDepReExportExplicit } from "@hiogawa/test-dep-use-client/re-export";
 import {
   default as BalancerDefault,
   Balancer as BalancerNamed,
@@ -17,6 +18,9 @@ export default function Page() {
       </div>
       <div>
         <TestDepUseClient />
+      </div>
+      <div>
+        <TestDepReExportExplicit />
       </div>
       <div>
         <TestDepServerComponent />

--- a/packages/react-server/src/features/client-component/plugin.ts
+++ b/packages/react-server/src/features/client-component/plugin.ts
@@ -87,7 +87,9 @@ export function vitePluginServerUseClient({
         // node_modules is already transpiled so we can parse it right away
         const code = await fs.promises.readFile(meta.id, "utf-8");
         const ast = await parseAstAsync(code);
-        meta.exportNames = new Set(getExportNames(ast, {}).exportNames);
+        meta.exportNames = new Set(
+          getExportNames(ast, { ignoreExportAllDeclaration: true }).exportNames,
+        );
         // we need to transform to client reference directly
         // otherwise `soruce` will be resolved infinitely by recursion
         id = wrapId(id);
@@ -95,6 +97,7 @@ export function vitePluginServerUseClient({
           directive: USE_CLIENT,
           id,
           runtime: "$$proxy",
+          ignoreExportAllDeclaration: true,
         });
         tinyassert(output);
         output.prepend(
@@ -147,6 +150,7 @@ export function vitePluginServerUseClient({
         directive: USE_CLIENT,
         id: clientId,
         runtime: "$$proxy",
+        ignoreExportAllDeclaration: true,
       });
       if (!output) {
         return;

--- a/packages/react-server/src/features/server-action/plugin.tsx
+++ b/packages/react-server/src/features/server-action/plugin.tsx
@@ -41,6 +41,7 @@ export function vitePluginClientUseServer({
         directive: USE_SERVER,
         id: serverId,
         runtime: "$$proxy",
+        ignoreExportAllDeclaration: true,
       });
       if (!output) {
         manager.serverReferenceMap.delete(id);


### PR DESCRIPTION
It looks like we'll need this for material ui
- https://github.com/hi-ogawa/material-ui/pull/1

Probably Next.js happens to support this since mui is a broken esm package. Not sure what to do, so just loosen the check, add a test and call it a day.

## todo

- [x] research what Next.js does
  - I think they don't support it either https://github.com/vercel/next.js/blob/4515db1e8376f1df84752377d9f50bf42ba0ddcb/packages/next/src/build/webpack/loaders/next-flight-loader/index.ts#L93-L101
  - probably the reason why mui works is that Next.js probably picks up cjs entries, in which case they have a generous support.
  - well, `@mui/material` is not a genuine ESM at all https://publint.dev/@mui/material@5.16.4 and it doesn't run on plain NodeJS (i.e. broken package)
- [x] test