### PR TITLE
test: pin react 19.0.0-rc-2d16326d-20240930

### DIFF
--- a/packages/react-server/misc/test.sh
+++ b/packages/react-server/misc/test.sh
@@ -14,7 +14,7 @@ cd "$test_dir"
 rm -rf dist node_modules
 
 node "$lib_dir/misc/overrides.mjs" "$test_dir/package.json"
-pnpm i
+pnpm i {react,react-dom,react-server-dom-webpack}@19.0.0-rc-2d16326d-20240930
 
 if test "${CI:-}" = "true"; then
   npx playwright install chromium


### PR DESCRIPTION
- related https://github.com/hi-ogawa/vite-plugins/pull/655

Since next version is broken, let's save `test-package` for now.