### PR TITLE
fix(rsc): fix `setRequireModule` call orders

### DIFF
--- a/packages/rsc/package.json
+++ b/packages/rsc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/vite-rsc",
-  "version": "0.0.1-pre.0",
+  "version": "0.0.1-pre.1",
   "homepage": "https://github.com/hi-ogawa/vite-plugins/tree/main/packages/rsc",
   "repository": {
     "type": "git",

--- a/packages/rsc/src/core/rsc.ts
+++ b/packages/rsc/src/core/rsc.ts
@@ -4,6 +4,7 @@ import {
   SERVER_REFERENCE_PREFIX,
   createReferenceCacheTag,
   removeReferenceCacheTag,
+  setServerWebpackRequire,
 } from "./shared";
 
 let init = false;
@@ -20,16 +21,9 @@ export function setRequireModule(options: {
   };
 
   // need memoize to return stable promise from __webpack_require__
-  const viteRscServerRequire = memoize(requireModule);
+  (globalThis as any).__vite_rsc_server_require__ = memoize(requireModule);
 
-  // branch client and server require when ssr and rsc share same global
-  (globalThis as any).__webpack_require__ = (id: string) => {
-    if (id.startsWith(SERVER_REFERENCE_PREFIX)) {
-      id = id.slice(SERVER_REFERENCE_PREFIX.length);
-      return viteRscServerRequire(id);
-    }
-    return (globalThis as any).__vite_rsc_client_require__(id);
-  };
+  setServerWebpackRequire();
 }
 
 export async function loadServerAction(id: string): Promise<Function> {

--- a/packages/rsc/src/core/shared.ts
+++ b/packages/rsc/src/core/shared.ts
@@ -10,3 +10,14 @@ export function createReferenceCacheTag(): string {
 export function removeReferenceCacheTag(id: string): string {
   return id.split("$$cache=")[0]!;
 }
+
+export function setServerWebpackRequire(): void {
+  // branch client and server require to support the case when ssr and rsc share the same global
+  (globalThis as any).__webpack_require__ = (id: string) => {
+    if (id.startsWith(SERVER_REFERENCE_PREFIX)) {
+      id = id.slice(SERVER_REFERENCE_PREFIX.length);
+      return (globalThis as any).__vite_rsc_server_require__(id);
+    }
+    return (globalThis as any).__vite_rsc_client_require__(id);
+  };
+}

--- a/packages/rsc/src/core/ssr.ts
+++ b/packages/rsc/src/core/ssr.ts
@@ -1,6 +1,6 @@
 import { memoize } from "@hiogawa/utils";
 import type { ServerConsumerManifest } from "../types";
-import { removeReferenceCacheTag } from "./shared";
+import { removeReferenceCacheTag, setServerWebpackRequire } from "./shared";
 
 let init = false;
 
@@ -19,12 +19,9 @@ export function setRequireModule(options: {
     options.prepareDestination?.(removeReferenceCacheTag(id));
     return requireModule(id);
   };
-
-  // define __webpack_require__ in case ssr and rsc don't shared the same global
-  (globalThis as any).__webpack_require__ ??= (id: string) => {
-    return (globalThis as any).__vite_rsc_client_require__(id);
-  };
   (globalThis as any).__vite_rsc_client_require__ = clientRequire;
+
+  setServerWebpackRequire();
 }
 
 export function createServerConsumerManifest(): ServerConsumerManifest {


### PR DESCRIPTION
Follow up to https://github.com/hi-ogawa/vite-plugins/pull/754/. We can make it more robust and allow any ordering rsc and ssr `setRequireModule`.