### PR TITLE
fix: disable hmr for react server runner

### DIFF
--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -220,8 +220,9 @@ export function vitePluginReactServer(
         tinyassert(manager.server);
         const reactServerEnv = manager.server.environments["rsc"];
         tinyassert(reactServerEnv);
-        // custom environment's node runner doesn't have hmr currently
-        const reactServerRunner = createServerModuleRunner(reactServerEnv);
+        const reactServerRunner = createServerModuleRunner(reactServerEnv, {
+          hmr: false,
+        });
         $__global.dev = {
           server: manager.server,
           reactServerRunner,


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/vite-plugins/issues/669

For now, let's use `ssrLoadModule` style server module invalidation, otherwise entire module cache resets on any changes. Also Vite has an issue with an virtual module entry full reload.