### PR TITLE
chore: add pnpm overrides for `@hiogawa/react-server`

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "vitest": "^3.0.3",
     "wrangler": "^3.79.0"
   },
-  "packageManager": "pnpm@9.12.1+sha512.e5a7e52a4183a02d5931057f7a0dbff9d5e9ce3161e33fa68ae392125b79282a8a8a470a51dfc8a0ed86221442eb2fb57019b0990ed24fab519bf0e1bc5ccfc4",
+  "packageManager": "pnpm@9.15.4+sha512.b2dc20e2fc72b3e18848459b37359a32064663e5627a51e4c74b2c29dd8e8e0491483c3abb40789cfd578bf362fb6ba8261b05f0387d76792ed6e23ea3b1b6a0",
   "volta": {
     "node": "20.14.0"
   },
@@ -42,6 +42,7 @@
       "react": "$react",
       "react-dom": "$react-dom",
       "react-server-dom-webpack": "$react-server-dom-webpack",
+      "@hiogawa/react-server": "workspace:*",
       "@types/react": "$@types/react",
       "@types/react-dom": "$@types/react-dom",
       "@vitejs/plugin-react": "$@vitejs/plugin-react"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   react: ^19.0.0
   react-dom: ^19.0.0
   react-server-dom-webpack: ^19.0.0
+  '@hiogawa/react-server': workspace:*
   '@types/react': ^19.0.1
   '@types/react-dom': ^19.0.1
   '@vitejs/plugin-react': ^4.3.4
@@ -213,7 +214,7 @@ importers:
   packages/react-server/examples/basic:
     dependencies:
       '@hiogawa/react-server':
-        specifier: latest
+        specifier: workspace:*
         version: link:../..
       '@hiogawa/test-dep-cjs':
         specifier: file:deps/cjs
@@ -394,7 +395,7 @@ importers:
   packages/react-server/examples/next:
     dependencies:
       '@hiogawa/react-server':
-        specifier: latest
+        specifier: workspace:*
         version: link:../..
       next:
         specifier: link:../../../react-server-next
@@ -456,7 +457,7 @@ importers:
   packages/react-server/examples/prerender:
     dependencies:
       '@hiogawa/react-server':
-        specifier: latest
+        specifier: workspace:*
         version: link:../..
       react:
         specifier: ^19.0.0
@@ -493,7 +494,7 @@ importers:
   packages/react-server/examples/starter:
     dependencies:
       '@hiogawa/react-server':
-        specifier: latest
+        specifier: workspace:*
         version: link:../..
       react:
         specifier: ^19.0.0


### PR DESCRIPTION
I though this is already the case via `link-workspace-packages=true`, but it looks like `latest` doesn't match when old commit is checked out (for example, latest is `0.4.0` but old commit is `0.3.8`). https://pnpm.io/workspaces

Let's force this via `pnpm.overrides`.