### PR TITLE
refactor: remove react-server-dom-webpack patch

### DIFF
--- a/packages/rsc/src/core/client-ssr.ts
+++ b/packages/rsc/src/core/client-ssr.ts
@@ -2,6 +2,7 @@ import * as clientReferences from "virtual:vite-rsc/client-references";
 import { memoize, tinyassert } from "@hiogawa/utils";
 import ReactDOM from "react-dom";
 import type { ImportManifestEntry, ModuleMap } from "../types";
+import { SERVER_REF_PREFIX } from "./shared";
 
 let init = false;
 export function initializeReactClientSsr(): void {
@@ -15,6 +16,9 @@ export function initializeReactClientSsr(): void {
 }
 
 function requireModule(id: string) {
+  if (id.startsWith(SERVER_REF_PREFIX)) {
+    return (globalThis as any).__vite_rsc_server_require__(id);
+  }
   prepareDestination(id);
   return requireModuleInner(id);
 }

--- a/packages/rsc/src/core/plugin.ts
+++ b/packages/rsc/src/core/plugin.ts
@@ -66,16 +66,6 @@ export function vitePluginRscCore(rscOptions: {
           );
           return { code, map: null };
         }
-        if (
-          this.environment?.name === "client" &&
-          id.includes("react-server-dom-webpack") &&
-          code.includes("__webpack_require__")
-        ) {
-          // avoid accessing `__webpack_require__` on import side effect
-          // https://github.com/facebook/react/blob/a9bbe34622885ef5667d33236d580fe7321c0d8b/packages/react-server-dom-webpack/src/client/ReactFlightClientConfigBundlerWebpackBrowser.js#L16-L17
-          code = code.replaceAll("__webpack_require__.u", "({}).u");
-          return { code, map: null };
-        }
         return;
       },
     },

--- a/packages/rsc/src/core/plugin.ts
+++ b/packages/rsc/src/core/plugin.ts
@@ -46,29 +46,6 @@ export function vitePluginRscCore(rscOptions: {
         }
       },
     },
-    {
-      name: "rsc-patch-webpack",
-      transform(code, id, _options) {
-        if (
-          this.environment?.name === "rsc" &&
-          id.includes("react-server-dom-webpack") &&
-          code.includes("__webpack_require__")
-        ) {
-          // rename webpack markers in rsc runtime
-          // to avoid conflict with ssr runtime which shares same globals
-          code = code.replaceAll(
-            "__webpack_require__",
-            "__vite_rsc_webpack_require__",
-          );
-          code = code.replaceAll(
-            "__webpack_chunk_load__",
-            "__vite_rsc_webpack_chunk_load__",
-          );
-          return { code, map: null };
-        }
-        return;
-      },
-    },
   ];
 }
 

--- a/packages/rsc/src/core/server.ts
+++ b/packages/rsc/src/core/server.ts
@@ -1,17 +1,13 @@
 import { memoize, tinyassert } from "@hiogawa/utils";
 import type { BundlerConfig, ImportManifestEntry } from "../types";
+import { SERVER_REF_PREFIX } from "./shared";
 
 let init = false;
 export function initializeReactServer(): void {
   if (init) return;
   init = true;
 
-  Object.assign(globalThis, {
-    __vite_rsc_webpack_require__: memoize(requireModule),
-    __vite_rsc_webpack_chunk_load__: () => {
-      throw new Error("__webpack_chunk_load__");
-    },
-  });
+  (globalThis as any).__vite_rsc_server_require__ = memoize(requireModule);
 }
 
 export async function importServerReference(id: string): Promise<Function> {
@@ -21,6 +17,12 @@ export async function importServerReference(id: string): Promise<Function> {
 }
 
 async function requireModule(id: string) {
+  tinyassert(
+    id.startsWith(SERVER_REF_PREFIX),
+    `invalid server reference '${id}'`,
+  );
+  id = id.slice(SERVER_REF_PREFIX.length);
+
   if (import.meta.env.DEV) {
     return import(/* @vite-ignore */ id);
   } else {

--- a/packages/rsc/src/core/shared.ts
+++ b/packages/rsc/src/core/shared.ts
@@ -1,3 +1,10 @@
 export function getBrowserPreamble(): string {
-  return `self.__viteRscImport = (id) => import(id);`;
+  let code = ``;
+  // avoid throwing when accessing `__webpack_require__` on import side effect
+  // (note that __webpack_require__ is later properly defined by packages/rsc/src/core/client-browser.ts)
+  // https://github.com/facebook/react/blob/a9bbe34622885ef5667d33236d580fe7321c0d8b/packages/react-server-dom-webpack/src/client/ReactFlightClientConfigBundlerWebpackBrowser.js#L16-L17
+  code += `self.__webpack_require__ = () => {};\n`;
+  // use __viteRscImport to avoid Vite adding `?import` query, which causes duplicate modules on browser.
+  code += `self.__viteRscImport = (id) => import(id);\n`;
+  return code;
 }

--- a/packages/rsc/src/core/shared.ts
+++ b/packages/rsc/src/core/shared.ts
@@ -8,3 +8,5 @@ export function getBrowserPreamble(): string {
   code += `self.__viteRscImport = (id) => import(id);\n`;
   return code;
 }
+
+export const SERVER_REF_PREFIX = "$$server:";

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -17,6 +17,7 @@ import {
 } from "vite";
 import { crawlFrameworkPkgs } from "vitefu";
 import { vitePluginRscCore } from "./core/plugin";
+import { SERVER_REF_PREFIX } from "./core/shared";
 import { toNodeHandler } from "./utils/fetch";
 
 // state for build orchestration
@@ -391,7 +392,7 @@ function vitePluginUseServer(): Plugin[] {
         const normalizedId = await normalizeReferenceId(id, "rsc");
         if (this.environment.name === "rsc") {
           const { output } = await transformServerActionServer(code, ast, {
-            id: normalizedId,
+            id: SERVER_REF_PREFIX + normalizedId,
             runtime: "$$register",
           });
           if (!output.hasChanged()) return;
@@ -409,7 +410,7 @@ function vitePluginUseServer(): Plugin[] {
           };
         } else {
           const output = await transformDirectiveProxyExport(ast, {
-            id: normalizedId,
+            id: SERVER_REF_PREFIX + normalizedId,
             runtime: "$$proxy",
             directive: "use server",
           });


### PR DESCRIPTION
Actually we didn't need `__vite_rsc_webpack_require__` patch after all.
(I think I initially patched it because I needed to patch async server reference anyways, but that's not the case, so we shouldn't need this either.)