### PR TITLE
test: test rolldown-vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "tsup": "^8.1.0",
     "tsx": "^4.16.2",
     "typescript": "^5.5.4",
-    "vite": "^6.1.0",
+    "vite": "https://pkg.pr.new/rolldown/vite@7e5a8b6",
     "vitest": "^3.0.3",
     "wrangler": "^3.79.0"
   },

--- a/packages/react-server-next/src/vite/index.ts
+++ b/packages/react-server-next/src/vite/index.ts
@@ -149,6 +149,7 @@ function nextJsxPlugin(): Plugin {
     config: () => ({
       esbuild: { jsx: "automatic" },
       optimizeDeps: {
+        // TODO: what's the equivalent on oxc?
         esbuildOptions: { jsx: "automatic", loader: { ".js": "jsx" } },
       },
     }),

--- a/packages/react-server/examples/basic/vite.config.ts
+++ b/packages/react-server/examples/basic/vite.config.ts
@@ -56,6 +56,22 @@ export default defineConfig({
         buildMode: process.env.VERCEL || process.env.CF_PAGES ? "import" : "fs",
       }),
     ]),
+    {
+      // external require polyfill prevents adapter-level bundling,
+      // but since rolldown is fast, we can simply go `noExternal: true`.
+      // cf. https://github.com/hi-ogawa/reproductions/tree/main/rolldown-vite-require-react-polyfill
+      name: "avoid-require-polyfill",
+      apply: "build",
+      configEnvironment(name) {
+        if (name === "ssr") {
+          return {
+            resolve: {
+              noExternal: true,
+            },
+          };
+        }
+      },
+    },
   ],
   build: {
     ssrEmitAssets: true,

--- a/packages/react-server/vitest.config.e2e.ts
+++ b/packages/react-server/vitest.config.e2e.ts
@@ -1,3 +1,4 @@
+import { transformWithEsbuild } from "vite";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
@@ -12,4 +13,26 @@ export default defineConfig({
     fileParallelism: false,
     watch: false,
   },
+  plugins: [
+    {
+      // OXC doesn't support `using` yet
+      // https://github.com/oxc-project/oxc/issues/9168
+      name: "esbuild-transform",
+      async transform(code, id, _options) {
+        if (id.endsWith(".ts") && code.includes("using")) {
+          const result = await transformWithEsbuild(code, id, {
+            sourcemap: true,
+            supported: {
+              using: false,
+            },
+          });
+          return {
+            code: result.code,
+            map: result.map,
+          };
+        }
+        return;
+      },
+    },
+  ],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  vite: ^6.1.0
+  vite: https://pkg.pr.new/rolldown/vite@7e5a8b6
   react: ^19.0.0
   react-dom: ^19.0.0
   react-server-dom-webpack: ^19.0.0
@@ -46,10 +46,10 @@ importers:
         version: 19.0.3(@types/react@19.0.8)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2))
+        version: 4.3.4(vite@https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4))
       '@vitejs/plugin-react-swc':
         specifier: ^3.7.2
-        version: 3.7.2(@swc/helpers@0.5.12)(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2))
+        version: 3.7.2(@swc/helpers@0.5.12)(vite@https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4))
       esbuild:
         specifier: ^0.24.2
         version: 0.24.2
@@ -72,11 +72,11 @@ importers:
         specifier: ^5.5.4
         version: 5.5.4
       vite:
-        specifier: ^6.1.0
-        version: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+        specifier: https://pkg.pr.new/rolldown/vite@7e5a8b6
+        version: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
       vitest:
         specifier: ^3.0.3
-        version: 3.0.3(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+        version: 3.0.3(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
       wrangler:
         specifier: ^3.79.0
         version: 3.79.0(@cloudflare/workers-types@4.20240925.0)
@@ -84,8 +84,8 @@ importers:
   packages/error-overlay:
     dependencies:
       vite:
-        specifier: ^6.1.0
-        version: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+        specifier: https://pkg.pr.new/rolldown/vite@7e5a8b6
+        version: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
 
   packages/error-overlay/examples/basic:
     dependencies:
@@ -102,8 +102,8 @@ importers:
         specifier: ^0.30.17
         version: 0.30.17
       vite:
-        specifier: ^6.1.0
-        version: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+        specifier: https://pkg.pr.new/rolldown/vite@7e5a8b6
+        version: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
     devDependencies:
       esbuild:
         specifier: ^0.24.2
@@ -128,8 +128,8 @@ importers:
         specifier: latest
         version: link:../..
       vite:
-        specifier: ^6.1.0
-        version: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+        specifier: https://pkg.pr.new/rolldown/vite@7e5a8b6
+        version: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
 
   packages/react-server:
     dependencies:
@@ -152,11 +152,11 @@ importers:
         specifier: ^19.0.0
         version: 19.0.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(webpack@5.93.0(@swc/core@1.10.0(@swc/helpers@0.5.12))(esbuild@0.24.2))
       vite:
-        specifier: ^6.1.0
-        version: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+        specifier: https://pkg.pr.new/rolldown/vite@7e5a8b6
+        version: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
       vitefu:
         specifier: ^1.0.5
-        version: 1.0.5(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2))
+        version: 1.0.5(vite@https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4))
     devDependencies:
       '@edge-runtime/cookies':
         specifier: ^6.0.0
@@ -181,7 +181,7 @@ importers:
         version: 0.6.4
       '@vitejs/plugin-react-swc':
         specifier: ^3.7.2
-        version: 3.7.2(@swc/helpers@0.5.12)(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2))
+        version: 3.7.2(@swc/helpers@0.5.12)(vite@https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4))
       esbuild:
         specifier: ^0.24.2
         version: 0.24.2
@@ -198,11 +198,11 @@ importers:
         specifier: ^19.0.0
         version: 19.0.0(react@19.0.0)
       vite:
-        specifier: ^6.1.0
-        version: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+        specifier: https://pkg.pr.new/rolldown/vite@7e5a8b6
+        version: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.5.4)(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2))
+        version: 5.1.4(typescript@5.5.4)(vite@https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4))
     devDependencies:
       '@hiogawa/react-server':
         specifier: workspace:*
@@ -258,7 +258,7 @@ importers:
     devDependencies:
       '@hiogawa/unocss-preset-antd':
         specifier: 2.2.1-pre.7
-        version: 2.2.1-pre.7(unocss@0.58.6(postcss@8.5.3)(rollup@4.34.8)(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)))
+        version: 2.2.1-pre.7(unocss@0.58.6(postcss@8.5.3)(rollup@4.34.8)(vite@https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)))
       '@hiogawa/utils':
         specifier: latest
         version: 1.7.0
@@ -294,16 +294,16 @@ importers:
         version: 19.0.3(@types/react@19.0.8)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2))
+        version: 4.3.4(vite@https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4))
       magic-string:
         specifier: ^0.30.17
         version: 0.30.17
       unocss:
         specifier: ^0.58.6
-        version: 0.58.6(postcss@8.5.3)(rollup@4.34.8)(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2))
+        version: 0.58.6(postcss@8.5.3)(rollup@4.34.8)(vite@https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4))
       vite:
-        specifier: ^6.1.0
-        version: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+        specifier: https://pkg.pr.new/rolldown/vite@7e5a8b6
+        version: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
 
   packages/react-server/examples/cloudflare:
     dependencies:
@@ -333,8 +333,8 @@ importers:
         specifier: ^19.0.3
         version: 19.0.3(@types/react@19.0.8)
       vite:
-        specifier: ^6.1.0
-        version: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+        specifier: https://pkg.pr.new/rolldown/vite@7e5a8b6
+        version: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
 
   packages/react-server/examples/custom-out-dir:
     dependencies:
