### PR TITLE
refactor(rsc): use react-server-dom-turbopack

### DIFF
--- a/packages/rsc/package.json
+++ b/packages/rsc/package.json
@@ -22,10 +22,13 @@
     "@hiogawa/transforms": "workspace:*",
     "vitefu": "^1.0.5"
   },
+  "devDependencies": {
+    "react-server-dom-turbopack": "^19.0.1"
+  },
   "peerDependencies": {
     "react": "*",
     "react-dom": "*",
-    "react-server-dom-webpack": "*",
+    "react-server-dom-turbopack": "*",
     "vite": "*"
   }
 }

--- a/packages/rsc/src/browser.tsx
+++ b/packages/rsc/src/browser.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import ReactDomClient from "react-dom/client";
-import ReactClient from "react-server-dom-webpack/client.browser";
+import ReactClient from "react-server-dom-turbopack/client.browser";
 import { initializeReactClientBrowser } from "./core/client-browser";
 import type { RscPayload } from "./server";
 import type { CallServerCallback } from "./types";

--- a/packages/rsc/src/core/client-browser.ts
+++ b/packages/rsc/src/core/client-browser.ts
@@ -7,8 +7,7 @@ export function initializeReactClientBrowser(): void {
   init = true;
 
   Object.assign(globalThis, {
-    __webpack_require__: memoize(requireModule),
-    __webpack_chunk_load__: async () => {},
+    __turbopack_require__: memoize(requireModule),
   });
 }
 

