### PR TITLE
chore: add server wasm example

### DIFF
--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -1618,3 +1618,8 @@ test("envPrefix", async ({ page }) => {
     '{ "MY_PREFIX_ENV_TEST": "yes", "VITE_ENV_TEST": null, "OTHER_ENV_TEST": null }',
   );
 });
+
+test("wasm", async ({ page }) => {
+  await page.goto("/test/wasm");
+  await expect(page.locator("pre.shiki")).toContainText('export default "ok"');
+});

--- a/packages/react-server/examples/basic/misc/cf/build.js
+++ b/packages/react-server/examples/basic/misc/cf/build.js
@@ -27,6 +27,9 @@ async function main() {
     format: "esm",
     platform: "browser",
     external: ["node:async_hooks"],
+    loader: {
+      ".wasm": "copy",
+    },
     define: {
       "process.env.NODE_ENV": `"production"`,
     },

--- a/packages/react-server/examples/basic/misc/vercel/build.js
+++ b/packages/react-server/examples/basic/misc/vercel/build.js
@@ -66,6 +66,9 @@ async function main() {
     format: "esm",
     platform: "browser",
     external: ["node:async_hooks"],
+    loader: {
+      ".wasm": "copy",
+    },
     define: {
       "process.env.NODE_ENV": `"production"`,
     },

--- a/packages/react-server/examples/basic/package.json
+++ b/packages/react-server/examples/basic/package.json
@@ -10,10 +10,10 @@
     "test-e2e": "playwright test",
     "test-e2e-preview": "E2E_PREVIEW=1 playwright test",
     "test-e2e-cf-preview": "E2E_PREVIEW=1 E2E_CF=1 playwright test",
-    "vc-build": "SSR_ENTRY=/src/adapters/vercel-edge pnpm build && node misc/vercel/build.js",
+    "vc-build": "VERCEL=1 SSR_ENTRY=/src/adapters/vercel-edge pnpm build && node misc/vercel/build.js",
     "vc-release": "vercel deploy --prod --prebuilt misc/vercel",
     "vc-release-staging": "vercel deploy --prebuilt misc/vercel",
-    "cf-build": "SSR_ENTRY=/src/adapters/cf pnpm build && node misc/cf/build.js",
+    "cf-build": "CF_PAGES=1 SSR_ENTRY=/src/adapters/cf pnpm build && node misc/cf/build.js",
     "cf-preview": "cd misc/cf && wrangler dev",
     "cf-release": "cd misc/cf && wrangler deploy"
   },

--- a/packages/react-server/examples/basic/package.json
+++ b/packages/react-server/examples/basic/package.json
@@ -27,6 +27,7 @@
     "react-server-dom-webpack": "rc",
     "react-tweet": "^3.2.1",
     "react-wrap-balancer": "^1.1.0",
+    "shiki": "^1.12.1",
     "styled-jsx": "^5.1.6"
   },
   "devDependencies": {

--- a/packages/react-server/examples/basic/package.json
+++ b/packages/react-server/examples/basic/package.json
@@ -43,6 +43,7 @@
     "@types/react": "latest",
     "@types/react-dom": "latest",
     "@vitejs/plugin-react": "^4.3.1",
+    "magic-string": "^0.30.8",
     "unocss": "^0.58.6",
     "vite": "latest"
   }

--- a/packages/react-server/examples/basic/src/routes/test/layout.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/layout.tsx
@@ -33,6 +33,7 @@ export default async function Layout(props: LayoutProps) {
           "/test/catchall-opt",
           "/test/mdx",
           "/test/env",
+          "/test/wasm",
         ]}
       />
       <div className="flex items-center gap-2 text-sm">