@@ -364,8 +364,8 @@ importers:
         specifier: ^19.0.3
         version: 19.0.3(@types/react@19.0.8)
       vite:
-        specifier: ^6.1.0
-        version: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+        specifier: https://pkg.pr.new/rolldown/vite@7e5a8b6
+        version: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
 
   packages/react-server/examples/minimal:
     dependencies:
@@ -392,8 +392,8 @@ importers:
         specifier: ^19.0.3
         version: 19.0.3(@types/react@19.0.8)
       vite:
-        specifier: ^6.1.0
-        version: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+        specifier: https://pkg.pr.new/rolldown/vite@7e5a8b6
+        version: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
 
   packages/react-server/examples/next:
     dependencies:
@@ -426,8 +426,8 @@ importers:
         specifier: ^19.0.3
         version: 19.0.3(@types/react@19.0.8)
       vite:
-        specifier: ^6.1.0
-        version: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+        specifier: https://pkg.pr.new/rolldown/vite@7e5a8b6
+        version: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
 
   packages/react-server/examples/postcss-tailwind:
     dependencies:
@@ -457,8 +457,8 @@ importers:
         specifier: ^3.4.10
         version: 3.4.10
       vite:
-        specifier: ^6.1.0
-        version: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+        specifier: https://pkg.pr.new/rolldown/vite@7e5a8b6
+        version: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
 
   packages/react-server/examples/prerender:
     dependencies:
@@ -492,10 +492,10 @@ importers:
         version: 19.0.3(@types/react@19.0.8)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2))
+        version: 4.3.4(vite@https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4))
       vite:
-        specifier: ^6.1.0
-        version: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+        specifier: https://pkg.pr.new/rolldown/vite@7e5a8b6
+        version: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
 
   packages/react-server/examples/starter:
     dependencies:
@@ -526,10 +526,10 @@ importers:
         version: 19.0.3(@types/react@19.0.8)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2))
+        version: 4.3.4(vite@https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4))
       vite:
-        specifier: ^6.1.0
-        version: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+        specifier: https://pkg.pr.new/rolldown/vite@7e5a8b6
+        version: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
 
   packages/server-asset:
     dependencies:
@@ -537,14 +537,14 @@ importers:
         specifier: ^0.30.17
         version: 0.30.17
       vite:
-        specifier: ^6.1.0
-        version: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+        specifier: https://pkg.pr.new/rolldown/vite@7e5a8b6
+        version: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
 
   packages/ssr-css:
     dependencies:
       vite:
-        specifier: ^6.1.0
-        version: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+        specifier: https://pkg.pr.new/rolldown/vite@7e5a8b6
+        version: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
 
   packages/transforms:
     dependencies:
@@ -565,8 +565,8 @@ importers:
   packages/vite-glob-routes:
     dependencies:
       vite:
-        specifier: ^6.1.0
-        version: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+        specifier: https://pkg.pr.new/rolldown/vite@7e5a8b6
+        version: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
     devDependencies:
       '@hattip/compose':
         specifier: ^0.0.44
@@ -600,7 +600,7 @@ importers:
         version: 0.1.1-pre.3
       '@hiogawa/theme-script':
         specifier: 0.0.4-pre.3
-        version: 0.0.4-pre.3(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2))
+        version: 0.0.4-pre.3(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(lightningcss@1.29.1)(terser@5.31.2)(tsx@4.16.2))
       '@hiogawa/tiny-cli':
         specifier: 0.0.4-pre.1
         version: 0.0.4-pre.1
@@ -621,7 +621,7 @@ importers:
         version: 0.1.1-pre.10(react@19.0.0)
       '@hiogawa/unocss-preset-antd':
         specifier: 2.2.1-pre.7
-        version: 2.2.1-pre.7(unocss@0.58.6(postcss@8.5.3)(rollup@4.34.8)(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)))
+        version: 2.2.1-pre.7(unocss@0.58.6(postcss@8.5.3)(rollup@4.34.8)(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(lightningcss@1.29.1)(terser@5.31.2)(tsx@4.16.2)))
       '@hiogawa/vite-glob-routes':
         specifier: workspace:*
         version: link:../..
@@ -660,7 +660,7 @@ importers:
         version: 19.0.3(@types/react@19.0.8)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2))
+        version: 4.3.4(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(lightningcss@1.29.1)(terser@5.31.2)(tsx@4.16.2))
       cookie:
         specifier: ^0.6.0
         version: 0.6.0
@@ -681,7 +681,7 @@ importers:
         version: 6.22.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       unocss:
         specifier: ^0.58.6
-        version: 0.58.6(postcss@8.5.3)(rollup@4.34.8)(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2))
+        version: 0.58.6(postcss@8.5.3)(rollup@4.34.8)(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(lightningcss@1.29.1)(terser@5.31.2)(tsx@4.16.2))
       zod:
         specifier: ^3.22.4
         version: 3.23.8
@@ -705,7 +705,7 @@ importers:
         version: 19.0.3(@types/react@19.0.8)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2))
+        version: 4.3.4(vite@https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4))
       react:
         specifier: ^19.0.0
         version: 19.0.0
@@ -716,8 +716,8 @@ importers:
         specifier: ^6.22.3
         version: 6.22.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       vite:
-        specifier: ^6.1.0
-        version: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+        specifier: https://pkg.pr.new/rolldown/vite@7e5a8b6
+        version: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
 
   packages/vite-glob-routes/examples/ssr:
     devDependencies:
@@ -753,7 +753,7 @@ importers:
         version: 19.0.3(@types/react@19.0.8)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2))
+        version: 4.3.4(vite@https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4))
       esbuild:
         specifier: ^0.24.2
         version: 0.24.2
@@ -770,20 +770,20 @@ importers:
         specifier: ^6.22.3
         version: 6.22.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       vite:
-        specifier: ^6.1.0
-        version: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+        specifier: https://pkg.pr.new/rolldown/vite@7e5a8b6
+        version: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
 
   packages/vite-import-dev-server:
     dependencies:
       vite:
-        specifier: ^6.1.0
-        version: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+        specifier: https://pkg.pr.new/rolldown/vite@7e5a8b6
+        version: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
 
   packages/vite-node-miniflare:
     dependencies:
       vite:
-        specifier: ^6.1.0
-        version: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+        specifier: https://pkg.pr.new/rolldown/vite@7e5a8b6
+        version: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20240821.1
@@ -802,7 +802,7 @@ importers:
     dependencies:
       '@hiogawa/tiny-react':
         specifier: 0.0.2-pre.9
-        version: 0.0.2-pre.9(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2))
+        version: 0.0.2-pre.9(vite@https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4))
       '@hiogawa/vite-node-miniflare':
         specifier: latest
         version: link:../..
@@ -813,8 +813,8 @@ importers:
         specifier: ^3.20240925.0
         version: 3.20240925.0
       vite:
-        specifier: ^6.1.0
-        version: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+        specifier: https://pkg.pr.new/rolldown/vite@7e5a8b6
+        version: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
 
   packages/vite-node-miniflare/examples/react:
     dependencies:
@@ -829,7 +829,7 @@ importers:
         version: 19.0.3(@types/react@19.0.8)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2))
+        version: 4.3.4(vite@https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4))
       miniflare:
         specifier: ^3.20240925.0
         version: 3.20240925.0
@@ -840,8 +840,8 @@ importers:
         specifier: ^19.0.0
         version: 19.0.0(react@19.0.0)
       vite:
