### PR TITLE
feat(pre-bundle-new-url): make esbuild plugin usable outside of Vite optimizer

### DIFF
--- a/packages/pre-bundle-new-url/README.md
+++ b/packages/pre-bundle-new-url/README.md
@@ -17,8 +17,8 @@ new Worker(new URL("./worker.js", import.meta.url))
 
 // ⇓ transform (worker.js is recursively bundled using esbuild)
 
-new URL("./__assets-image-(hash).svg", import.meta.url)
-new Worker(new URL("./__workers-worker-(hash).js", import.meta.url))
+new URL("./__asset-image-(hash).svg", import.meta.url)
+new Worker(new URL("./__worker-worker-(hash).js", import.meta.url))
 ```
 
 Note that this is only to support `new URL` in _external packages_ during _development_

--- a/packages/pre-bundle-new-url/README.md
+++ b/packages/pre-bundle-new-url/README.md
@@ -17,11 +17,11 @@ new Worker(new URL("./worker.js", import.meta.url))
 
 // ⇓ transform (worker.js is recursively bundled using esbuild)
 
-new URL("/absoute-path-to/node_modules/some-package/image.svg", import.meta.url)
-new Worker(new URL("/absolute-path-to/node_modules/.vite/__worker/some_package_worker_js-(hash).js", import.meta.url))
+new URL("./__assets/image-(hash).svg", import.meta.url)
+new Worker(new URL("./__workers/worker-(hash).js", import.meta.url))
 ```
 
-Note that this is only for _external packages_ during _development_
+Note that this is only to support `new URL` in _external packages_ during _development_
 since Vite's normal transform pipeline works for non pre-bundled code.
 
 ## related

--- a/packages/pre-bundle-new-url/README.md
+++ b/packages/pre-bundle-new-url/README.md
@@ -17,8 +17,8 @@ new Worker(new URL("./worker.js", import.meta.url))
 
 // ⇓ transform (worker.js is recursively bundled using esbuild)
 
-new URL("./__assets/image-(hash).svg", import.meta.url)
-new Worker(new URL("./__workers/worker-(hash).js", import.meta.url))
+new URL("./__assets-image-(hash).svg", import.meta.url)
+new Worker(new URL("./__workers-worker-(hash).js", import.meta.url))
 ```
 
 Note that this is only to support `new URL` in _external packages_ during _development_

--- a/packages/pre-bundle-new-url/examples/basic/deps/worker/worker-esm.js
+++ b/packages/pre-bundle-new-url/examples/basic/deps/worker/worker-esm.js
@@ -3,10 +3,10 @@ import { workerDep } from "./worker-dep.js";
 self.onmessage = async () => {
   const { workerDepDynamic } = await import("./worker-dep-dynamic.js");
   const data = {
-    "self.location.href": self.location.href,
+    href: self.location.href,
+    viteSvg: new URL("./vite.svg", import.meta.url).href,
     workerDep,
     workerDepDynamic,
-    viteSvg: new URL("./vite.svg", import.meta.url),
   };
-  self.postMessage(JSON.stringify(data, null, 2));
+  self.postMessage(data);
 };

--- a/packages/pre-bundle-new-url/examples/basic/deps/worker/worker.js
+++ b/packages/pre-bundle-new-url/examples/basic/deps/worker/worker.js
@@ -3,9 +3,9 @@ import { workerDep } from "./worker-dep.js";
 self.onmessage = async () => {
   const { workerDepDynamic } = await import("./worker-dep-dynamic.js");
   const data = {
-    "self.location.href": self.location.href,
+    href: self.location.href,
     workerDep,
     workerDepDynamic,
   };
-  self.postMessage(JSON.stringify(data, null, 2));
+  self.postMessage(data);
 };

--- a/packages/pre-bundle-new-url/examples/basic/src/main.js
+++ b/packages/pre-bundle-new-url/examples/basic/src/main.js
@@ -8,6 +8,7 @@ async function main() {
     "image1",
     `\
 <h4>new URL("./vite.svg", import.meta.url)</h4>
+<a href="${testDepImage.image1}">${testDepImage.image1}</a><br/>
 <img width="40" src="${testDepImage.image1}" />
 `,
   );
@@ -16,6 +17,7 @@ async function main() {
     "image2",
     `\
 <h4>new URL("vite.svg", import.meta.url)</h4>
+<a href="${testDepImage.image2}">${testDepImage.image2}</a><br/>
 <img width="40" src="${testDepImage.image2}" />
 `,
   );
@@ -25,7 +27,8 @@ async function main() {
       "worker-classic",
       `\
 <h4>worker-classic</h4>
-<pre>${e.data}</pre>
+<a href="${e.data.href}">${e.data.href}</a><br/>
+<pre>${JSON.stringify(e.data, null, 2)}</pre>
 `,
     );
   });
@@ -35,7 +38,9 @@ async function main() {
       "worker-esm",
       `\
 <h4>worker-esm</h4>
