### PR TITLE
fix(pre-bundle-new-url): handle recursive worker reference

### DIFF
--- a/packages/pre-bundle-new-url/examples/basic/vite.config.ts
+++ b/packages/pre-bundle-new-url/examples/basic/vite.config.ts
@@ -3,5 +3,9 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   clearScreen: false,
-  plugins: [vitePluginPreBundleNewUrl()],
+  plugins: [
+    vitePluginPreBundleNewUrl({
+      // debug: true,
+    }),
+  ],
 });

--- a/packages/pre-bundle-new-url/package.json
+++ b/packages/pre-bundle-new-url/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/vite-plugin-pre-bundle-new-url",
-  "version": "0.0.0-pre.0",
+  "version": "0.0.0-pre.1",
   "homepage": "https://github.com/hi-ogawa/vite-plugins/tree/main/packages/pre-bundle-new-url",
   "repository": {
     "type": "git",

--- a/packages/pre-bundle-new-url/src/index.ts
+++ b/packages/pre-bundle-new-url/src/index.ts
@@ -7,6 +7,7 @@ import type { Plugin, ResolvedConfig } from "vite";
 
 export function vitePluginPreBundleNewUrl(options?: {
   filter?: RegExp;
+  debug?: boolean;
 }): Plugin {
   let resolvedConfig: ResolvedConfig;
 
@@ -34,6 +35,7 @@ export function vitePluginPreBundleNewUrl(options?: {
 
 function esbuildPluginNewUrl(options: {
   filter?: RegExp;
+  debug?: boolean;
   getResolvedConfig: () => ResolvedConfig;
 }): esbuild.Plugin {
   return {
@@ -79,6 +81,14 @@ function esbuildPluginNewUrl(options: {
                     resolvedConfig.optimizeDeps.force ||
                     !fs.existsSync(outfile)
                   ) {
+                    if (options.debug) {
+                      console.log(
+                        "[pre-bundenew-url]",
+                        args.path,
+                        "=>",
+                        absUrl,
+                      );
+                    }
                     await esbuild.build({
                       outfile,
                       entryPoints: [absUrl],
@@ -93,6 +103,7 @@ function esbuildPluginNewUrl(options: {
                         //   importScripts("/@vite/env")(() => ...)()
                         js: ";\n",
                       },
+                      logLevel: options.debug ? "debug" : undefined,
                     });
                   }
                   output.update(urlStart, urlEnd, JSON.stringify(outfile));

--- a/packages/pre-bundle-new-url/src/index.ts
+++ b/packages/pre-bundle-new-url/src/index.ts
@@ -39,7 +39,7 @@ export function vitePluginPreBundleNewUrl(options?: {
   };
 }
 
-// track which worker is built to handle recursive worker such as
+// track worker build to handle recursive worker such as
 // https://github.com/gkjohnson/three-mesh-bvh/blob/9718501eee2619f1015fa332d7bddafaf6cf562a/src/workers/parallelMeshBVH.worker.js#L12
 let buildPromiseMap = new Map<string, Promise<unknown>>();
 
@@ -114,7 +114,7 @@ function esbuildPluginNewUrl(options: {
                       logLevel: options.debug ? "debug" : undefined,
                     });
                     buildPromiseMap.set(outfile, buildPromise);
-                    await buildPromise
+                    await buildPromise;
                   }
                   output.update(urlStart, urlEnd, JSON.stringify(outfile));
                 }


### PR DESCRIPTION
Testing it on https://github.com/gkjohnson/three-gpu-pathtracer, it's eating up memory due to never-ending recursive worker bundle
- https://github.com/gkjohnson/three-mesh-bvh/blob/9718501eee2619f1015fa332d7bddafaf6cf562a/src/workers/parallelMeshBVH.worker.js#L12