### PR TITLE
feat: support `Metadata.twitter`

### DIFF
--- a/packages/react-server-next/src/compat/og.tsx
+++ b/packages/react-server-next/src/compat/og.tsx
@@ -19,6 +19,14 @@ export class ImageResponse extends Response {
     });
     const headers = new Headers(args[1]?.headers);
     headers.set("content-type", "image/png");
+    if (!headers.has("cache-control")) {
+      headers.set(
+        "cache-control",
+        process.env["NODE_ENV"] === "development"
+          ? "no-cache, no-store"
+          : "public, immutable, no-transform, max-age=31536000",
+      );
+    }
     super(body, { ...args[1], headers });
   }
 }

--- a/packages/react-server-next/src/compat/og.tsx
+++ b/packages/react-server-next/src/compat/og.tsx
@@ -19,14 +19,6 @@ export class ImageResponse extends Response {
     });
     const headers = new Headers(args[1]?.headers);
     headers.set("content-type", "image/png");
-    if (!headers.has("cache-control")) {
-      headers.set(
-        "cache-control",
-        process.env["NODE_ENV"] === "development"
-          ? "no-cache, no-store"
-          : "public, immutable, no-transform, max-age=31536000",
-      );
-    }
     super(body, { ...args[1], headers });
   }
 }

--- a/packages/react-server/examples/next/app/layout.tsx
+++ b/packages/react-server/examples/next/app/layout.tsx
@@ -23,6 +23,9 @@ export const metadata: Metadata = {
     title: "Next on Vite",
     images: [encodeURI("/test/og?title=Next on Vite")],
   },
