### PR TITLE
refactor: perf: externalize rsc build from ssr build

### DIFF
--- a/packages/react-server/examples/custom-out-dir/e2e/basic.test.ts
+++ b/packages/react-server/examples/custom-out-dir/e2e/basic.test.ts
@@ -9,7 +9,7 @@ test("custom outDir app can be visited", async ({ page }) => {
   if (!process.env.E2E_CF) {
     await expect(page.getByTestId("import-meta-url")).toContainText(
       process.env.E2E_PREVIEW
-        ? "examples/custom-out-dir/custom-out-dir/server"
+        ? "examples/custom-out-dir/custom-out-dir/rsc/"
         : "examples/custom-out-dir/app/page.tsx",
     );
   }

--- a/packages/react-server/src/entry/ssr.tsx
+++ b/packages/react-server/src/entry/ssr.tsx
@@ -81,13 +81,6 @@ export async function importReactServer(): Promise<typeof import("./server")> {
   if (import.meta.env.DEV) {
     return $__global.dev.reactServer.ssrLoadModule(ENTRY_SERVER_WRAPPER) as any;
   } else {
-    // TODO: process this as relative external e.g.
-    // dist/
-    //   server/index.js
-    //   rsc/index.js
-    // where
-    //   server/index.js can simply have
-    //     await import("../rsc/index.js")
     return import("virtual:react-server-build" as string);
   }
 }

--- a/packages/react-server/src/entry/ssr.tsx
+++ b/packages/react-server/src/entry/ssr.tsx
@@ -254,6 +254,13 @@ async function importRouteManifest(): Promise<{
   if (import.meta.env.DEV) {
     return { routeManifest: emptyRouteManifest() };
   } else {
+    // TODO: process this as relative external e.g.
+    // dist/
+    //   server/index.js
+    //   rsc/index.js
+    // where
+    //   server/index.js can simply do
+    //     await import("../rsc/index.js")
     const mod = await import("virtual:route-manifest" as string);
     return mod.default;
   }

--- a/packages/react-server/src/entry/ssr.tsx
+++ b/packages/react-server/src/entry/ssr.tsx
@@ -81,6 +81,13 @@ export async function importReactServer(): Promise<typeof import("./server")> {
   if (import.meta.env.DEV) {
     return $__global.dev.reactServer.ssrLoadModule(ENTRY_SERVER_WRAPPER) as any;
   } else {
+    // TODO: process this as relative external e.g.
+    // dist/
+    //   server/index.js
+    //   rsc/index.js
+    // where
+    //   server/index.js can simply have
+    //     await import("../rsc/index.js")
     return import("virtual:react-server-build" as string);
   }
 }
@@ -254,13 +261,6 @@ async function importRouteManifest(): Promise<{
   if (import.meta.env.DEV) {
     return { routeManifest: emptyRouteManifest() };
   } else {
-    // TODO: process this as relative external e.g.
-    // dist/
-    //   server/index.js
-    //   rsc/index.js
-    // where
-    //   server/index.js can simply do
-    //     await import("../rsc/index.js")
     const mod = await import("virtual:route-manifest" as string);
     return mod.default;
   }

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -443,9 +443,18 @@ export function vitePluginReactServer(
       "server-only": `'server-only' is included in client build`,
     }),
 
-    createVirtualPlugin("react-server-build", () => {
-      return `export * from "/${outDir}/rsc/index.js";`;
-    }),
+    // createVirtualPlugin("react-server-build", () => {
+    //   return `export * from "/${outDir}/rsc/index.js";`;
+    // }),
+    {
+      name: "virtual:react-server-build",
+      resolveId(source) {
+        if (source === "virtual:react-server-build") {
+          return { id: "../rsc/index.js", external: true };
+        }
+        return;
+      },
+    },
 
     createVirtualPlugin("client-routes", () => {
       return `

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -443,13 +443,13 @@ export function vitePluginReactServer(
       "server-only": `'server-only' is included in client build`,
     }),
 
-    // createVirtualPlugin("react-server-build", () => {
-    //   return `export * from "/${outDir}/rsc/index.js";`;
-    // }),
     {
       name: "virtual:react-server-build",
       resolveId(source) {
         if (source === "virtual:react-server-build") {
+          // externalize as relative path
+          // from: dist/server/index.js  (ssr build)
+          // to:   dist/rsc/index.js     (rsc build)
           return { id: "../rsc/index.js", external: true };
         }
         return;


### PR DESCRIPTION
https://github.com/hi-ogawa/vite-plugins/pull/616 restacked on main to merge it before https://github.com/hi-ogawa/vite-plugins/pull/614.

_copied description_

Currently `dist/rsc/index.js` is bundled again by ssr build and mostly just copied over to `dist/ssr/assets`. Probably we can just externalize it and let adapter handles further bundling when needed.

As seen in https://github.com/hi-ogawa/vite-plugins/pull/614, if we don't do this, we need to essentially apply the same plugin to just externalize `import "xxx.wasm"` properly, which looks redundant and error prone.

---

Also obviously this improves ssr build time:

```sh
## before
$ pnpm -C packages/react-server/examples/basic build
...
✓ built in 349ms  // <-- ssr build
✓ built in 2.05s  // <-- total

## after
$ pnpm -C packages/react-server/examples/basic build
...
✓ built in 142ms 
✓ built in 1.80s 
```