### PR TITLE
refactor(rsc): simplify `SERVER_REFERENCE_PREFIX` trick

### DIFF
--- a/packages/rsc/src/core/server.ts
+++ b/packages/rsc/src/core/server.ts
@@ -13,6 +13,7 @@ export function initializeReactServer(): void {
 
   (globalThis as any).__webpack_require__ = (id: string) => {
     if (id.startsWith(SERVER_REFERENCE_PREFIX)) {
+      id = id.slice(SERVER_REFERENCE_PREFIX.length);
       return (globalThis as any).__vite_rsc_server_require__(id);
     }
     return (globalThis as any).__vite_rsc_client_require__(id);
@@ -30,12 +31,6 @@ export async function importServerReference(id: string): Promise<Function> {
 
 async function requireModule(id: string): Promise<unknown> {
   id = removeReferenceCacheTag(id);
-
-  tinyassert(
-    id.startsWith(SERVER_REFERENCE_PREFIX),
-    `invalid server reference '${id}'`,
-  );
-  id = id.slice(SERVER_REFERENCE_PREFIX.length);
 
   if (import.meta.env.DEV) {
     return import(/* @vite-ignore */ id);
@@ -61,7 +56,7 @@ export function createServerReferenceConfig(): BundlerConfig {
         tinyassert(id);
         tinyassert(name);
         return {
-          id: id + cacheTag,
+          id: SERVER_REFERENCE_PREFIX + id + cacheTag,
           name,
           chunks: [],
           async: true,

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -17,7 +17,6 @@ import {
 } from "vite";
 import { crawlFrameworkPkgs } from "vitefu";
 import { vitePluginRscCore } from "./core/plugin";
-import { SERVER_REFERENCE_PREFIX } from "./core/shared";
 import { toNodeHandler } from "./utils/fetch";
 
 // state for build orchestration
@@ -392,7 +391,7 @@ function vitePluginUseServer(): Plugin[] {
         const normalizedId = await normalizeReferenceId(id, "rsc");
         if (this.environment.name === "rsc") {
           const { output } = await transformServerActionServer(code, ast, {
-            id: SERVER_REFERENCE_PREFIX + normalizedId,
+            id: normalizedId,
             runtime: "$$register",
           });
           if (!output.hasChanged()) return;
@@ -410,7 +409,7 @@ function vitePluginUseServer(): Plugin[] {
           };
         } else {
           const output = await transformDirectiveProxyExport(ast, {
-            id: SERVER_REFERENCE_PREFIX + normalizedId,
+            id: normalizedId,
             runtime: "$$proxy",
             directive: "use server",
           });


### PR DESCRIPTION
I realized we can simplify this with the same idea from https://github.com/hi-ogawa/vite-plugins/pull/706