--- a/packages/rsc/src/core/server.ts
+++ b/packages/rsc/src/core/server.ts
@@ -11,7 +11,7 @@ export function initializeReactServer(): void {
   if (init) return;
   init = true;
 
-  (globalThis as any).__webpack_require__ = (id: string) => {
+  (globalThis as any).__turbopack_require__ = (id: string) => {
     if (id.startsWith(SERVER_REFERENCE_PREFIX)) {
       id = id.slice(SERVER_REFERENCE_PREFIX.length);
       return (globalThis as any).__vite_rsc_server_require__(id);

--- a/packages/rsc/src/core/shared.ts
+++ b/packages/rsc/src/core/shared.ts
@@ -4,7 +4,7 @@ export function getBrowserPreamble(): string {
   // avoid throwing when accessing `__webpack_require__` on import side effect
   // https://github.com/facebook/react/blob/a9bbe34622885ef5667d33236d580fe7321c0d8b/packages/react-server-dom-webpack/src/client/ReactFlightClientConfigBundlerWebpackBrowser.js#L16-L17
   // (note that __webpack_require__ is later properly defined by packages/rsc/src/core/client-browser.ts)
-  code += `self.__webpack_require__ = () => {};\n`;
+  // code += `self.__webpack_require__ = () => {};\n`;
 
   // use __viteRscImport to avoid Vite adding `?import` query, which causes duplicate modules on browser.
   code += `self.__viteRscImport = (id) => import(id);\n`;

--- a/packages/rsc/src/core/shared.ts
+++ b/packages/rsc/src/core/shared.ts
@@ -1,11 +1,6 @@
 export function getBrowserPreamble(): string {
   let code = ``;
 
-  // avoid throwing when accessing `__webpack_require__` on import side effect
-  // https://github.com/facebook/react/blob/a9bbe34622885ef5667d33236d580fe7321c0d8b/packages/react-server-dom-webpack/src/client/ReactFlightClientConfigBundlerWebpackBrowser.js#L16-L17
-  // (note that __webpack_require__ is later properly defined by packages/rsc/src/core/client-browser.ts)
-  // code += `self.__webpack_require__ = () => {};\n`;
-
   // use __viteRscImport to avoid Vite adding `?import` query, which causes duplicate modules on browser.
   code += `self.__viteRscImport = (id) => import(id);\n`;
 

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -45,7 +45,7 @@ export default function vitePluginRsc(rscOptions: {
               optimizeDeps: {
                 include: [
                   "react-dom/client",
-                  `react-server-dom-webpack/client.browser`,
+                  `react-server-dom-turbopack/client.browser`,
                 ],
                 exclude: [PKG_NAME],
               },
@@ -122,7 +122,7 @@ export default function vitePluginRsc(rscOptions: {
             noExternal: [
               "react",
               "react-dom",
-              "react-server-dom-webpack",
+              "react-server-dom-turbopack",
               ...result.ssr.noExternal,
             ].sort(),
           },
@@ -131,7 +131,7 @@ export default function vitePluginRsc(rscOptions: {
               "react",
               "react/jsx-runtime",
               "react/jsx-dev-runtime",
-              `react-server-dom-webpack/server.edge`,
+              `react-server-dom-turbopack/server.edge`,
             ],
           },
         };
@@ -371,7 +371,7 @@ function vitePluginUseClient(): Plugin[] {
         if (!output) return;
         clientReferences[normalizedId] = id;
         output.prepend(`
-          import * as $$ReactServer from "react-server-dom-webpack/server.edge";
+          import * as $$ReactServer from "react-server-dom-turbopack/server.edge";
           const $$register = (id, name) => $$ReactServer.registerClientReference({}, id, name);
         `);
         return { code: output.toString(), map: { mappings: "" } };
@@ -397,7 +397,7 @@ function vitePluginUseServer(): Plugin[] {
           if (!output.hasChanged()) return;
           serverReferences[normalizedId] = id;
           output.prepend(`
-            import * as $$ReactServer from "react-server-dom-webpack/server.edge";
+            import * as $$ReactServer from "react-server-dom-turbopack/server.edge";
             const $$register = (value, id, name) => {
               if (typeof value !== 'function') return value;
               return $$ReactServer.registerServerReference(value, id, name);
@@ -417,7 +417,7 @@ function vitePluginUseServer(): Plugin[] {
           serverReferences[normalizedId] = id;
           const name = this.environment.name === "client" ? "browser" : "edge";
           output.prepend(`
-            import * as $$ReactClient from "react-server-dom-webpack/server.${name}";
+            import * as $$ReactClient from "react-server-dom-turbopack/server.${name}";
             const $$proxy = (id, name) => $$ReactClient.createServerReference(${JSON.stringify(id + "#" + name)}, (...args) => __viteRscCallServer(...args))
           `);
           return { code: output.toString(), map: { mappings: "" } };

--- a/packages/rsc/src/server.tsx
+++ b/packages/rsc/src/server.tsx
@@ -1,5 +1,5 @@
 import type { ReactFormState } from "react-dom/client";
-import ReactServer from "react-server-dom-webpack/server.edge";
+import ReactServer from "react-server-dom-turbopack/server.edge";
 import {
   createClientReferenceConfig,
   createServerReferenceConfig,

--- a/packages/rsc/src/ssr.tsx
+++ b/packages/rsc/src/ssr.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { ReactFormState } from "react-dom/client";
 import ReactDomServer from "react-dom/server.edge";
-import ReactClient from "react-server-dom-webpack/client.edge";
+import ReactClient from "react-server-dom-turbopack/client.edge";
 import {
   createSsrModuleMap,
   initializeReactClientSsr,

--- a/packages/rsc/src/types/react.ts
+++ b/packages/rsc/src/types/react.ts
@@ -3,7 +3,7 @@ declare module "react-dom/server.edge" {
 }
 
 // https://github.com/facebook/react/blob/89021fb4ec9aa82194b0788566e736a4cedfc0e4/packages/react-server-dom-webpack/src/ReactFlightDOMServerEdge.js
-declare module "react-server-dom-webpack/server.edge" {
+declare module "react-server-dom-turbopack/server.edge" {
   export function renderToReadableStream<T>(
     data: T,
     bundlerConfig: import(".").BundlerConfig,
@@ -39,7 +39,7 @@ declare module "react-server-dom-webpack/server.edge" {
 }
 
 // https://github.com/facebook/react/blob/89021fb4ec9aa82194b0788566e736a4cedfc0e4/packages/react-server-dom-webpack/src/ReactFlightDOMClientEdge.js
-declare module "react-server-dom-webpack/client.edge" {
+declare module "react-server-dom-turbopack/client.edge" {
   export function createServerReference(
     id: string,
     callServer: import(".").CallServerCallback,
@@ -54,7 +54,7 @@ declare module "react-server-dom-webpack/client.edge" {
 }
 
 // https://github.com/facebook/react/blob/89021fb4ec9aa82194b0788566e736a4cedfc0e4/packages/react-server-dom-webpack/src/ReactFlightDOMClientBrowser.js
-declare module "react-server-dom-webpack/client.browser" {
+declare module "react-server-dom-turbopack/client.browser" {
   export function createServerReference(
     id: string,
     callServer: import(".").CallServerCallback,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -548,15 +548,16 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
-      react-server-dom-webpack:
-        specifier: ^19.1.0
-        version: 19.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(webpack@5.93.0(@swc/core@1.10.18(@swc/helpers@0.5.15))(esbuild@0.24.2))
       vite:
         specifier: ^6.1.0
         version: 6.1.1(@types/node@22.13.5)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
       vitefu:
         specifier: ^1.0.5
         version: 1.0.5(vite@6.1.1(@types/node@22.13.5)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
+    devDependencies:
+      react-server-dom-turbopack:
+        specifier: ^19.0.1
+        version: 19.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
   packages/rsc/examples/basic:
     dependencies:
@@ -5313,6 +5314,13 @@ packages:
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: ^19.1.0
+
+  react-server-dom-turbopack@19.1.0:
+    resolution: {integrity: sha512-Cqm8pKuj389JInLjqbg1Vxy+DGAxNIcMbi/zfimrqW1EIha3w7veuetsJ7DnMtBWaY6eKhDox4WpRQ7oXnNNNg==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: ^19.1.0
+      react-dom: ^19.1.0
 
   react-server-dom-webpack@19.1.0:
     resolution: {integrity: sha512-GUbawkNSN0oj8GnuNhMzsvyIHpXqqpAmyOY5NRqNNQ/M8wvUUN8YBoGjDUj9lbmBrmAHS65BByp6325CcWA0eg==}
@@ -10881,6 +10889,13 @@ snapshots:
     dependencies:
       '@remix-run/router': 1.22.0
       react: 19.1.0
+
+  react-server-dom-turbopack@19.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      acorn-loose: 8.4.0
+      neo-async: 2.6.2
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   react-server-dom-webpack@19.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(webpack@5.93.0(@swc/core@1.10.18(@swc/helpers@0.5.15))(esbuild@0.24.2)):
     dependencies:


### PR DESCRIPTION
It appears essentially same, but we don't have to workaround this additional import side effect of `__webpack_require__` https://github.com/facebook/react/blob/a9bbe34622885ef5667d33236d580fe7321c0d8b/packages/react-server-dom-webpack/src/client/ReactFlightClientConfigBundlerWebpackBrowser.js#L16-L17

---

Oh well, `react-server-dom-turbopack` actually doesn't support async server reference https://github.com/hi-ogawa/react/blob/a9bbe34622885ef5667d33236d580fe7321c0d8b/packages/react-server-dom-turbopack/src/client/ReactFlightClientConfigBundlerTurbopack.js#L131-L132, so we cannot use the same idea as `react-server-dom-webpack` https://github.com/hi-ogawa/vite-plugins/pull/704 and workaround would require more patches, so probably this is no-go for now.