-        specifier: ^6.1.0
-        version: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+        specifier: https://pkg.pr.new/rolldown/vite@7e5a8b6
+        version: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
 
   packages/vite-node-miniflare/examples/react-router:
     dependencies:
@@ -865,7 +865,7 @@ importers:
         version: 19.0.3(@types/react@19.0.8)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2))
+        version: 4.3.4(vite@https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4))
       miniflare:
         specifier: ^3.20240925.0
         version: 3.20240925.0
@@ -879,8 +879,8 @@ importers:
         specifier: ^6.22.3
         version: 6.22.3(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       vite:
-        specifier: ^6.1.0
-        version: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+        specifier: https://pkg.pr.new/rolldown/vite@7e5a8b6
+        version: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
 
   packages/vite-node-miniflare/examples/remix:
     dependencies:
@@ -908,7 +908,7 @@ importers:
         version: link:../..
       '@remix-run/dev':
         specifier: 2.8.1
-        version: 2.8.1(patch_hash=5f3898baeffa886bc4c107d8484475b85e481b37ce98d989a505a8500b02a4b3)(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2))(wrangler@3.79.0(@cloudflare/workers-types@4.20240925.0))
+        version: 2.8.1(patch_hash=5f3898baeffa886bc4c107d8484475b85e481b37ce98d989a505a8500b02a4b3)(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)(vite@https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4))(wrangler@3.79.0(@cloudflare/workers-types@4.20240925.0))
       '@types/react':
         specifier: ^19.0.8
         version: 19.0.8
@@ -925,8 +925,8 @@ importers:
         specifier: ^1.6.0
         version: 1.6.0
       vite:
-        specifier: ^6.1.0
-        version: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+        specifier: https://pkg.pr.new/rolldown/vite@7e5a8b6
+        version: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
 
   packages/vite-plugin-simple-hmr:
     dependencies:
@@ -934,8 +934,8 @@ importers:
         specifier: ^0.30.17
         version: 0.30.17
       vite:
-        specifier: ^6.1.0
-        version: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+        specifier: https://pkg.pr.new/rolldown/vite@7e5a8b6
+        version: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
     devDependencies:
       '@types/estree':
         specifier: ^1.0.6
@@ -953,8 +953,8 @@ importers:
   packages/vite-plugin-ssr-middleware:
     dependencies:
       vite:
-        specifier: ^6.1.0
-        version: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+        specifier: https://pkg.pr.new/rolldown/vite@7e5a8b6
+        version: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
 
   packages/vite-plugin-ssr-middleware/examples/react:
     dependencies:
@@ -969,7 +969,7 @@ importers:
         version: 19.0.3(@types/react@19.0.8)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2))
+        version: 4.3.4(vite@https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4))
       react:
         specifier: ^19.0.0
         version: 19.0.0
@@ -977,8 +977,8 @@ importers:
         specifier: ^19.0.0
         version: 19.0.0(react@19.0.0)
       vite:
-        specifier: ^6.1.0
-        version: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+        specifier: https://pkg.pr.new/rolldown/vite@7e5a8b6
+        version: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
 
 packages:
 
@@ -1335,6 +1335,15 @@ packages:
   '@edge-runtime/cookies@6.0.0':
     resolution: {integrity: sha512-VVO/8AwC2qVbygLb2IOkX1zWFx2yWIHzFv4D602CTnoRffd/+cdcXqpSydKaedFrk7a1dRYXbWwjzfV/gwZ2Gw==}
     engines: {node: '>=18'}
+
+  '@emnapi/core@1.3.1':
+    resolution: {integrity: sha512-pVGjBIt1Y6gg3EJN8jTcfpP/+uuRksIo055oE/OBkDNcjZqVbfkWCksG1Jp4yZnj3iKWyWX8fdG/j6UDYPbFog==}
+
+  '@emnapi/runtime@1.3.1':
+    resolution: {integrity: sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==}
+
+  '@emnapi/wasi-threads@1.0.1':
+    resolution: {integrity: sha512-iIBu7mwkq4UQGeMEM8bLwNK962nXdhodeScX4slfQnRhEMMzvYivHhutCIk8uojvmASXXPC2WNEjwxFWk72Oqw==}
 
   '@emotion/hash@0.9.1':
     resolution: {integrity: sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==}
@@ -1968,7 +1977,7 @@ packages:
   '@hiogawa/theme-script@0.0.4-pre.3':
     resolution: {integrity: sha512-2uxVhemdAMUFE/OaUcaTT2QeZsXnxtnF/CLNs+CcrlgwaUXXfsnXUTvUZCz8MTmxzzz4Vp5hfAyi4pp58XHJCQ==}
     peerDependencies:
-      vite: ^6.1.0
+      vite: '*'
     peerDependenciesMeta:
       vite:
         optional: true
@@ -1998,8 +2007,9 @@ packages:
 
   '@hiogawa/tiny-react@0.0.2-pre.9':
     resolution: {integrity: sha512-q5zIFwmJMMLbq4g0e/2/AKaggjsOl0dQ6fAiG7k/PjOdj3/xWJvcxr7oCOzybEuxR7oNIOgsBhydBqZPRQ+BLQ==}
+    version: 0.0.2-pre.9
     peerDependencies:
-      vite: ^6.1.0
+      vite: '*'
     peerDependenciesMeta:
       vite:
         optional: true
@@ -2017,6 +2027,7 @@ packages:
 
   '@hiogawa/unocss-preset-antd@2.2.1-pre.7':
     resolution: {integrity: sha512-gwY0T8FpFzvHE3I2bShDFKRFAlf1dxgAeaLkfGy7VpNkVr7NkrS3hIUb3An95zAjQWSvgP90t+p1e8AaFW8oXw==}
+    version: 2.2.1-pre.7
     peerDependencies:
       unocss: '*'
 
@@ -2080,6 +2091,9 @@ packages:
     peerDependencies:
       rollup: '>=2'
 