-<pre>worker-esm = ${e.data}</pre>
+<a href="${e.data.href}">${e.data.href}</a><br/>
+<a href="${e.data.viteSvg}">${e.data.viteSvg}</a><br/>
+<pre>${JSON.stringify(e.data, null, 2)}</pre>
 `,
     );
   });

--- a/packages/pre-bundle-new-url/package.json
+++ b/packages/pre-bundle-new-url/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/vite-plugin-pre-bundle-new-url",
-  "version": "0.0.0-pre.6",
+  "version": "0.0.0-pre.7",
   "homepage": "https://github.com/hi-ogawa/vite-plugins/tree/main/packages/pre-bundle-new-url",
   "repository": {
     "type": "git",

--- a/packages/pre-bundle-new-url/package.json
+++ b/packages/pre-bundle-new-url/package.json
@@ -22,10 +22,13 @@
     "prepack": "tsup --clean"
   },
   "dependencies": {
-    "esbuild": "^0.21.5",
     "magic-string": "^0.30.8"
   },
+  "devDependencies": {
+    "esbuild": "^0.21.5"
+  },
   "peerDependencies": {
-    "vite": "*"
+    "vite": "*",
+    "esbuild": "*"
   }
 }

--- a/packages/pre-bundle-new-url/src/index.ts
+++ b/packages/pre-bundle-new-url/src/index.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs";
 import path from "node:path";
-import { tinyassert } from "@hiogawa/utils";
 import * as esbuild from "esbuild";
 import MagicString from "magic-string";
 import type { Plugin } from "vite";
@@ -44,11 +43,6 @@ export function esbuildPluginPreBundleNewUrl({
         return;
       }
 
-      // uses .vite/deps_temp_xxx directory
-      // https://github.com/vitejs/vite/blob/321b213756a1e69eb0ddc4dc06e59a30db099c8e/packages/vite/src/node/optimizer/index.ts#L810
-      tinyassert(build.initialOptions.outdir, "'outdir' option is required.");
-      const outdir = build.initialOptions.outdir;
-
       build.onLoad({ filter, namespace: "file" }, async (args) => {
         const data = await fs.promises.readFile(args.path, "utf-8");
         if (data.includes("import.meta.url")) {
@@ -89,7 +83,8 @@ export function esbuildPluginPreBundleNewUrl({
                         .at(-1)!
                         .replace(/[^0-9a-zA-Z]/g, "_") + ".js";
                     bundlePromise = esbuild.build({
-                      outdir,
+                      absWorkingDir: build.initialOptions.absWorkingDir,
+                      outdir: build.initialOptions.outdir,
                       entryPoints: {
                         [entryName]: absUrl,
                       },

--- a/packages/pre-bundle-new-url/src/index.ts
+++ b/packages/pre-bundle-new-url/src/index.ts
@@ -102,6 +102,8 @@ export function esbuildPluginPreBundleNewUrl({
                       metafile: true,
                       // TODO: should we detect WorkerType and use esm only when `{ type: "module" }`?
                       format: "esm",
+                      // TODO: worker condition? https://github.com/vitejs/vite/issues/7439
+                      // conditions: ["worker"],
                       plugins: [
                         esbuildPluginPreBundleNewUrl({
                           filter,

--- a/packages/pre-bundle-new-url/src/index.ts
+++ b/packages/pre-bundle-new-url/src/index.ts
@@ -87,8 +87,13 @@ export function esbuildPluginPreBundleNewUrl({
                   if (!bundlePromise) {
                     const entryName = makeOutputFilename(absUrl);
                     bundlePromise = esbuild.build({
+                      // inherit config
                       absWorkingDir: build.initialOptions.absWorkingDir,
                       outdir: build.initialOptions.outdir,
+                      platform: build.initialOptions.platform,
+                      define: build.initialOptions.define,
+                      target: build.initialOptions.target,
+                      // own config
                       entryPoints: {
                         [entryName]: absUrl,
                       },
@@ -97,7 +102,6 @@ export function esbuildPluginPreBundleNewUrl({
                       metafile: true,
                       // TODO: should we detect WorkerType and use esm only when `{ type: "module" }`?
                       format: "esm",
-                      platform: "browser",
                       plugins: [
                         esbuildPluginPreBundleNewUrl({
                           filter,

--- a/packages/pre-bundle-new-url/src/index.ts
+++ b/packages/pre-bundle-new-url/src/index.ts
@@ -68,7 +68,10 @@ export function esbuildPluginPreBundleNewUrl({
 
               const url = match[2]!.slice(1, -1);
               if (url[0] !== "/") {
-                // TODO: use build.resolve?
+                // TODO: use build.resolve? https://esbuild.github.io/plugins/#resolve
+                // however esbuild requires explicit "./", so need to resolve twice for
+                // - build.resolve("relative-or-package")
+                // - build.resolve("./relative-or-package")
                 const absUrl = path.resolve(path.dirname(args.path), url);
 
                 if (fs.existsSync(absUrl)) {

--- a/packages/pre-bundle-new-url/src/index.ts
+++ b/packages/pre-bundle-new-url/src/index.ts
@@ -77,11 +77,10 @@ export function esbuildPluginPreBundleNewUrl({
                   }
                   let bundlePromise = bundleMap.get(absUrl);
                   if (!bundlePromise) {
-                    const entryName =
-                      absUrl
-                        .split("/node_modules/")
-                        .at(-1)!
-                        .replace(/[^0-9a-zA-Z]/g, "_") + ".js";
+                    const entryName = absUrl
+                      .split("/node_modules/")
+                      .at(-1)!
+                      .replace(/[^0-9a-zA-Z]/g, "_");
                     bundlePromise = esbuild.build({
                       absWorkingDir: build.initialOptions.absWorkingDir,
                       outdir: build.initialOptions.outdir,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,15 +95,16 @@ importers:
 
   packages/pre-bundle-new-url:
     dependencies:
-      esbuild:
-        specifier: ^0.21.5
-        version: 0.21.5
       magic-string:
         specifier: ^0.30.8
         version: 0.30.10
       vite:
         specifier: ^5.3.3
         version: 5.3.3(@types/node@20.14.10)(terser@5.31.2)
+    devDependencies:
+      esbuild:
+        specifier: ^0.21.5
+        version: 0.21.5
 
   packages/pre-bundle-new-url/examples/basic:
     dependencies:


### PR DESCRIPTION
It looks like it's possible to make it agnostic to Vite since `build.initialOptions` gives enough information about where to put the output. The only assumption is that output files are flattened in a single directory like Vite's deps optimization.