### PR TITLE
fix(vite-plugin-ssr-css): handle css virtual module via `ssrLoadModule`

### DIFF
--- a/packages/ssr-css/src/collect.ts
+++ b/packages/ssr-css/src/collect.ts
@@ -43,7 +43,9 @@ async function collectStyleUrls(
   await Promise.all(entries.map((url) => traverse(url)));
 
   // filter
-  return [...visited].filter((url) => url.match(CSS_LANGS_RE));
+  return [...visited]
+    .filter((url) => !url.includes("\0"))
+    .filter((url) => url.match(CSS_LANGS_RE));
 }
 
 // cf. https://github.com/vitejs/vite/blob/d6bde8b03d433778aaed62afc2be0630c8131908/packages/vite/src/node/constants.ts#L49C23-L50

--- a/packages/ssr-css/src/plugin.ts
+++ b/packages/ssr-css/src/plugin.ts
@@ -17,9 +17,10 @@ export function vitePluginSsrCss(pluginOpts: { entries: string[] }): Plugin {
       server = server_;
 
       // invalidate virtual modules for each direct request
-      server.middlewares.use((req, _res, next) => {
+      server.middlewares.use((req, res, next) => {
         if (req.url === virtualHref) {
           invalidateModule(server, "\0" + VIRTUAL_ENTRY + "?direct");
+          return res.status(200).set("Content-Type", "text/css").end();
         }
         next();
       });


### PR DESCRIPTION
Thanks for this useful plugin! I was confused about getting a 404, which actually turned out to be a false warning because everything happens in this virtual module.
Sending an empty response gets rid of this.

<img src=https://github.com/user-attachments/assets/9642ee78-79b0-41c4-bdbf-5fd5bf5409d0 width=500>
