### PR TITLE
feat(rsc): ssr modulepreload only for build

### DIFF
--- a/packages/rsc/examples/basic-core/src/rsc.tsx
+++ b/packages/rsc/examples/basic-core/src/rsc.tsx
@@ -72,6 +72,5 @@ export default async function handler(request: Request): Promise<Response> {
 }
 
 async function importSsr(): Promise<typeof import("./ssr")> {
-  // console.log("[viteSsrRunner.import]");
   return (globalThis as any).__viteSsrRunner.import("/src/ssr.tsx");
 }

--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -43,22 +43,18 @@ async function testAction(page: Page) {
   ).toBeVisible();
 }
 
-testNoJs("module preload on ssr", async ({ page }) => {
+testNoJs("module preload on ssr @build", async ({ page }) => {
   await page.goto("/");
   const srcs = await Promise.all(
     (await page.locator(`head >> link[rel="modulepreload"]`).all()).map((s) =>
       s.getAttribute("href"),
     ),
   );
-  if (process.env.E2E_PREVIEW) {
-    const viteManifest = JSON.parse(
-      fs.readFileSync("dist/client/.vite/manifest.json", "utf-8"),
-    );
-    const file = "/" + viteManifest["src/counter.tsx"].file;
-    expect(srcs).toContain(file);
-  } else {
-    expect(srcs).toContain("/src/counter.tsx");
-  }
+  const viteManifest = JSON.parse(
+    fs.readFileSync("dist/client/.vite/manifest.json", "utf-8"),
+  );
+  const file = "/" + viteManifest["src/counter.tsx"].file;
+  expect(srcs).toContain(file);
 });
 
 test("server reference update @dev @js", async ({ page }) => {

--- a/packages/rsc/src/extra/ssr.tsx
+++ b/packages/rsc/src/extra/ssr.tsx
@@ -1,11 +1,7 @@
-import * as clientReferences from "virtual:vite-rsc/client-references";
-import { tinyassert } from "@hiogawa/utils";
 import React from "react";
-import ReactDOM from "react-dom";
 import type { ReactFormState } from "react-dom/client";
 import ReactDomServer from "react-dom/server.edge";
-import { setRequireModule } from "../core/ssr";
-import { createFromReadableStream, importAssets } from "../ssr";
+import { createFromReadableStream, importAssets, initialize } from "../ssr";
 import type { RscPayload } from "./rsc";
 import {
   createBufferedTransformStream,
@@ -16,33 +12,7 @@ export async function renderHtml({
   stream,
   formState,
 }: { stream: ReadableStream; formState?: ReactFormState }): Promise<Response> {
-  setRequireModule({
-    load: async (id) => {
-      if (import.meta.env.DEV) {
-        return import(/* @vite-ignore */ id);
-      } else {
-        const import_ = clientReferences.default[id];
-        tinyassert(import_, `client reference not found '${id}'`);
-        return import_();
-      }
-    },
-    prepareDestination(id) {
-      // we manually run `preloadModule` instead of react-server-dom-webpack's prepareDestinationWithChunks
-      // maybe we can have this logic baked in react-server-dom-vite
-      if (import.meta.env.DEV) {
-        ReactDOM.preloadModule(id);
-      } else {
-        if (clientReferences.assetDeps) {
-          const deps = clientReferences.assetDeps[id];
-          if (deps) {
-            for (const js of deps.js) {
-              ReactDOM.preloadModule(js);
-            }
-          }
-        }
-      }
-    },
-  });
+  initialize();
 
   const [stream1, stream2] = stream.tee();
 

--- a/packages/rsc/src/ssr.ts
+++ b/packages/rsc/src/ssr.ts
@@ -1,3 +1,5 @@
+import * as clientReferences from "virtual:vite-rsc/client-references";
+import * as ReactDOM from "react-dom";
 import { setRequireModule } from "./core/ssr";
 import type { ServerAssets } from "./types";
 
@@ -11,14 +13,27 @@ export function initialize(): void {
       if (import.meta.env.DEV) {
         return import(/* @vite-ignore */ id);
       } else {
-        const clientReferences = await import(
-          "virtual:vite-rsc/client-references" as any
-        );
         const import_ = clientReferences.default[id];
         if (!import_) {
           throw new Error(`client reference not found '${id}'`);
         }
         return import_();
+      }
+    },
+    prepareDestination(id) {
+      // we manually run `preloadModule` instead of react-server-dom-webpack's prepareDestination
+      // maybe we can have this logic baked in react-server-dom-vite.
+      // for unbundled dev, preventing waterfall is not practical so this is build only
+      // (need to traverse entire module graph and add entire import chains to modulepreload).
+      if (!import.meta.env.DEV) {
+        if (clientReferences.assetDeps) {
+          const deps = clientReferences.assetDeps[id];
+          if (deps) {
+            for (const js of deps.js) {
+              ReactDOM.preloadModule(js);
+            }
+          }
+        }
       }
     },
   });


### PR DESCRIPTION
I realized doing this for dev is meaningless. Moving previous `extra/ssr.ts` to `ssr.ts` and remove dev preload and do always only for build.
