### PR TITLE
feat(rsc): tree shake unused reference exports

### DIFF
--- a/packages/rsc/package.json
+++ b/packages/rsc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/vite-rsc",
-  "version": "0.0.1-pre.1",
+  "version": "0.0.1-pre.3",
   "homepage": "https://github.com/hi-ogawa/vite-plugins/tree/main/packages/rsc",
   "repository": {
     "type": "git",

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -49,7 +49,6 @@ export default function vitePluginRsc({
   };
   // TODO: this can be heuristically cralwed from package.json.
   // TODO: in principle, same trick is needed for `"use server"` package imported directly from client component.
-  // TODO: tree shake unused exports.
   clientPackages?: string[];
 }): Plugin[] {
   return [
@@ -395,9 +394,10 @@ async function normalizeReferenceId(id: string, name: "client" | "rsc") {
 function vitePluginUseClient({
   clientPackages = [],
 }: { clientPackages?: string[] }): Plugin[] {
+  // TODO: tree shaking can be done for non client package too.
   const clientPackageMeta: Record<
     string,
-    { source: string; exportNames: string[] }
+    { source: string; exportNames: string[]; renderedExports: string[] }
   > = {};
 
   return [
@@ -487,7 +487,11 @@ function vitePluginUseClient({
           ) {
             const resolved = await this.resolve(source, importer, options);
             if (resolved) {
-              clientPackageMeta[resolved.id] = { source, exportNames: [] };
+              clientPackageMeta[resolved.id] = {
+                source,
+                exportNames: [],
+                renderedExports: [],
+              };
               return resolved;
             }
           }
@@ -501,10 +505,30 @@ function vitePluginUseClient({
           const source = id.slice(
             "\0virtual:vite-rsc/client-package-proxy/".length,
           );
-          const { exportNames } = Object.values(clientPackageMeta).find(
+          const meta = Object.values(clientPackageMeta).find(
             (v) => v.source === source,
           )!;
+          const exportNames =
+            this.environment.mode === "build"
+              ? meta.renderedExports
+              : meta.exportNames;
           return `export {${exportNames.join(",")}} from ${JSON.stringify(source)};\n`;
+        }
+      },
+      generateBundle(_options, bundle) {
+        if (this.environment.name !== "rsc") return;
+
+        // track used exports of client references in rsc build
+        // to tree shake unused exports in browser and ssr build
+        for (const chunk of Object.values(bundle)) {
+          if (chunk.type === "chunk") {
+            for (const [id, mod] of Object.entries(chunk.modules)) {
+              const meta = clientPackageMeta[id];
+              if (meta) {
+                meta.renderedExports = mod.renderedExports;
+              }
+            }
+          }
         }
       },
     },

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -452,6 +452,7 @@ function vitePluginUseClient({
         clientReferences[referenceKey] = referenceValue;
         output.prepend(`
           import * as $$ReactServer from "${PKG_NAME}/rsc";
+          /* @__NO_SIDE_EFFECTS__ */
           const $$register = (id, name) => $$ReactServer.registerClientReference({}, id, name);
         `);
         return { code: output.toString(), map: { mappings: "" } };
@@ -528,6 +529,7 @@ function vitePluginUseServer(): Plugin[] {
           serverReferences[normalizedId] = id;
           output.prepend(`
             import * as $$ReactServer from "${PKG_NAME}/rsc";
+            /* @__NO_SIDE_EFFECTS__ */
             const $$register = (value, id, name) => {
               if (typeof value !== 'function') return value;
               return $$ReactServer.registerServerReference(value, id, name);
@@ -548,6 +550,7 @@ function vitePluginUseServer(): Plugin[] {
           const name = this.environment.name === "client" ? "browser" : "ssr";
           output.prepend(`
             import * as $$ReactClient from "${PKG_NAME}/${name}";
+            /* @__NO_SIDE_EFFECTS__ */
             const $$proxy = (id, name) => $$ReactClient.createServerReference(${JSON.stringify(id + "#" + name)})
           `);
           return { code: output.toString(), map: { mappings: "" } };


### PR DESCRIPTION
- Closes https://github.com/hi-ogawa/vite-plugins/issues/582

Probably we can use `RenderedModule.renderedExports` https://rollupjs.org/plugin-development/#generatebundle to find which exports is used in rsc build, then pass it to browser/ssr build to filter.

Let's try to do for `clientPackages` first. Technically our current `client-package-proxy` should be just applied to all client references, but that can be done later.
(Also, we should do the same for server reference, but that's less critical, so further unification is postponed...)

---

## result

Note that `react-router` is externalized on ssr build, so that doesn't affect. The main bundle difference is in `dist/client/assets/index-xxx.js`.

- after

```sh
$ pnpm -C packages/rsc/examples/react-router build

vite v6.3.2 building SSR bundle for production...
✓ 47 modules transformed.
dist/rsc/assets/server-references-Bldlspfa.js           0.13 kB
dist/rsc/assets/about-CUcNGHwo.js                       0.26 kB
dist/rsc/assets/home.actions-Cck91-B3.js                0.53 kB
dist/rsc/assets/home-DVRVvJuR.js                        2.30 kB
dist/rsc/assets/root-CMeUtk6m.js                        3.31 kB
dist/rsc/assets/jsx-runtime.react-server-BDq-Hq70.js   15.20 kB
dist/rsc/index.js                                     376.30 kB
✓ built in 289ms
vite v6.3.2 building for production...
✓ 54 modules transformed.
dist/client/.vite/manifest.json                     1.66 kB │ gzip:   0.36 kB
dist/client/assets/index-DeaUKArL.css              23.67 kB │ gzip:   4.55 kB
dist/client/assets/home.client-Cdv-49UE.js          0.41 kB │ gzip:   0.28 kB
dist/client/assets/client-CM4Rtqh4.js               0.65 kB │ gzip:   0.36 kB
dist/client/assets/about-C7X8dF1a.js                0.73 kB │ gzip:   0.37 kB
dist/client/assets/client-references-BNXKhrph.js    1.18 kB │ gzip:   0.53 kB
dist/client/assets/root.client-DLAGeMbT.js          1.34 kB │ gzip:   0.53 kB
dist/client/assets/index-B8Zmg6ll.js              802.79 kB │ gzip: 153.18 kB  👈👈
✓ built in 601ms
vite v6.3.2 building SSR bundle for production...
✓ 13 modules transformed.
dist/ssr/assets/server-assets-DlCNEQBi.js      0.14 kB
dist/ssr/assets/home.client-t_GsLM3r.js        0.34 kB
dist/ssr/assets/client-references-L8GfCDbl.js  0.59 kB
dist/ssr/assets/client-DDRZdLow.js             0.61 kB
dist/ssr/assets/about-BrZkHQC3.js              0.64 kB
dist/ssr/assets/root.client-CUlk-0Cp.js        1.18 kB
dist/ssr/index.js                              3.02 kB
✓ built in 20ms
```

<details><summary>packages/rsc/examples/react-router/dist/client/assets/client-references-BNXKhrph.js</summary>

```js
const __vite__mapDeps=(i,m=__vite__mapDeps,d=(m.f||(m.f=["assets/about-C7X8dF1a.js","assets/index-B8Zmg6ll.js","assets/index-DeaUKArL.css","assets/home.client-Cdv-49UE.js","assets/client-CM4Rtqh4.js","assets/root.client-DLAGeMbT.js"])))=>i.map(i=>d[i]);
import { _ as __vitePreload, L as Link, O as Outlet } from "./index-B8Zmg6ll.js";
const clientReferences = {
  "33f97434c268": () => __vitePreload(() => import("./about-C7X8dF1a.js"), true ? __vite__mapDeps([0,1,2]) : void 0),
  "ef9e8b85646e": () => __vitePreload(() => Promise.resolve().then(() => reactRouter), true ? void 0 : void 0),
  "272cde86fe25": () => __vitePreload(() => import("./home.client-Cdv-49UE.js"), true ? __vite__mapDeps([3,1,2]) : void 0),
  "00a500f9e756": () => __vitePreload(() => import("./client-CM4Rtqh4.js"), true ? __vite__mapDeps([4,1,2]) : void 0),
  "54bed2d5ed07": () => __vitePreload(() => import("./root.client-DLAGeMbT.js"), true ? __vite__mapDeps([5,1,2]) : void 0)
};
const reactRouter = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({
  __proto__: null,
  Link,
  Outlet
}, Symbol.toStringTag, { value: "Module" }));
export {
  clientReferences as default
};
```

</details>

- before

```sh
vite v6.3.2 building SSR bundle for production...
✓ 47 modules transformed.
dist/rsc/assets/server-references-C_in8BOX.js           0.13 kB
dist/rsc/assets/about-DXURGlLA.js                       0.22 kB
dist/rsc/assets/home.actions-CnC_m0aI.js                0.49 kB
dist/rsc/assets/home-CGW1cN1I.js                        2.25 kB
dist/rsc/assets/root-QydXwBhm.js                        9.16 kB
dist/rsc/assets/jsx-runtime.react-server-BDq-Hq70.js   15.20 kB
dist/rsc/index.js                                     376.30 kB
✓ built in 287ms
vite v6.3.2 building for production...
✓ 54 modules transformed.
dist/client/.vite/manifest.json                     1.66 kB │ gzip:   0.37 kB
dist/client/assets/index-DeaUKArL.css              23.67 kB │ gzip:   4.55 kB
dist/client/assets/home.client-D9OcCngK.js          0.41 kB │ gzip:   0.27 kB
dist/client/assets/client-dX4kdTyc.js               0.65 kB │ gzip:   0.36 kB
dist/client/assets/about-DGkq8w1P.js                0.73 kB │ gzip:   0.36 kB
dist/client/assets/root.client-aQE00Hdn.js          1.34 kB │ gzip:   0.53 kB
dist/client/assets/client-references-Dz712GCE.js    6.96 kB │ gzip:   2.15 kB
dist/client/assets/index-LTdxuAwi.js              997.38 kB │ gzip: 193.96 kB  👈👈
✓ built in 691ms
vite v6.3.2 building SSR bundle for production...
✓ 13 modules transformed.
dist/ssr/assets/server-assets-DTHqN4Er.js      0.14 kB
dist/ssr/assets/home.client-t_GsLM3r.js        0.34 kB
dist/ssr/assets/client-DDRZdLow.js             0.61 kB
dist/ssr/assets/about-BrZkHQC3.js              0.64 kB
dist/ssr/assets/root.client-CUlk-0Cp.js        1.18 kB
dist/ssr/index.js                              3.02 kB
dist/ssr/assets/client-references-XByJsYeu.js  5.26 kB
✓ built in 24ms
```

<details><summary>packages/rsc/examples/react-router/dist/client/assets/client-references-Dz712GCE.js</summary>

```js
const __vite__mapDeps=(i,m=__vite__mapDeps,d=(m.f||(m.f=["assets/about-DGkq8w1P.js","assets/index-LTdxuAwi.js","assets/index-DeaUKArL.css","assets/client-dX4kdTyc.js","assets/root.client-aQE00Hdn.js","assets/home.client-D9OcCngK.js"])))=>i.map(i=>d[i]);
import { _ as __vitePreload, A as Await, B as BrowserRouter, F as Form, H as HashRouter, I as IDLE_BLOCKER, b as IDLE_FETCHER, c as IDLE_NAVIGATION, L as Link, d as Links, M as MemoryRouter, e as Meta, N as NavLink, f as Navigate, g as Action, O as Outlet, P as PrefetchPageLinks, h as RSCHydratedRouter, i as RSCStaticRouter, k as Route, l as Router, m as RouterProvider, n as Routes, S as Scripts, o as ScrollRestoration, p as ServerRouter, q as StaticRouter, s as StaticRouterProvider, D as DataRouterContext, t as DataRouterStateContext, E as ErrorResponseImpl, v as FetchersContext, w as FrameworkContext, x as LocationContext, y as NavigationContext, z as RemixErrorBoundary, C as RouteContext, G as ServerMode, J as SingleFetchRedirectSymbol, V as ViewTransitionContext, K as createBrowserHistory, Q as createClientRoutes, T as createClientRoutesWithHMRRevalidationOptOut, U as createRouter, W as decodeViaTurboStream, X as deserializeErrors2, Y as getHydrationData, Z as getPatchRoutesOnNavigationFunction, $ as getTurboStreamSingleFetchDataStrategy, a0 as hydrationRouteProperties, a1 as invariant, a2 as mapRouteProperties, a3 as shouldHydrateRouteLoader, a4 as useFogOFWarDiscovery, a5 as useScrollRestoration, a6 as createBrowserRouter, a7 as createCallServer, a8 as createCookie, a9 as createCookieSessionStorage, aa as createHashRouter, ab as createMemoryRouter, ac as createMemorySessionStorage, ad as createPath, ae as createRequestHandler, af as createRoutesFromChildren, ag as createRoutesFromElements, ah as createRoutesStub, ai as createSearchParams, aj as createSession, ak as createSessionStorage, al as createStaticHandler2, am as createStaticRouter, an as data, ao as generatePath, ap as getServerStream, aq as href, ar as isCookie, as as isRouteErrorResponse, at as isSession, au as matchPath, av as matchRoutes, aw as parsePath, ax as redirect, ay as redirectDocument, az as renderMatches, aA as replace, aB as resolvePath, aC as routeRSCServerRequest, aD as HistoryRouter, aE as unstable_RouterContextProvider, aF as unstable_createContext, aG as setDevServerHooks, aH as usePrompt, aI as useActionData, aJ as useAsyncError, aK as useAsyncValue, aL as useBeforeUnload, aM as useBlocker, aN as useFetcher, aO as useFetchers, aP as useFormAction, aQ as useHref, aR as useInRouterContext, aS as useLinkClickHandler, aT as useLoaderData, aU as useLocation, aV as useMatch, aW as useMatches, aX as useNavigate, u as useNavigation, aY as useNavigationType, aZ as useOutlet, a_ as useOutletContext, a$ as useParams, b0 as useResolvedPath, b1 as useRevalidator, a as useRouteError, b2 as useRouteLoaderData, b3 as useRoutes, b4 as useSearchParams, b5 as useSubmit, b6 as useViewTransitionState } from "./index-LTdxuAwi.js";
const clientReferences = {
  "33f97434c268": () => __vitePreload(() => import("./about-DGkq8w1P.js"), true ? __vite__mapDeps([0,1,2]) : void 0),
  "ef9e8b85646e": () => __vitePreload(() => Promise.resolve().then(() => reactRouter), true ? void 0 : void 0),
  "00a500f9e756": () => __vitePreload(() => import("./client-dX4kdTyc.js"), true ? __vite__mapDeps([3,1,2]) : void 0),
  "54bed2d5ed07": () => __vitePreload(() => import("./root.client-aQE00Hdn.js"), true ? __vite__mapDeps([4,1,2]) : void 0),
  "272cde86fe25": () => __vitePreload(() => import("./home.client-D9OcCngK.js"), true ? __vite__mapDeps([5,1,2]) : void 0)
};
const reactRouter = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({
  __proto__: null,
  Await,
  BrowserRouter,
  Form,
  HashRouter,
  IDLE_BLOCKER,
  IDLE_FETCHER,
  IDLE_NAVIGATION,
  Link,
  Links,
  MemoryRouter,
  Meta,
  NavLink,
  Navigate,
  NavigationType: Action,
  Outlet,
  PrefetchPageLinks,
  RSCHydratedRouter,
  RSCStaticRouter,
  Route,
  Router,
  RouterProvider,
  Routes,
  Scripts,
  ScrollRestoration,
  ServerRouter,
  StaticRouter,
  StaticRouterProvider,
  UNSAFE_DataRouterContext: DataRouterContext,
  UNSAFE_DataRouterStateContext: DataRouterStateContext,
  UNSAFE_ErrorResponseImpl: ErrorResponseImpl,
  UNSAFE_FetchersContext: FetchersContext,
  UNSAFE_FrameworkContext: FrameworkContext,
  UNSAFE_LocationContext: LocationContext,
  UNSAFE_NavigationContext: NavigationContext,
  UNSAFE_RemixErrorBoundary: RemixErrorBoundary,
  UNSAFE_RouteContext: RouteContext,
  UNSAFE_ServerMode: ServerMode,
  UNSAFE_SingleFetchRedirectSymbol: SingleFetchRedirectSymbol,
  UNSAFE_ViewTransitionContext: ViewTransitionContext,
  UNSAFE_createBrowserHistory: createBrowserHistory,
  UNSAFE_createClientRoutes: createClientRoutes,
  UNSAFE_createClientRoutesWithHMRRevalidationOptOut: createClientRoutesWithHMRRevalidationOptOut,
  UNSAFE_createRouter: createRouter,
  UNSAFE_decodeViaTurboStream: decodeViaTurboStream,
  UNSAFE_deserializeErrors: deserializeErrors2,
  UNSAFE_getHydrationData: getHydrationData,
  UNSAFE_getPatchRoutesOnNavigationFunction: getPatchRoutesOnNavigationFunction,
  UNSAFE_getTurboStreamSingleFetchDataStrategy: getTurboStreamSingleFetchDataStrategy,
  UNSAFE_hydrationRouteProperties: hydrationRouteProperties,
  UNSAFE_invariant: invariant,
  UNSAFE_mapRouteProperties: mapRouteProperties,
  UNSAFE_shouldHydrateRouteLoader: shouldHydrateRouteLoader,
  UNSAFE_useFogOFWarDiscovery: useFogOFWarDiscovery,
  UNSAFE_useScrollRestoration: useScrollRestoration,
  createBrowserRouter,
  createCallServer,
  createCookie,
  createCookieSessionStorage,
  createHashRouter,
  createMemoryRouter,
  createMemorySessionStorage,
  createPath,
  createRequestHandler,
  createRoutesFromChildren,
  createRoutesFromElements,
  createRoutesStub,
  createSearchParams,
  createSession,
  createSessionStorage,
  createStaticHandler: createStaticHandler2,
  createStaticRouter,
  data,
  generatePath,
  getServerStream,
  href,
  isCookie,
  isRouteErrorResponse,
  isSession,
  matchPath,
  matchRoutes,
  parsePath,
  redirect,
  redirectDocument,
  renderMatches,
  replace,
  resolvePath,
  routeRSCServerRequest,
  unstable_HistoryRouter: HistoryRouter,
  unstable_RouterContextProvider,
  unstable_createContext,
  unstable_setDevServerHooks: setDevServerHooks,
  unstable_usePrompt: usePrompt,
  useActionData,
  useAsyncError,
  useAsyncValue,
  useBeforeUnload,
  useBlocker,
  useFetcher,
  useFetchers,
  useFormAction,
  useHref,
  useInRouterContext,
  useLinkClickHandler,
  useLoaderData,
  useLocation,
  useMatch,
  useMatches,
  useNavigate,
  useNavigation,
  useNavigationType,
  useOutlet,
  useOutletContext,
  useParams,
  useResolvedPath,
  useRevalidator,
  useRouteError,
  useRouteLoaderData,
  useRoutes,
  useSearchParams,
  useSubmit,
  useViewTransitionState
}, Symbol.toStringTag, { value: "Module" }));
export {
  clientReferences as default
};
```