--- a/packages/react-server/examples/basic/src/routes/test/wasm/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/wasm/page.tsx
@@ -15,14 +15,19 @@ const getHighlither = once(async () => {
 
 export default async function Page() {
   const highligher = await getHighlither();
-  const code = "const a = 1";
+  const code = `export default "ok"`;
   const html = highligher.codeToHtml(code, {
     lang: "js",
     theme: "nord",
   });
   return (
-    <div>
+    <div className="flex flex-col gap-2 p-2">
       <h4 className="font-bold">Wasm</h4>
+      <style>{`
+        .shiki {
+          padding: 0.5rem 1rem;
+        }
+      `}</style>
       <div dangerouslySetInnerHTML={{ __html: html }}></div>
     </div>
   );

--- a/packages/react-server/examples/basic/src/routes/test/wasm/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/wasm/page.tsx
@@ -1,10 +1,22 @@
-import { codeToHtml } from "shiki";
+import { once } from "@hiogawa/utils";
+import { createHighlighterCore } from "shiki/core";
+import js from "shiki/langs/javascript.mjs";
+import nord from "shiki/themes/nord.mjs";
+
+const getHighlither = once(async () => {
+  return createHighlighterCore({
+    themes: [nord],
+    langs: [js],
+    loadWasm: import("shiki/onig.wasm" as string),
+  });
+});
 
 export default async function Page() {
+  const highligher = await getHighlither();
   const code = "const a = 1";
-  const html = await codeToHtml(code, {
-    lang: "javascript",
-    theme: "vitesse-dark",
+  const html = highligher.codeToHtml(code, {
+    lang: "js",
+    theme: "nord",
   });
   return (
     <div>

--- a/packages/react-server/examples/basic/src/routes/test/wasm/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/wasm/page.tsx
@@ -7,6 +7,8 @@ const getHighlither = once(async () => {
   return createHighlighterCore({
     themes: [nord],
     langs: [js],
+    // non js extension file is not externalized
+    // https://github.com/vitejs/vite/blob/fcf50c2e881356ea0d725cc563722712a2bf5695/packages/vite/src/node/plugins/resolve.ts#L810-L818
     loadWasm: import("shiki/onig.wasm" as string),
   });
 });

--- a/packages/react-server/examples/basic/src/routes/test/wasm/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/wasm/page.tsx
@@ -4,6 +4,27 @@ import js from "shiki/langs/javascript.mjs";
 import nord from "shiki/themes/nord.mjs";
 
 const getHighlither = once(async () => {
+  // https://github.com/nodejs/undici/issues/2751#issuecomment-1944132179
+
+  // const url = new URL("shiki/onig.wasm", import.meta.url);
+  // url;
+  // fetch(new URL("shiki/onig.wasm", import.meta.url));
+
+  // fetch(new URL("shiki/onig.wasm", import.meta.url)).then((res) =>
+  //   res.arrayBuffer(),
+  // );
+  // // const data
+  // const wasmModule = new WebAssembly.Module(
+  //   await fetch(new URL("shiki/onig.wasm", import.meta.url)).then((res) =>
+  //     res.arrayBuffer(),
+  //   ),
+  // );
+  // (await import("node:fs")).promises.readFile(new URL("shiki/onig.wasm", import.meta.url))
+  // transformed to
+  //   import("shiki/onig.wasm")
+  // on cloudflare bundler
+  // fetch
+
   return createHighlighterCore({
     themes: [nord],
     langs: [js],

--- a/packages/react-server/examples/basic/src/routes/test/wasm/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/wasm/page.tsx
@@ -4,27 +4,6 @@ import js from "shiki/langs/javascript.mjs";
 import nord from "shiki/themes/nord.mjs";
 
 const getHighlither = once(async () => {
-  // https://github.com/nodejs/undici/issues/2751#issuecomment-1944132179
-
-  // const url = new URL("shiki/onig.wasm", import.meta.url);
-  // url;
-  // fetch(new URL("shiki/onig.wasm", import.meta.url));
-
-  // fetch(new URL("shiki/onig.wasm", import.meta.url)).then((res) =>
-  //   res.arrayBuffer(),
-  // );
-  // // const data
-  // const wasmModule = new WebAssembly.Module(
-  //   await fetch(new URL("shiki/onig.wasm", import.meta.url)).then((res) =>
-  //     res.arrayBuffer(),
-  //   ),
-  // );
-  // (await import("node:fs")).promises.readFile(new URL("shiki/onig.wasm", import.meta.url))
-  // transformed to
-  //   import("shiki/onig.wasm")
-  // on cloudflare bundler
-  // fetch
-
   return createHighlighterCore({
     themes: [nord],
     langs: [js],

--- a/packages/react-server/examples/basic/src/routes/test/wasm/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/wasm/page.tsx
@@ -22,7 +22,10 @@ export default async function Page() {
   });
   return (
     <div className="flex flex-col gap-2 p-2">
-      <h4 className="font-bold">Wasm</h4>
+      <h4 className="font-lg">Wasm</h4>
+      <a className="antd-link" href="https://github.com/shikijs/shiki">
+        Shiki
+      </a>
       <style>{`
         .shiki {
           padding: 0.5rem 1rem;

--- a/packages/react-server/examples/basic/src/routes/test/wasm/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/wasm/page.tsx
@@ -7,7 +7,7 @@ const getHighlither = once(async () => {
   return createHighlighterCore({
     themes: [nord],
     langs: [js],
-    // non js extension file is not externalized
+    // non js extension file is not externalized, so we can transform this via `load` hook
     // https://github.com/vitejs/vite/blob/fcf50c2e881356ea0d725cc563722712a2bf5695/packages/vite/src/node/plugins/resolve.ts#L810-L818
     loadWasm: import("shiki/onig.wasm" as string),
   });

--- a/packages/react-server/examples/basic/src/routes/test/wasm/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/wasm/page.tsx
@@ -1,0 +1,15 @@
+import { codeToHtml } from "shiki";
+
+export default async function Page() {
+  const code = "const a = 1";
+  const html = await codeToHtml(code, {
+    lang: "javascript",
+    theme: "vitesse-dark",
+  });
+  return (
+    <div>
+      <h4 className="font-bold">Wasm</h4>
+      <div dangerouslySetInnerHTML={{ __html: html }}></div>
+    </div>
+  );
+}

--- a/packages/react-server/examples/basic/tsconfig.json
+++ b/packages/react-server/examples/basic/tsconfig.json
@@ -1,11 +1,5 @@
 {
-  "include": [
-    "src",
-    "e2e",
-    "vite.config.ts",
-    "uno.config.ts",
-    "playwright.config.ts"
-  ],
+  "include": ["src", "e2e", "*.ts"],
   "compilerOptions": {
     "strict": true,
     "noUnusedLocals": true,

--- a/packages/react-server/examples/basic/vite-plugin-wasm-module.ts
+++ b/packages/react-server/examples/basic/vite-plugin-wasm-module.ts
@@ -1,0 +1,141 @@
+import fs from "node:fs";
+import path from "node:path";
+import MagicString from "magic-string";
+import { type ConfigEnv, type Plugin } from "vite";
+
+// normalize wasm import based on environments
+// - CF: keep import "xxx.wasm"
+// - Vercel edge: rewrite to import "xxx.wasm?module"
+// - Others: replace it with explicit instantiation of `WebAssembly.Module`
+//   - inline
+//   - local asset + fs.readFile
+// https://developers.cloudflare.com/pages/functions/module-support/#webassembly-modules
+// https://github.com/withastro/adapters/blob/cd4c0842aadc58defc67f4ccf6d6ef6f0401a9ac/packages/cloudflare/src/utils/cloudflare-module-loader.ts#L213-L216
+// https://vercel.com/docs/functions/wasm
+// https://github.com/unjs/unwasm
+
+export function wasmModulePlugin(options: {
+  mode: "inline" | "asset-fs" | "asset-import";
+}): Plugin {
+  let env: ConfigEnv;
+  return {
+    name: wasmModulePlugin.name,
+    config(_config, env_) {
+      env = env_;
+    },
+    load(id) {
+      if (id.endsWith(".wasm")) {
+        // inline + WebAssembly.Module
+        if (options.mode === "inline") {
+          const base64 = fs.readFileSync(id).toString("base64");
+          return `
+            const buffer = Uint8Array.from(atob("${base64}"), c => c.charCodeAt(0));
+            export default new WebAssembly.Module(buffer);
+          `;
+        }
+
+        // file + WebAssembly.Module
+        if (options.mode === "asset-fs") {
+          let source = JSON.stringify(id);
+          if (env.command === "build") {
+            const referenceId = this.emitFile({
+              type: "asset",
+              name: path.basename(id),
+              source: fs.readFileSync(id),
+            });
+            source = `fileURLToPath(import.meta.ROLLUP_FILE_URL_${referenceId})`;
+          }
+          return `
+            import fs from "node:fs";
+            import { fileURLToPath } from "node:url";
+            const buffer = fs.readFileSync(${source});
+            export default new WebAssembly.Module(buffer);
+          `;
+        }
+
+        // keep wasm import
+        if (options.mode === "asset-import") {
+          if (env.command === "build") {
+            const referenceId = this.emitFile({
+              type: "asset",
+              name: path.basename(id),
+              source: fs.readFileSync(id),
+            });
+            // temporary placeholder replaced during renderChunk
+            return `export default "__WASM_IMPORT_URL_${referenceId}"`;
+          }
+        }
+      }
+    },
+    renderChunk(code, chunk) {
+      const matches = code.matchAll(/"__WASM_IMPORT_URL_(\w+)"/dg);
+      const output = new MagicString(code);
+      for (const match of matches) {
+        const referenceId = match[1];
+        const assetFileName = this.getFileName(referenceId);
+        const importSource =
+          "./" +
+          path.relative(
+            path.resolve(chunk.fileName, ".."),
+            path.resolve(assetFileName),
+          );
+        const importName = `__wasm_${referenceId}`;
+        const [start, end] = match.indices![0];
+        output.prepend(`import ${importName} from "${importSource}";\n`);
+        output.update(start, end, importName);
+      }
+      if (output.hasChanged()) {
+        return output.toString();
+      }
+    },
+  };
+}
+
+// copied from https://github.com/hi-ogawa/reproductions/blob/7c97fab6ca35d67711557f7463b311a71d959e42/webpack-new-url-worker-bundle-or-copy/rollup.config.ts
+export function assetImportMetaUrlPlugin(): Plugin {
+  // https://github.com/vitejs/vite/blob/0f56e1724162df76fffd5508148db118767ebe32/packages/vite/src/node/plugins/assetImportMetaUrl.ts#L51-L52
+  const assetImportMetaUrlRE =
+    /\bnew\s+URL\s*\(\s*('[^']+'|"[^"]+"|`[^`]+`)\s*,\s*import\.meta\.url\s*(?:,\s*)?\)/dg;
+
+  return {
+    name: assetImportMetaUrlPlugin.name,
+    apply: (_config, env) => !!env.isSsrBuild,
+    transform(code, id) {
+      if (code.includes("import.meta.url")) {
+        // replace
+        //   new URL("./asset.svg", import.meta.url)
+        // with
+        //   new URL(import.meta.ROLLUP_FILE_URL_xxx)
+        // which in turn rollup repalces with
+        //   new URL(new URL("...", import.meta.url).href)
+        const output = new MagicString(code);
+        const matches = code.matchAll(assetImportMetaUrlRE);
+        for (const match of matches) {
+          const url = match[1]!.slice(1, -1);
+          if (url[0] !== "/") {
+            const absUrl = path.resolve(path.dirname(id), url);
+            if (fs.existsSync(absUrl)) {
+              const referenceId = this.emitFile({
+                type: "asset",
+                name: path.basename(absUrl),
+                source: fs.readFileSync(absUrl),
+              });
+              const [start, end] = match.indices![0]!;
+              output.update(
+                start,
+                end,
+                `new URL(import.meta.ROLLUP_FILE_URL_${referenceId})`,
+              );
+            }
+          }
+        }
+        if (output.hasChanged()) {
+          return {
+            code: output.toString(),
+            map: output.generateMap(),
+          };
+        }
+      }
+    },
+  };
+}

--- a/packages/react-server/examples/basic/vite.config.ts
+++ b/packages/react-server/examples/basic/vite.config.ts
@@ -32,7 +32,10 @@ export default defineConfig({
         mdx(),
         testVitePluginVirtual(),
         wasmModulePlugin({
-          mode: process.env.CF_PAGES ? "asset-import" : "asset-fs",
+          mode:
+            process.env.VERCEL || process.env.CF_PAGES
+              ? "asset-import"
+              : "asset-fs",
         }),
         {
           name: "cusotm-react-server-config",

--- a/packages/react-server/examples/basic/vite.config.ts
+++ b/packages/react-server/examples/basic/vite.config.ts
@@ -9,10 +9,7 @@ import mdx from "@mdx-js/rollup";
 import react from "@vitejs/plugin-react";
 import unocss from "unocss/vite";
 import { type Plugin, defineConfig } from "vite";
-import {
-  assetImportMetaUrlPlugin,
-  wasmModulePlugin,
-} from "./vite-plugin-wasm-module";
+import { wasmModulePlugin } from "./vite-plugin-wasm-module";
 
 export default defineConfig({
   clearScreen: false,
@@ -54,8 +51,6 @@ export default defineConfig({
         },
       ],
     }),
-    wasmModulePlugin({ mode: "asset-import" }),
-    assetImportMetaUrlPlugin(),
     vitePluginLogger(),
     vitePluginSsrMiddleware({
       entry: process.env["SSR_ENTRY"] || "/src/adapters/node.ts",

--- a/packages/react-server/examples/basic/vite.config.ts
+++ b/packages/react-server/examples/basic/vite.config.ts
@@ -1,4 +1,3 @@
-import fs from "node:fs";
 import path from "node:path";
 import { vitePluginReactServer } from "@hiogawa/react-server/plugin";
 import { vitePluginErrorOverlay } from "@hiogawa/vite-plugin-error-overlay";
@@ -8,9 +7,12 @@ import {
 } from "@hiogawa/vite-plugin-ssr-middleware";
 import mdx from "@mdx-js/rollup";
 import react from "@vitejs/plugin-react";
-import MagicString from "magic-string";
 import unocss from "unocss/vite";
-import { type ConfigEnv, type Plugin, defineConfig } from "vite";
+import { type Plugin, defineConfig } from "vite";
+import {
+  assetImportMetaUrlPlugin,
+  wasmModulePlugin,
+} from "./vite-plugin-wasm-module";
 
 export default defineConfig({
   clearScreen: false,
@@ -107,141 +109,6 @@ function testVitePluginVirtual(): Plugin {
         `.trimStart();
       }
       return;
-    },
-  };
-}
-
-// normalize wasm import based on environments
-// - CF: keep import "xxx.wasm"
-// - Vercel edge: rewrite to import "xxx.wasm?module"
-// - Others: replace it with explicit instantiation of `WebAssembly.Module`
-//   - inline
-//   - local asset + fs.readFile
-// https://developers.cloudflare.com/pages/functions/module-support/#webassembly-modules
-// https://github.com/withastro/adapters/blob/cd4c0842aadc58defc67f4ccf6d6ef6f0401a9ac/packages/cloudflare/src/utils/cloudflare-module-loader.ts#L213-L216
-// https://vercel.com/docs/functions/wasm
-// https://github.com/unjs/unwasm
-function wasmModulePlugin(options: {
-  mode: "inline" | "asset-fs" | "asset-import";
-}): Plugin {
-  let env: ConfigEnv;
-  return {
-    name: wasmModulePlugin.name,
-    config(_config, env_) {
-      env = env_;
-    },
-    load(id) {
-      if (id.endsWith(".wasm")) {
-        // inline + WebAssembly.Module
-        if (options.mode === "inline") {
-          const base64 = fs.readFileSync(id).toString("base64");
-          return `
-            const buffer = Uint8Array.from(atob("${base64}"), c => c.charCodeAt(0));
-            export default new WebAssembly.Module(buffer);
-          `;
-        }
-
-        // file + WebAssembly.Module
-        if (options.mode === "asset-fs") {
-          let source = JSON.stringify(id);
-          if (env.command === "build") {
-            const referenceId = this.emitFile({
-              type: "asset",
-              name: path.basename(id),
-              source: fs.readFileSync(id),
-            });
-            source = `fileURLToPath(import.meta.ROLLUP_FILE_URL_${referenceId})`;
-          }
-          return `
-            import fs from "node:fs";
-            import { fileURLToPath } from "node:url";
-            const buffer = fs.readFileSync(${source});
-            export default new WebAssembly.Module(buffer);
-          `;
-        }
-
-        // keep wasm import
-        if (options.mode === "asset-import") {
-          if (env.command === "build") {
-            const referenceId = this.emitFile({
-              type: "asset",
-              name: path.basename(id),
-              source: fs.readFileSync(id),
-            });
-            // temporary placeholder replaced during renderChunk
-            return `export default "__WASM_IMPORT_URL_${referenceId}"`;
-          }
-        }
-      }
-    },
-    renderChunk(code, chunk) {
-      const matches = code.matchAll(/"__WASM_IMPORT_URL_(\w+)"/dg);
-      const output = new MagicString(code);
-      for (const match of matches) {
-        const referenceId = match[1];
-        const assetFileName = this.getFileName(referenceId);
-        const importSource =
-          "./" +
-          path.relative(
-            path.resolve(chunk.fileName, ".."),
-            path.resolve(assetFileName),
-          );
-        const importName = `__wasm_${referenceId}`;
-        const [start, end] = match.indices![0];
-        output.prepend(`import ${importName} from "${importSource}";\n`);
-        output.update(start, end, importName);
-      }
-      if (output.hasChanged()) {
-        return output.toString();
-      }
-    },
-  };
-}
-
-function assetImportMetaUrlPlugin(): Plugin {
-  // https://github.com/vitejs/vite/blob/0f56e1724162df76fffd5508148db118767ebe32/packages/vite/src/node/plugins/assetImportMetaUrl.ts#L51-L52
-  const assetImportMetaUrlRE =
-    /\bnew\s+URL\s*\(\s*('[^']+'|"[^"]+"|`[^`]+`)\s*,\s*import\.meta\.url\s*(?:,\s*)?\)/dg;
-
-  return {
-    name: assetImportMetaUrlPlugin.name,
-    apply: (_config, env) => !!env.isSsrBuild,
-    transform(code, id) {
-      if (code.includes("import.meta.url")) {
-        // replace
-        //   new URL("./asset.svg", import.meta.url)
-        // with
-        //   new URL(import.meta.ROLLUP_FILE_URL_xxx)
-        // which in turn rollup repalces with
-        //   new URL(new URL("...", import.meta.url).href)
-        const output = new MagicString(code);
-        const matches = code.matchAll(assetImportMetaUrlRE);
-        for (const match of matches) {
-          const url = match[1]!.slice(1, -1);
-          if (url[0] !== "/") {
-            const absUrl = path.resolve(path.dirname(id), url);
-            if (fs.existsSync(absUrl)) {
-              const referenceId = this.emitFile({
-                type: "asset",
-                name: path.basename(absUrl),
-                source: fs.readFileSync(absUrl),
-              });
-              const [start, end] = match.indices![0]!;
-              output.update(
-                start,
-                end,
-                `new URL(import.meta.ROLLUP_FILE_URL_${referenceId})`,
-              );
-            }
-          }
-        }
-        if (output.hasChanged()) {
-          return {
-            code: output.toString(),
-            map: output.generateMap(),
-          };
-        }
-      }
     },
   };
 }

--- a/packages/react-server/examples/basic/vite.config.ts
+++ b/packages/react-server/examples/basic/vite.config.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import { vitePluginReactServer } from "@hiogawa/react-server/plugin";
 import { vitePluginErrorOverlay } from "@hiogawa/vite-plugin-error-overlay";
@@ -29,6 +30,7 @@ export default defineConfig({
         // see https://mdxjs.com/docs/getting-started/#vite for how to setup client hmr.
         mdx(),
         testVitePluginVirtual(),
+        wasmModulePlugin(),
         {
           name: "cusotm-react-server-config",
           config() {
@@ -94,6 +96,19 @@ function testVitePluginVirtual(): Plugin {
         `.trimStart();
       }
       return;
+    },
+  };
+}
+
+// https://github.com/withastro/adapters/blob/cd4c0842aadc58defc67f4ccf6d6ef6f0401a9ac/packages/cloudflare/src/utils/cloudflare-module-loader.ts#L213-L216
+function wasmModulePlugin(): Plugin {
+  return {
+    name: wasmModulePlugin.name,
+    load(id) {
+      if (id.endsWith(".wasm")) {
+        const base64 = fs.readFileSync(id).toString("base64");
+        return `export default new WebAssembly.Module(Uint8Array.from(atob("${base64}"), c => c.charCodeAt(0)));`;
+      }
     },
   };
 }

--- a/packages/react-server/examples/basic/vite.config.ts
+++ b/packages/react-server/examples/basic/vite.config.ts
@@ -112,3 +112,10 @@ function wasmModulePlugin(): Plugin {
     },
   };
 }
+
+// function fetchServerFileTransformPlugin(): Plugin {
+//   return {
+//     name: fetchServerFileTransformPlugin.name,
+//     // fs
+//   }
+// }

--- a/packages/react-server/examples/basic/vite.config.ts
+++ b/packages/react-server/examples/basic/vite.config.ts
@@ -12,7 +12,7 @@ import MagicString from "magic-string";
 import unocss from "unocss/vite";
 import { type ConfigEnv, type Plugin, defineConfig } from "vite";
 
-export default defineConfig(async (_env) => ({
+export default defineConfig({
   clearScreen: false,
   plugins: [
     process.env["USE_SWC"]
@@ -66,7 +66,7 @@ export default defineConfig(async (_env) => ({
           next();
         });
       },
-    } satisfies Plugin,
+    },
     testVitePluginVirtual(),
   ],
   build: {
@@ -83,7 +83,7 @@ export default defineConfig(async (_env) => ({
     ],
   },
   envPrefix: "MY_PREFIX_",
-}));
+});
 
 function testVitePluginVirtual(): Plugin {
   return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,6 +225,9 @@ importers:
       react-wrap-balancer:
         specifier: ^1.1.0
         version: 1.1.0(react@19.0.0-rc-df5f2736-20240712)
+      shiki:
+        specifier: ^1.12.1
+        version: 1.12.1
       styled-jsx:
         specifier: ^5.1.6
         version: 5.1.6(@babel/core@7.24.7)(react@19.0.0-rc-df5f2736-20240712)
@@ -2407,6 +2410,9 @@ packages:
     resolution: {integrity: sha512-yjk2MAkQmoaPYCSu35RLJ62+dz358nE83VfTePJRp8CG7aMg25mEJYpXFiD+NcevhX8LxD5OP5tktPXnXN7GDw==}
     cpu: [x64]
     os: [win32]
+
+  '@shikijs/core@1.12.1':
+    resolution: {integrity: sha512-biCz/mnkMktImI6hMfMX3H9kOeqsInxWEyCHbSlL8C/2TR1FqfmGxTLRNwYCKsyCyxWLbB8rEqXRVZuyxuLFmA==}
 
   '@shuding/opentype.js@1.4.0-beta.0':
     resolution: {integrity: sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==}
@@ -5031,6 +5037,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  shiki@1.12.1:
+    resolution: {integrity: sha512-nwmjbHKnOYYAe1aaQyEBHvQymJgfm86ZSS7fT8OaPRr4sbAcBNz7PbfAikMEFSDQ6se2j2zobkXvVKcBOm0ysg==}
+
   side-channel@1.0.6:
     resolution: {integrity: sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==}
     engines: {node: '>= 0.4'}
@@ -7022,6 +7031,10 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.18.1':
     optional: true
 
+  '@shikijs/core@1.12.1':
+    dependencies:
+      '@types/hast': 3.0.4
+
   '@shuding/opentype.js@1.4.0-beta.0':
     dependencies:
       fflate: 0.7.4
@@ -7186,7 +7199,7 @@ snapshots:
 
   '@types/hast@3.0.4':
     dependencies:
-      '@types/unist': 2.0.10
+      '@types/unist': 3.0.2
 
   '@types/http-errors@2.0.4': {}
 
@@ -10356,6 +10369,11 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shiki@1.12.1:
+    dependencies:
+      '@shikijs/core': 1.12.1
+      '@types/hast': 3.0.4
 
   side-channel@1.0.6:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,6 +268,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.1
         version: 4.3.1(vite@5.3.3(@types/node@20.14.10)(terser@5.31.2))
+      magic-string:
+        specifier: ^0.30.8
+        version: 0.30.10
       unocss:
         specifier: ^0.58.6
         version: 0.58.6(postcss@8.4.39)(rollup@4.18.1)(vite@5.3.3(@types/node@20.14.10)(terser@5.31.2))


### PR DESCRIPTION
- closes https://github.com/users/hi-ogawa/projects/4/views/1?pane=issue&itemId=74354460
- related https://github.com/hi-ogawa/vite-plugins/pull/548

<details><summary>old discussion</summary>

## todo

- [ ]  implement `new URL(..., import.meta.url)` asset relocation for server build
  - [ ] vite (rollup) plugin (for user code + inline dep)
  - [ ] esbuild plugin (for external dep and adapter build)
- [ ] implement cloudflare adapter specific `.wasm`  module
  - https://developers.cloudflare.com/pages/functions/module-support/#webassembly-modules

---

Unfortunately, we cannot make `new URL(...)` convention as a base logic. Since cloudflare can take only `import "xxx.wasm"`, we need to make wasm module import as a common denominator and we need to lower down for other platform cf astro cloudflare adapter https://github.com/withastro/adapters/blob/cd4c0842aadc58defc67f4ccf6d6ef6f0401a9ac/packages/cloudflare/src/utils/cloudflare-module-loader.ts#L213-L216

Or we could provide a polyfill/transform for potential universal patterns like `fetch(new URL(..., import.meta.url))`
- https://github.com/nodejs/undici/issues/2751

</details>

---

Changing the direction, we start with `import wasmModule from "some-file.wasm"` and transform this for various environemtns:

- [x] cf
  - emit/relocate `.wasm` file but keep `import wasmModule from "./relocated-file.wasm"`
  - use `{ ".wasm": "copy" }` loader for esbuild adapter bundle
- [x] vercel edge
  - the documentation says `xxx.wasm?module` https://vercel.com/docs/functions/wasm, but it looks like it's not needed fro  `--prebuilt`, so vercel edge is same as cf
- [x] node / vercel function
  - emit/relocate `.wasm` and load it via `fs.readFileSync(new URL(..., import.meta.url).href)`
  - (later) need `new URL(..., import.meta.url)` for esbuild adapter build like https://github.com/hi-ogawa/vite-plugins/tree/main/packages/pre-bundle-new-url 

## todo

- [x] test
- [x] deployment