+  twitter: {
+    card: "summary_large_image",
+  },
 };
 
 export default function RootLayout({

--- a/packages/react-server/examples/next/app/test/og/route.tsx
+++ b/packages/react-server/examples/next/app/test/og/route.tsx
@@ -9,15 +9,28 @@ export async function GET(request: Request) {
   return new ImageResponse(
     <div
       style={{
-        position: "absolute",
-        top: "50%",
-        left: "50%",
-        transform: "translate(-50%, -50%)",
-        fontSize: "48px",
-        fontWeight: "600",
+        position: "relative",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        color: "#171717",
+        backgroundColor: "#ffffff",
+        width: "100%",
+        height: "100%",
       }}
     >
-      {title}
+      <div
+        style={{
+          position: "absolute",
+          top: "50%",
+          left: "50%",
+          transform: "translate(-50%, -50%)",
+          fontSize: "48px",
+          fontWeight: "600",
+        }}
+      >
+        {title}
+      </div>
     </div>,
     {
       width: 843,

--- a/packages/react-server/examples/next/e2e/basic.test.ts
+++ b/packages/react-server/examples/next/e2e/basic.test.ts
@@ -146,13 +146,27 @@ test("next/og", async ({ page }) => {
   expect(res?.headers()).toMatchObject({ "content-type": "image/png" });
 });
 
-testNoJs("Metadata.openGraph", async ({ page }) => {
+testNoJs("Metadata", async ({ page }) => {
   await page.goto("/");
   await expect(page.locator(`meta[property="og:title"]`)).toHaveAttribute(
     "content",
     "Next on Vite",
   );
   await expect(page.locator(`meta[property="og:image"]`)).toHaveAttribute(
+    "content",
+    (process.env.E2E_CF
+      ? "https://test-next-vite.pages.dev"
+      : "http://localhost:5243") + "/test/og?title=Next%20on%20Vite",
+  );
+  await expect(page.locator(`meta[name="twitter:card"]`)).toHaveAttribute(
+    "content",
+    "summary_large_image",
+  );
+  await expect(page.locator(`meta[name="twitter:title"]`)).toHaveAttribute(
+    "content",
+    "Next on Vite",
+  );
+  await expect(page.locator(`meta[name="twitter:image"]`)).toHaveAttribute(
     "content",
     (process.env.E2E_CF
       ? "https://test-next-vite.pages.dev"

--- a/packages/react-server/src/features/meta/server.tsx
+++ b/packages/react-server/src/features/meta/server.tsx
@@ -38,6 +38,9 @@ export function renderMetadata(m: Metadata) {
               content={new URL(image, metadataBase).href}
             />
           ))}
+      {typeof m.twitter?.card === "string" && (
+        <meta property="twitter:card" content={m.twitter.card} />
+      )}
     </>
   );
 }

--- a/packages/react-server/src/features/meta/server.tsx
+++ b/packages/react-server/src/features/meta/server.tsx
@@ -1,7 +1,9 @@
 import { objectHas } from "@hiogawa/utils";
-import type { Metadata } from "./utils";
+import { type Metadata, normalizeMetadata } from "./utils";
 
 export function renderMetadata(m: Metadata) {
+  normalizeMetadata(m);
+
   const title =
     typeof m.title === "string"
       ? m.title
@@ -39,8 +41,24 @@ export function renderMetadata(m: Metadata) {
             />
           ))}
       {typeof m.twitter?.card === "string" && (
-        <meta property="twitter:card" content={m.twitter.card} />
+        <meta name="twitter:card" content={m.twitter.card} />
       )}
+      {typeof m.twitter?.title === "string" && (
+        <meta name="twitter:title" content={m.twitter.title} />
+      )}
+      {typeof m.twitter?.description === "string" && (
+        <meta name="twitter:description" content={m.twitter.description} />
+      )}
+      {typeof m.twitter?.images !== "undefined" &&
+        [m.twitter.images]
+          .flat()
+          .map((image, i) => (
+            <meta
+              key={i}
+              name="twitter:image"
+              content={new URL(image, metadataBase).href}
+            />
+          ))}
     </>
   );
 }

--- a/packages/react-server/src/features/meta/utils.ts
+++ b/packages/react-server/src/features/meta/utils.ts
@@ -4,13 +4,22 @@ export type Metadata = {
   description?: null | string;
   metadataBase?: null | URL;
   openGraph?: null | MetadataOpenGraph;
+  twitter?: null | MetadataTwitter;
   [k: string]: unknown;
 };
 
-export type MetadataOpenGraph = {
+type MetadataOpenGraph = {
   title?: string;
   description?: string;
-  images?: MetadataOgImage | Array<MetadataOgImage>;
+  images?: Arrayable<string | URL>;
+  [k: string]: unknown;
 };
 
-type MetadataOgImage = string | URL;
+type MetadataTwitter = {
+  title?: string;
+  description?: string;
+  images?: Arrayable<string | URL>;
+  [k: string]: unknown;
+};
+
+type Arrayable<T> = T | Array<T>;

--- a/packages/react-server/src/features/meta/utils.ts
+++ b/packages/react-server/src/features/meta/utils.ts
@@ -19,6 +19,7 @@ type MetadataTwitter = {
   title?: string;
   description?: string;
   images?: Arrayable<string | URL>;
+  card?: string;
   [k: string]: unknown;
 };
 

--- a/packages/react-server/src/features/meta/utils.ts
+++ b/packages/react-server/src/features/meta/utils.ts
@@ -24,3 +24,16 @@ type MetadataTwitter = {
 };
 
 type Arrayable<T> = T | Array<T>;
+
+export function normalizeMetadata(m: Metadata) {
+  // copy from openGraph to twitter
+  // cf. https://github.com/vercel/next.js/blob/afc73d5eadb108f10a22b223cbcb55f491bf5431/packages/next/src/lib/metadata/resolve-metadata.ts#L579-L652
+  if (m.openGraph) {
+    for (const key of ["title", "description", "images"] as const) {
+      if (m.openGraph[key] && !m.twitter?.[key]) {
+        m.twitter ??= {};
+        m.twitter[key] = m.openGraph[key] as any;
+      }
+    }
+  }
+}


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/vite-plugins/issues/625

---

Even if we set `cache-control` https://github.com/hi-ogawa/vite-plugins/pull/626/commits/416aa7cb3bd809c7a75bdcb14ac680d26373c575, it doesn't look like Vercel is caching image on CDN.

For example, https://test-next-vite.vercel.app/test/og only returns `x-vercel-cache: MISS`. While on Next.js, they seem to be able to get to `x-vercel-cache: HIT` for https://app-router.vercel.app/api/og

Maybe this is something to do with `x-matched-path`? Not sure what's happening, so let's revert it for now.