+  '@napi-rs/wasm-runtime@0.2.7':
+    resolution: {integrity: sha512-5yximcFK5FNompXfJFoWanu5l8v1hNGqNHh9du1xETp9HWk/B/PzvchX55WYOPaIeNglG8++68AAiauBAtbnzw==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -2111,6 +2125,13 @@ packages:
   '@oxc-parser/wasm@0.23.0':
     resolution: {integrity: sha512-vo3HVL7ynx1u82hlACYdl+JrSDpQ7dRdEXBnq/TC3RmjW/gS6r43X6TZdc2BvJNFMgb9gbRb/Qb6tUEJGdGRJw==}
 
+  '@oxc-project/runtime@0.51.0':
+    resolution: {integrity: sha512-s/G0/yOpmcD9QY8O1wc4G7nb7BRV9m206PvfM/t3oPu6z+2vyZlfB2kTA9P6vMXO2fzquDMw3G22kCXx4qzfUQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@oxc-project/types@0.51.0':
+    resolution: {integrity: sha512-rDHFQBU2lS0Fh1t1rgvSWK21OfgkzjIWqj+FKKRJueecgvdZ6hO+qqstwBy2v9lFhg2DPuaDdLyCXZNGwsKjMw==}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -2125,12 +2146,13 @@ packages:
 
   '@remix-run/dev@2.8.1':
     resolution: {integrity: sha512-qFt4jAsAJeIOyg6ngeSnTG/9Z5N9QJfeThP/8wRHc1crqYgTiEtcI3DZ8WlAXjVSF5emgn/ZZKqzLAI02OgMfQ==}
+    version: 2.8.1
     engines: {node: '>=18.0.0'}
     hasBin: true
     peerDependencies:
       '@remix-run/serve': ^2.8.1
       typescript: ^5.1.0
-      vite: ^6.1.0
+      vite: ^5.1.0
       wrangler: ^3.28.2
     peerDependenciesMeta:
       '@remix-run/serve':
@@ -2198,6 +2220,66 @@ packages:
   '@resvg/resvg-wasm@2.4.0':
     resolution: {integrity: sha512-C7c51Nn4yTxXFKvgh2txJFNweaVcfUPQxwEUFw4aWsCmfiBDJsTSwviIF8EcwjQ6k8bPyMWCl1vw4BdxE569Cg==}
     engines: {node: '>= 10'}
+
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.3-commit.b546e53':
+    resolution: {integrity: sha512-89SghJmrU7zH3dt7J1Vgd2x49T6KIsEvI4mmcfb0VG7L1sR392za4q+doQsNJifVC+onUBx40jnwYHMEdberXg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-beta.3-commit.b546e53':
+    resolution: {integrity: sha512-7SUzG5q3fu6Sh2Jausn/zJCCU/aygE5YAIBg/tT0ojpfDezrlVrsm0gKf0OfE2c1GeC3wNpZcNDmnZo3wKdK+g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.3-commit.b546e53':
+    resolution: {integrity: sha512-WjqVaI3L7GjebX7L1YnvqqshgFPh9bThlJjpm20LmQl8nrcukZh5iw0js0aE+a8FZOltOR6GVN1knBYF9YJpmw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.3-commit.b546e53':
+    resolution: {integrity: sha512-BpUmsD+gmI3t1fs9ofn4hgE5ukaxrmauViBOFpHCdOQZkK2d+jPOQCRSphK+GFxY3rsLzfBkWY4AXOuW+YZLKg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.3-commit.b546e53':
+    resolution: {integrity: sha512-3dW77dszpSvB54qcbHGztkUF5OoYwP21Q5W955HdybMDoM6V6nDfW+Nyp2d1zQmyXxaAzMDSwTP3PfgZqAqWLw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.3-commit.b546e53':
+    resolution: {integrity: sha512-xNHLIfoDvMb5CwEtVy/TmDtfhTR4yS3LBNQkLww7AH09NrLT2PEV23THICNJh03UxgANLkWhkJgRlIeBkOKjIw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.3-commit.b546e53':
+    resolution: {integrity: sha512-lUy5d6wC1/QiiNHI/Au+hqTWe2ZDMtaT6yOWz91JGnskFN35tc/QRuz5ptCFjJFMHFz82T8NGUidERXI1+dl+g==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.3-commit.b546e53':
+    resolution: {integrity: sha512-B7Qb8BnJJkDRJ6hfA8u30K9BGGxQFzz6aVhfpQXhIoLN5VErJh/LLpiJJgYuJzbngqKtGUbu54XJ0vokNzji/g==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.3-commit.b546e53':
+    resolution: {integrity: sha512-tn9fu3l4aKktb964gOd1FPd34/UpEImyU3sfl6zIQXkAcksHw6YNcD/aPdINFNbLUToYdg5E2NLHnGYjvLnpRw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.3-commit.b546e53':
+    resolution: {integrity: sha512-Z+c0RACfOJWm32BClafn2QKJg1i4+H+bDvaEUWS44GuY6Pri6QWlwrPe9PR9gz/7+L75XKe2nBTAq4FKrtaD9w==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.3-commit.b546e53':
+    resolution: {integrity: sha512-NqfFVOPIxvbX8eZwm4je3cZhwQpC7V9Vo/SCSuZgYVEeHXlsazbLbwF27Kkv16wIHsijRViEO/uEhW8yPRUcnw==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.3-commit.b546e53':
+    resolution: {integrity: sha512-G8Dkwmtq+K5hZsDZQds7fPfbbmhHJO7V3hcMJIP+mubEJ5280J2BPv35QVRsA/xVLEEbrmutXajbho9xx+/IlQ==}
+    cpu: [x64]
+    os: [win32]
 
   '@rollup/pluginutils@5.1.0':
     resolution: {integrity: sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==}
@@ -2526,6 +2608,9 @@ packages:
   '@tsconfig/strictest@2.0.5':
     resolution: {integrity: sha512-ec4tjL2Rr0pkZ5hww65c+EEPYwxOi4Ryv+0MtjeaSQRJyq322Q27eOQiFbuNgw2hpL4hB1/W/HBGk3VKS43osg==}
 
+  '@tybys/wasm-util@0.9.0':
+    resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
+
   '@types/acorn@4.0.6':
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
 
@@ -2638,8 +2723,9 @@ packages:
 
   '@unocss/astro@0.58.6':
     resolution: {integrity: sha512-0BvbhEp5Ln6wFNnhISusB2hcfycWkdgnjlFMcLT69efvj4G39MzB6JYT/1qiidLfpj35HcqkpBz7TfZ4bUmOAw==}
+    version: 0.58.6
     peerDependencies:
-      vite: ^6.1.0
+      vite: ^2.9.0 || ^3.0.0-0 || ^4.0.0 || ^5.0.0-0
     peerDependenciesMeta:
       vite:
         optional: true
@@ -2719,8 +2805,14 @@ packages:
 
   '@unocss/vite@0.58.6':
     resolution: {integrity: sha512-DPXCoYU/Ozqc/Jeptd41XvtW8MSgVxmtTyhpMAsm/hJuBfwIV7Fy3TZquf4V9BpaTb4ao1LVXzgXmVUmj2HXpA==}
+    version: 0.58.6
     peerDependencies:
-      vite: ^6.1.0
+      vite: ^2.9.0 || ^3.0.0-0 || ^4.0.0 || ^5.0.0-0
+
+  '@valibot/to-json-schema@1.0.0-beta.5':
+    resolution: {integrity: sha512-8aI2sG98gWS+6YuIL3OMkg60sImhICPdZIFCV1XDyX8k6UOCX+MgXaeR3f2fDShuNXYHV46vcjWRpov8ojzDNw==}
+    peerDependencies:
+      valibot: ^1.0.0 || ^1.0.0-beta.5 || ^1.0.0-rc
 
   '@vanilla-extract/babel-plugin-debug-ids@1.0.5':
     resolution: {integrity: sha512-Rc9A6ylsw7EBErmpgqCMvc/Z/eEZxI5k1xfLQHw7f5HHh3oc5YfzsAsYU/PdmSNjF1dp3sGEViBdDltvwnfVaA==}
@@ -2740,23 +2832,26 @@ packages:
 
   '@vitejs/plugin-react-swc@3.7.2':
     resolution: {integrity: sha512-y0byko2b2tSVVf5Gpng1eEhX1OvPC7x8yns1Fx8jDzlJp4LS6CMkCPfLw47cjyoMrshQDoQw4qcgjsU9VvlCew==}
+    version: 3.7.2
     peerDependencies:
-      vite: ^6.1.0
+      vite: ^4 || ^5 || ^6
 
   '@vitejs/plugin-react@4.3.4':
     resolution: {integrity: sha512-SCCPBJtYLdE8PX/7ZQAs1QAZ8Jqwih+0VBLum1EGqmCCQal+MIUqLCzj3ZUy8ufbC0cAM4LRlSTm7IQJwWT4ug==}
+    version: 4.3.4
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: ^6.1.0
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0
 
   '@vitest/expect@3.0.3':
     resolution: {integrity: sha512-SbRCHU4qr91xguu+dH3RUdI5dC86zm8aZWydbp961aIR7G8OYNN6ZiayFuf9WAngRbFOfdrLHCGgXTj3GtoMRQ==}
 
   '@vitest/mocker@3.0.3':
     resolution: {integrity: sha512-XT2XBc4AN9UdaxJAeIlcSZ0ILi/GzmG5G8XSly4gaiqIvPV3HMTSIDZWJVX6QRJ0PX1m+W8Cy0K9ByXNb/bPIA==}
+    version: 3.0.3
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.1.0
+      vite: ^5.0.0 || ^6.0.0
     peerDependenciesMeta:
       msw:
         optional: true
@@ -3286,6 +3381,11 @@ packages:
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  detect-libc@1.0.3:
+    resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
+    engines: {node: '>=0.10'}
+    hasBin: true
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -3920,6 +4020,70 @@ packages:
 
   kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
+
+  lightningcss-darwin-arm64@1.29.1:
+    resolution: {integrity: sha512-HtR5XJ5A0lvCqYAoSv2QdZZyoHNttBpa5EP9aNuzBQeKGfbyH5+UipLWvVzpP4Uml5ej4BYs5I9Lco9u1fECqw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.29.1:
+    resolution: {integrity: sha512-k33G9IzKUpHy/J/3+9MCO4e+PzaFblsgBjSGlpAaFikeBFm8B/CkO3cKU9oI4g+fjS2KlkLM/Bza9K/aw8wsNA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.29.1:
+    resolution: {integrity: sha512-0SUW22fv/8kln2LnIdOCmSuXnxgxVC276W5KLTwoehiO0hxkacBxjHOL5EtHD8BAXg2BvuhsJPmVMasvby3LiQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.29.1:
+    resolution: {integrity: sha512-sD32pFvlR0kDlqsOZmYqH/68SqUMPNj+0pucGxToXZi4XZgZmqeX/NkxNKCPsswAXU3UeYgDSpGhu05eAufjDg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.29.1:
+    resolution: {integrity: sha512-0+vClRIZ6mmJl/dxGuRsE197o1HDEeeRk6nzycSy2GofC2JsY4ifCRnvUWf/CUBQmlrvMzt6SMQNMSEu22csWQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.29.1:
+    resolution: {integrity: sha512-UKMFrG4rL/uHNgelBsDwJcBqVpzNJbzsKkbI3Ja5fg00sgQnHw/VrzUTEc4jhZ+AN2BvQYz/tkHu4vt1kLuJyw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.29.1:
+    resolution: {integrity: sha512-u1S+xdODy/eEtjADqirA774y3jLcm8RPtYztwReEXoZKdzgsHYPl0s5V52Tst+GKzqjebkULT86XMSxejzfISw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.29.1:
+    resolution: {integrity: sha512-L0Tx0DtaNUTzXv0lbGCLB/c/qEADanHbu4QdcNOXLIe1i8i22rZRpbT3gpWYsCh9aSL9zFujY/WmEXIatWvXbw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.29.1:
+    resolution: {integrity: sha512-QoOVnkIEFfbW4xPi+dpdft/zAKmgLgsRHfJalEPYuJDOWf7cLQzYg0DEh8/sn737FaeMJxHZRc1oBreiwZCjog==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.29.1:
+    resolution: {integrity: sha512-NygcbThNBe4JElP+olyTI/doBNGJvLs3bFCRPdvuCcxZCcCZ71B858IHpdm7L1btZex0FvCmM17FK98Y9MRy1Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.29.1:
+    resolution: {integrity: sha512-FmGoeD4S05ewj+AkhTY+D+myDvXI6eL27FjHIjoyUkO/uw7WZD1fBVs0QxeYWa7E17CUHJaYX/RUGISCtcrG4Q==}
+    engines: {node: '>= 12.0.0'}
 
   lilconfig@2.1.0:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
@@ -4860,6 +5024,15 @@ packages:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rolldown@1.0.0-beta.3-commit.b546e53:
+    resolution: {integrity: sha512-boMVf8ecS38Kczjb+8LDnfOSXy9ldpsv4sfrPsPJYBsc0Wo/cam+IrOotCWPvGXQeIyxuh3PaWMfLbVZW+hTwg==}
+    hasBin: true
+    peerDependencies:
+      '@oxc-project/runtime': 0.51.0
+    peerDependenciesMeta:
+      '@oxc-project/runtime':
+        optional: true
+
   rollup-plugin-inject@3.0.2:
     resolution: {integrity: sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==}
     deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.
@@ -5380,10 +5553,11 @@ packages:
 
   unocss@0.58.6:
     resolution: {integrity: sha512-HBstDtC6KKD5yCYh5hHpPdHGZai0B/iLlDwkOIK+xfQYrvl8tNBvKfRz3xgiaI5MJ+fLmEOxbfXQIjleU1A0iA==}
+    version: 0.58.6
     engines: {node: '>=14'}
     peerDependencies:
       '@unocss/webpack': 0.58.6
-      vite: ^6.1.0
+      vite: ^2.9.0 || ^3.0.0-0 || ^4.0.0 || ^5.0.0-0
     peerDependenciesMeta:
       '@unocss/webpack':
         optional: true
@@ -5432,6 +5606,14 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  valibot@1.0.0-beta.14:
+    resolution: {integrity: sha512-tLyV2rE5QL6U29MFy3xt4AqMrn+/HErcp2ZThASnQvPMwfSozjV1uBGKIGiegtZIGjinJqn0SlBdannf18wENA==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
@@ -5467,8 +5649,9 @@ packages:
 
   vite-tsconfig-paths@5.1.4:
     resolution: {integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==}
+    version: 5.1.4
     peerDependencies:
-      vite: ^6.1.0
+      vite: '*'
     peerDependenciesMeta:
       vite:
         optional: true
@@ -5513,10 +5696,52 @@ packages:
       yaml:
         optional: true
 
+  vite@https://pkg.pr.new/rolldown/vite@7e5a8b6:
+    resolution: {tarball: https://pkg.pr.new/rolldown/vite@7e5a8b6}
+    version: 6.1.0
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      esbuild: ^0.24.0
+      jiti: '>=1.21.0'
+      less: '*'
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
   vitefu@1.0.5:
     resolution: {integrity: sha512-h4Vflt9gxODPFNGPwp4zAMZRpZR7eslzwH2c5hn5kNZ5rhnKyRJ50U+yGCdc2IRaBs8O4haIgLNGrV5CrpMsCA==}
+    version: 1.0.5
     peerDependencies:
-      vite: ^6.1.0
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
     peerDependenciesMeta:
       vite:
         optional: true
@@ -6097,6 +6322,22 @@ snapshots:
 
   '@edge-runtime/cookies@6.0.0': {}
 
+  '@emnapi/core@1.3.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.0.1
+      tslib: 2.6.2
+    optional: true
+
+  '@emnapi/runtime@1.3.1':
+    dependencies:
+      tslib: 2.6.2
+    optional: true
+
+  '@emnapi/wasi-threads@1.0.1':
+    dependencies:
+      tslib: 2.6.2
+    optional: true
+
   '@emotion/hash@0.9.1': {}
 
   '@esbuild-plugins/node-globals-polyfill@0.2.3(esbuild@0.17.19)':
@@ -6445,9 +6686,9 @@ snapshots:
     dependencies:
       react: 19.0.0
 
-  '@hiogawa/theme-script@0.0.4-pre.3(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2))':
+  '@hiogawa/theme-script@0.0.4-pre.3(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(lightningcss@1.29.1)(terser@5.31.2)(tsx@4.16.2))':
     optionalDependencies:
-      vite: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+      vite: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(lightningcss@1.29.1)(terser@5.31.2)(tsx@4.16.2)
 
   '@hiogawa/tiny-cli@0.0.4-pre.1': {}
 
@@ -6461,9 +6702,9 @@ snapshots:
     optionalDependencies:
       react: 19.0.0
 
-  '@hiogawa/tiny-react@0.0.2-pre.9(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2))':
+  '@hiogawa/tiny-react@0.0.2-pre.9(vite@https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4))':
     optionalDependencies:
-      vite: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+      vite: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
 
   '@hiogawa/tiny-rpc@0.2.3-pre.18': {}
 
@@ -6471,9 +6712,13 @@ snapshots:
     optionalDependencies:
       react: 19.0.0
 
-  '@hiogawa/unocss-preset-antd@2.2.1-pre.7(unocss@0.58.6(postcss@8.5.3)(rollup@4.34.8)(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)))':
+  '@hiogawa/unocss-preset-antd@2.2.1-pre.7(unocss@0.58.6(postcss@8.5.3)(rollup@4.34.8)(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(lightningcss@1.29.1)(terser@5.31.2)(tsx@4.16.2)))':
     dependencies:
-      unocss: 0.58.6(postcss@8.5.3)(rollup@4.34.8)(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2))
+      unocss: 0.58.6(postcss@8.5.3)(rollup@4.34.8)(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(lightningcss@1.29.1)(terser@5.31.2)(tsx@4.16.2))
+
+  '@hiogawa/unocss-preset-antd@2.2.1-pre.7(unocss@0.58.6(postcss@8.5.3)(rollup@4.34.8)(vite@https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)))':
+    dependencies:
+      unocss: 0.58.6(postcss@8.5.3)(rollup@4.34.8)(vite@https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4))
 
   '@hiogawa/utils-node@0.0.2': {}
 
@@ -6597,6 +6842,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@napi-rs/wasm-runtime@0.2.7':
+    dependencies:
+      '@emnapi/core': 1.3.1
+      '@emnapi/runtime': 1.3.1
+      '@tybys/wasm-util': 0.9.0
+    optional: true
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -6644,6 +6896,10 @@ snapshots:
 
   '@oxc-parser/wasm@0.23.0': {}
 
+  '@oxc-project/runtime@0.51.0': {}
+
+  '@oxc-project/types@0.51.0': {}
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -6653,7 +6909,7 @@ snapshots:
 
   '@polka/url@1.0.0-next.25': {}
 
-  '@remix-run/dev@2.8.1(patch_hash=5f3898baeffa886bc4c107d8484475b85e481b37ce98d989a505a8500b02a4b3)(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2))(wrangler@3.79.0(@cloudflare/workers-types@4.20240925.0))':
+  '@remix-run/dev@2.8.1(patch_hash=5f3898baeffa886bc4c107d8484475b85e481b37ce98d989a505a8500b02a4b3)(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)(vite@https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4))(wrangler@3.79.0(@cloudflare/workers-types@4.20240925.0))':
     dependencies:
       '@babel/core': 7.24.7
       '@babel/generator': 7.24.7
@@ -6669,7 +6925,7 @@ snapshots:
       '@remix-run/router': 1.15.3-pre.0
       '@remix-run/server-runtime': 2.8.1(typescript@5.5.4)
       '@types/mdx': 2.0.13
-      '@vanilla-extract/integration': 6.5.0(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+      '@vanilla-extract/integration': 6.5.0(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
       arg: 5.0.2
       cacache: 17.1.4
       chalk: 4.1.2
@@ -6710,7 +6966,7 @@ snapshots:
       ws: 7.5.9
     optionalDependencies:
       typescript: 5.5.4
-      vite: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+      vite: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
       wrangler: 3.79.0(@cloudflare/workers-types@4.20240925.0)
     transitivePeerDependencies:
       - '@types/node'
@@ -6718,7 +6974,6 @@ snapshots:
       - bufferutil
       - jiti
       - less
-      - lightningcss
       - sass
       - sass-embedded
       - stylus
@@ -6798,6 +7053,44 @@ snapshots:
       web-streams-polyfill: 3.3.3
 
   '@resvg/resvg-wasm@2.4.0': {}
+
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.3-commit.b546e53':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-beta.3-commit.b546e53':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.3-commit.b546e53':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.3-commit.b546e53':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.3-commit.b546e53':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.3-commit.b546e53':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.3-commit.b546e53':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.3-commit.b546e53':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.3-commit.b546e53':
+    dependencies:
+      '@napi-rs/wasm-runtime': 0.2.7
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.3-commit.b546e53':
+    optional: true
+
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.3-commit.b546e53':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.3-commit.b546e53':
+    optional: true
 
   '@rollup/pluginutils@5.1.0(rollup@4.34.8)':
     dependencies:
@@ -7035,6 +7328,11 @@ snapshots:
 
   '@tsconfig/strictest@2.0.5': {}
 
+  '@tybys/wasm-util@0.9.0':
+    dependencies:
+      tslib: 2.6.2
+    optional: true
+
   '@types/acorn@4.0.6':
     dependencies:
       '@types/estree': 1.0.6
@@ -7170,13 +7468,23 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@unocss/astro@0.58.6(rollup@4.34.8)(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2))':
+  '@unocss/astro@0.58.6(rollup@4.34.8)(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(lightningcss@1.29.1)(terser@5.31.2)(tsx@4.16.2))':
     dependencies:
       '@unocss/core': 0.58.6
       '@unocss/reset': 0.58.6
-      '@unocss/vite': 0.58.6(rollup@4.34.8)(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2))
+      '@unocss/vite': 0.58.6(rollup@4.34.8)(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(lightningcss@1.29.1)(terser@5.31.2)(tsx@4.16.2))
     optionalDependencies:
-      vite: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+      vite: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(lightningcss@1.29.1)(terser@5.31.2)(tsx@4.16.2)
+    transitivePeerDependencies:
+      - rollup
+
+  '@unocss/astro@0.58.6(rollup@4.34.8)(vite@https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4))':
+    dependencies:
+      '@unocss/core': 0.58.6
+      '@unocss/reset': 0.58.6
+      '@unocss/vite': 0.58.6(rollup@4.34.8)(vite@https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4))
+    optionalDependencies:
+      vite: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
     transitivePeerDependencies:
       - rollup
 
@@ -7307,7 +7615,7 @@ snapshots:
     dependencies:
       '@unocss/core': 0.58.6
 
-  '@unocss/vite@0.58.6(rollup@4.34.8)(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2))':
+  '@unocss/vite@0.58.6(rollup@4.34.8)(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(lightningcss@1.29.1)(terser@5.31.2)(tsx@4.16.2))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@rollup/pluginutils': 5.1.0(rollup@4.34.8)
@@ -7319,9 +7627,29 @@ snapshots:
       chokidar: 3.6.0
       fast-glob: 3.3.3
       magic-string: 0.30.17
-      vite: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+      vite: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(lightningcss@1.29.1)(terser@5.31.2)(tsx@4.16.2)
     transitivePeerDependencies:
       - rollup
+
+  '@unocss/vite@0.58.6(rollup@4.34.8)(vite@https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@rollup/pluginutils': 5.1.0(rollup@4.34.8)
+      '@unocss/config': 0.58.6
+      '@unocss/core': 0.58.6
+      '@unocss/inspector': 0.58.6
+      '@unocss/scope': 0.58.6
+      '@unocss/transformer-directives': 0.58.6
+      chokidar: 3.6.0
+      fast-glob: 3.3.3
+      magic-string: 0.30.17
+      vite: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
+    transitivePeerDependencies:
+      - rollup
+
+  '@valibot/to-json-schema@1.0.0-beta.5(valibot@1.0.0-beta.14(typescript@5.5.4))':
+    dependencies:
+      valibot: 1.0.0-beta.14(typescript@5.5.4)
 
   '@vanilla-extract/babel-plugin-debug-ids@1.0.5':
     dependencies:
@@ -7343,7 +7671,7 @@ snapshots:
       modern-ahocorasick: 1.0.1
       outdent: 0.8.0
 
-  '@vanilla-extract/integration@6.5.0(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)':
+  '@vanilla-extract/integration@6.5.0(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)':
     dependencies:
       '@babel/core': 7.24.7
       '@babel/plugin-syntax-typescript': 7.23.3(@babel/core@7.24.7)
@@ -7356,13 +7684,12 @@ snapshots:
       lodash: 4.17.21
       mlly: 1.6.1
       outdent: 0.8.0
-      vite: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
-      vite-node: 1.4.0(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+      vite: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.17.19)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
+      vite-node: 1.4.0(@types/node@20.14.10)(esbuild@0.17.19)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
       - less
-      - lightningcss
       - sass
       - sass-embedded
       - stylus
@@ -7370,6 +7697,7 @@ snapshots:
       - supports-color
       - terser
       - tsx
+      - typescript
       - yaml
 
   '@vanilla-extract/private@1.0.3': {}
@@ -7380,21 +7708,32 @@ snapshots:
       satori: 0.12.0
       yoga-wasm-web: 0.3.3
 
-  '@vitejs/plugin-react-swc@3.7.2(@swc/helpers@0.5.12)(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2))':
+  '@vitejs/plugin-react-swc@3.7.2(@swc/helpers@0.5.12)(vite@https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4))':
     dependencies:
       '@swc/core': 1.10.0(@swc/helpers@0.5.12)
-      vite: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+      vite: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitejs/plugin-react@4.3.4(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2))':
+  '@vitejs/plugin-react@4.3.4(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(lightningcss@1.29.1)(terser@5.31.2)(tsx@4.16.2))':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.0)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+      vite: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(lightningcss@1.29.1)(terser@5.31.2)(tsx@4.16.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitejs/plugin-react@4.3.4(vite@https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4))':
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.0)
+      '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.0)
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.14.2
+      vite: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -7405,13 +7744,13 @@ snapshots:
       chai: 5.1.2
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.3(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2))':
+  '@vitest/mocker@3.0.3(vite@https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4))':
     dependencies:
       '@vitest/spy': 3.0.3
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+      vite: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
 
   '@vitest/pretty-format@3.0.3':
     dependencies:
@@ -7930,6 +8269,8 @@ snapshots:
   destr@2.0.3: {}
 
   destroy@1.2.0: {}
+
+  detect-libc@1.0.3: {}
 
   devlop@1.1.0:
     dependencies:
@@ -8683,6 +9024,51 @@ snapshots:
   kleur@4.1.5: {}
 
   kolorist@1.8.0: {}
+
+  lightningcss-darwin-arm64@1.29.1:
+    optional: true
+
+  lightningcss-darwin-x64@1.29.1:
+    optional: true
+
+  lightningcss-freebsd-x64@1.29.1:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.29.1:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.29.1:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.29.1:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.29.1:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.29.1:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.29.1:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.29.1:
+    optional: true
+
+  lightningcss@1.29.1:
+    dependencies:
+      detect-libc: 1.0.3
+    optionalDependencies:
+      lightningcss-darwin-arm64: 1.29.1
+      lightningcss-darwin-x64: 1.29.1
+      lightningcss-freebsd-x64: 1.29.1
+      lightningcss-linux-arm-gnueabihf: 1.29.1
+      lightningcss-linux-arm64-gnu: 1.29.1
+      lightningcss-linux-arm64-musl: 1.29.1
+      lightningcss-linux-x64-gnu: 1.29.1
+      lightningcss-linux-x64-musl: 1.29.1
+      lightningcss-win32-arm64-msvc: 1.29.1
+      lightningcss-win32-x64-msvc: 1.29.1
 
   lilconfig@2.1.0: {}
 
@@ -10008,6 +10394,28 @@ snapshots:
 
   reusify@1.0.4: {}
 
+  rolldown@1.0.0-beta.3-commit.b546e53(@oxc-project/runtime@0.51.0)(typescript@5.5.4):
+    dependencies:
+      '@oxc-project/types': 0.51.0
+      '@valibot/to-json-schema': 1.0.0-beta.5(valibot@1.0.0-beta.14(typescript@5.5.4))
+      valibot: 1.0.0-beta.14(typescript@5.5.4)
+    optionalDependencies:
+      '@oxc-project/runtime': 0.51.0
+      '@rolldown/binding-darwin-arm64': 1.0.0-beta.3-commit.b546e53
+      '@rolldown/binding-darwin-x64': 1.0.0-beta.3-commit.b546e53
+      '@rolldown/binding-freebsd-x64': 1.0.0-beta.3-commit.b546e53
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-beta.3-commit.b546e53
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-beta.3-commit.b546e53
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-beta.3-commit.b546e53
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-beta.3-commit.b546e53
+      '@rolldown/binding-linux-x64-musl': 1.0.0-beta.3-commit.b546e53
+      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.3-commit.b546e53
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.3-commit.b546e53
+      '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.3-commit.b546e53
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.3-commit.b546e53
+    transitivePeerDependencies:
+      - typescript
+
   rollup-plugin-inject@3.0.2:
     dependencies:
       estree-walker: 0.6.1
@@ -10647,9 +11055,9 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unocss@0.58.6(postcss@8.5.3)(rollup@4.34.8)(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)):
+  unocss@0.58.6(postcss@8.5.3)(rollup@4.34.8)(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(lightningcss@1.29.1)(terser@5.31.2)(tsx@4.16.2)):
     dependencies:
-      '@unocss/astro': 0.58.6(rollup@4.34.8)(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2))
+      '@unocss/astro': 0.58.6(rollup@4.34.8)(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(lightningcss@1.29.1)(terser@5.31.2)(tsx@4.16.2))
       '@unocss/cli': 0.58.6(rollup@4.34.8)
       '@unocss/core': 0.58.6
       '@unocss/extractor-arbitrary-variants': 0.58.6
@@ -10668,9 +11076,38 @@ snapshots:
       '@unocss/transformer-compile-class': 0.58.6
       '@unocss/transformer-directives': 0.58.6
       '@unocss/transformer-variant-group': 0.58.6
-      '@unocss/vite': 0.58.6(rollup@4.34.8)(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2))
+      '@unocss/vite': 0.58.6(rollup@4.34.8)(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(lightningcss@1.29.1)(terser@5.31.2)(tsx@4.16.2))
     optionalDependencies:
-      vite: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+      vite: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(lightningcss@1.29.1)(terser@5.31.2)(tsx@4.16.2)
+    transitivePeerDependencies:
+      - postcss
+      - rollup
+      - supports-color
+
+  unocss@0.58.6(postcss@8.5.3)(rollup@4.34.8)(vite@https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)):
+    dependencies:
+      '@unocss/astro': 0.58.6(rollup@4.34.8)(vite@https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4))
+      '@unocss/cli': 0.58.6(rollup@4.34.8)
+      '@unocss/core': 0.58.6
+      '@unocss/extractor-arbitrary-variants': 0.58.6
+      '@unocss/postcss': 0.58.6(postcss@8.5.3)
+      '@unocss/preset-attributify': 0.58.6
+      '@unocss/preset-icons': 0.58.6
+      '@unocss/preset-mini': 0.58.6
+      '@unocss/preset-tagify': 0.58.6
+      '@unocss/preset-typography': 0.58.6
+      '@unocss/preset-uno': 0.58.6
+      '@unocss/preset-web-fonts': 0.58.6
+      '@unocss/preset-wind': 0.58.6
+      '@unocss/reset': 0.58.6
+      '@unocss/transformer-attributify-jsx': 0.58.6
+      '@unocss/transformer-attributify-jsx-babel': 0.58.6
+      '@unocss/transformer-compile-class': 0.58.6
+      '@unocss/transformer-directives': 0.58.6
+      '@unocss/transformer-variant-group': 0.58.6
+      '@unocss/vite': 0.58.6(rollup@4.34.8)(vite@https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4))
+    optionalDependencies:
+      vite: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
     transitivePeerDependencies:
       - postcss
       - rollup
@@ -10719,6 +11156,10 @@ snapshots:
       kleur: 4.1.5
       sade: 1.8.1
 
+  valibot@1.0.0-beta.14(typescript@5.5.4):
+    optionalDependencies:
+      typescript: 5.5.4
+
   validate-npm-package-license@3.0.4:
     dependencies:
       spdx-correct: 3.2.0
@@ -10753,18 +11194,18 @@ snapshots:
       unist-util-stringify-position: 4.0.0
       vfile-message: 4.0.2
 
-  vite-node@1.4.0(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2):
+  vite-node@1.4.0(@types/node@20.14.10)(esbuild@0.17.19)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       pathe: 1.1.2
       picocolors: 1.1.1
-      vite: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+      vite: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.17.19)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
     transitivePeerDependencies:
       - '@types/node'
+      - esbuild
       - jiti
       - less
-      - lightningcss
       - sass
       - sass-embedded
       - stylus
@@ -10772,20 +11213,21 @@ snapshots:
       - supports-color
       - terser
       - tsx
+      - typescript
       - yaml
 
-  vite-node@3.0.3(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2):
+  vite-node@3.0.3(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.2
-      vite: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+      vite: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
     transitivePeerDependencies:
       - '@types/node'
+      - esbuild
       - jiti
       - less
-      - lightningcss
       - sass
       - sass-embedded
       - stylus
@@ -10793,20 +11235,21 @@ snapshots:
       - supports-color
       - terser
       - tsx
+      - typescript
       - yaml
 
-  vite-tsconfig-paths@5.1.4(typescript@5.5.4)(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)):
+  vite-tsconfig-paths@5.1.4(typescript@5.5.4)(vite@https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)):
     dependencies:
       debug: 4.4.0
       globrex: 0.1.2
       tsconfck: 3.1.0(typescript@5.5.4)
     optionalDependencies:
-      vite: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+      vite: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2):
+  vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(lightningcss@1.29.1)(terser@5.31.2)(tsx@4.16.2):
     dependencies:
       esbuild: 0.24.2
       postcss: 8.5.3
@@ -10815,17 +11258,50 @@ snapshots:
       '@types/node': 20.14.10
       fsevents: 2.3.3
       jiti: 1.21.0
+      lightningcss: 1.29.1
       terser: 5.31.2
       tsx: 4.16.2
 
-  vitefu@1.0.5(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)):
+  vite@https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.17.19)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4):
+    dependencies:
+      '@oxc-project/runtime': 0.51.0
+      lightningcss: 1.29.1
+      postcss: 8.5.3
+      rolldown: 1.0.0-beta.3-commit.b546e53(@oxc-project/runtime@0.51.0)(typescript@5.5.4)
     optionalDependencies:
-      vite: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+      '@types/node': 20.14.10
+      esbuild: 0.17.19
+      fsevents: 2.3.3
+      jiti: 1.21.0
+      terser: 5.31.2
+      tsx: 4.16.2
+    transitivePeerDependencies:
+      - typescript
 
-  vitest@3.0.3(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2):
+  vite@https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4):
+    dependencies:
+      '@oxc-project/runtime': 0.51.0
+      lightningcss: 1.29.1
+      postcss: 8.5.3
+      rolldown: 1.0.0-beta.3-commit.b546e53(@oxc-project/runtime@0.51.0)(typescript@5.5.4)
+    optionalDependencies:
+      '@types/node': 20.14.10
+      esbuild: 0.24.2
+      fsevents: 2.3.3
+      jiti: 1.21.0
+      terser: 5.31.2
+      tsx: 4.16.2
+    transitivePeerDependencies:
+      - typescript
+
+  vitefu@1.0.5(vite@https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)):
+    optionalDependencies:
+      vite: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
+
+  vitest@3.0.3(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4):
     dependencies:
       '@vitest/expect': 3.0.3
-      '@vitest/mocker': 3.0.3(vite@6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2))
+      '@vitest/mocker': 3.0.3(vite@https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4))
       '@vitest/pretty-format': 3.0.3
       '@vitest/runner': 3.0.3
       '@vitest/snapshot': 3.0.3
@@ -10841,15 +11317,15 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.1.1(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
-      vite-node: 3.0.3(@types/node@20.14.10)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)
+      vite: https://pkg.pr.new/rolldown/vite@7e5a8b6(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
+      vite-node: 3.0.3(@types/node@20.14.10)(esbuild@0.24.2)(jiti@1.21.0)(terser@5.31.2)(tsx@4.16.2)(typescript@5.5.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.14.10
     transitivePeerDependencies:
+      - esbuild
       - jiti
       - less
-      - lightningcss
       - msw
       - sass
       - sass-embedded
@@ -10858,6 +11334,7 @@ snapshots:
       - supports-color
       - terser
       - tsx
+      - typescript
       - yaml
 
   watchpack@2.4.1:


### PR DESCRIPTION
## issues

- [x] chunk total order reproduction https://github.com/rolldown/rolldown/issues/3429#issuecomment-2618556361

```sh
pnpm i
pnpm build
pnpm -C packages/react-server/examples/next build
```

- [x] `next/og` fails
  - need `ROLLUP_FILE_URL_xxx`
  - for now, it's fixed user land via `renderChunk` replacement.
  - [x] probably we should have this compat in Rolldown or at least in Vite. https://github.com/rolldown/rolldown/pull/3488
- [x] `prerenderPlugin` fails
  - due to chunking difference from rollup,  `virtual:react-server-build`'s `resolveId: { id: "../rsc/index.js", external: true }` needs to be adjusted?
  - this should be fixed on my side.
- [x] async local storage global broken `packages/react-server/examples/basic`
  - probably import side effect related? execution order?
  - this is also due to chunking difference and the bug would've also happened on rollup. this should be fixed on my plugin side.
```
  5 failed
    [chromium] › basic.test.ts:1017:1 › action context @js ─────────────────────────────────────────
    [chromium] › basic.test.ts:1023:1 › action context @nojs ───────────────────────────────────────
    [chromium] › basic.test.ts:1335:1 › React.cache @js ────────────────────────────────────────────
    [chromium] › basic.test.ts:1339:1 › React.cache @nojs ──────────────────────────────────────────
    [chromium] › basic.test.ts:1483:1 › cookies api route ──────────────────────────────────────────
```
- [x] unocss: `packages/react-server/examples/basic` and `test-vite-glob-routes`
  - https://github.com/unocss/unocss/issues/4403
- [x] `pnpm -C packages/react-server/examples/basic cf-build` errors with `createRequire` import
  - this is due to https://github.com/hi-ogawa/reproductions/tree/main/rolldown-vite-require-react-polyfill
  - this can be avoided by `noExternal: true` on ssr build and that's probably a reasonable thing to do anyway since rolldown is fast.
- [x] optimize deps esbuild options (test-pre-bundle-new-url)
  - this is esbuild workaround, so let's skip it for now

## todo

- [ ] test https://github.com/hi-ogawa/next-app-router-playground/pull/12
  - compare build time and investigate bottleneck