### PR TITLE
refactor!: remove `next/*.js` exports

### DIFF
--- a/packages/react-server-next/package.json
+++ b/packages/react-server-next/package.json
@@ -22,19 +22,10 @@
     ".": {
       "types": "./types/index.d.ts"
     },
-    "./navigation.js": {
-      "types": "./dist/compat/navigation.d.ts",
-      "react-server": "./dist/compat/navigation.react-server.js",
-      "default": "./dist/compat/navigation.js"
-    },
     "./navigation": {
       "types": "./dist/compat/navigation.d.ts",
       "react-server": "./dist/compat/navigation.react-server.js",
       "default": "./dist/compat/navigation.js"
-    },
-    "./*.js": {
-      "types": "./dist/compat/*.d.ts",
-      "default": "./dist/compat/*.js"
     },
     "./*": {
       "types": "./dist/compat/*.d.ts",


### PR DESCRIPTION
- partially revert https://github.com/hi-ogawa/vite-plugins/pull/559/

This one is added to help https://github.com/hi-ogawa/next-learn/pull/1 (weird import by nextauth?) but it's fairly ugly (probably it confused IDE import completion too?) so let's forget about it and remove them.
Probably users can workaround it by doing `alias` manually.

I wonder what Next.js would end up eventually
- https://github.com/vercel/next.js/pull/68455

---

Well, it looks like next-auth has fixed it already
- https://github.com/nextauthjs/next-auth/pull/11551