### PR TITLE
fix(pre-bundle-new-url): do nothing during dep-scan

### DIFF
--- a/packages/pre-bundle-new-url/src/index.ts
+++ b/packages/pre-bundle-new-url/src/index.ts
@@ -39,6 +39,13 @@ function esbuildPluginNewUrl(options: {
   return {
     name: esbuildPluginNewUrl.name,
     setup(build) {
+      // do nothing during dep-scan
+      if (
+        build.initialOptions.plugins?.find((p) => p.name === "vite:dep-scan")
+      ) {
+        return;
+      }
+
       const resolvedConfig = options.getResolvedConfig();
       const filter = options.filter ?? /\.js$/;
 
@@ -76,7 +83,7 @@ function esbuildPluginNewUrl(options: {
                       outfile,
                       entryPoints: [absUrl],
                       bundle: true,
-                      // TODO: should detect WorkerType and use esm only for `{ type: "module" }`?
+                      // TODO: should we detect WorkerType and use esm only when `{ type: "module" }`?
                       format: "esm",
                       platform: "browser",
                       plugins: [esbuildPluginNewUrl(options)],


### PR DESCRIPTION
Probably the plugin shouldn't intervene during dep scan because that it would steal `onLoad` hooks from Vite's `vite:dep-scan`.