### PR TITLE
feat(rsc): refactor assets manifest and expose it to rsc build

### DIFF
--- a/packages/rsc/examples/react-router/src/entry.ssr.tsx
+++ b/packages/rsc/examples/react-router/src/entry.ssr.tsx
@@ -1,6 +1,6 @@
 import {
   createFromReadableStream,
-  importAssets,
+  getAssetsManifest,
   initialize,
 } from "@hiogawa/vite-rsc/ssr";
 // @ts-ignore
@@ -13,7 +13,7 @@ export default async function handler(
   request: Request,
   callServer: (request: Request) => Promise<Response>,
 ) {
-  const assets = await importAssets();
+  const assets = getAssetsManifest().entryAssets;
   const css = assets.css.map((href) => (
     <link key={href} rel="stylesheet" href={href} precedence="high" />
   ));

--- a/packages/rsc/examples/react-router/src/entry.ssr.tsx
+++ b/packages/rsc/examples/react-router/src/entry.ssr.tsx
@@ -13,9 +13,12 @@ export default async function handler(
   request: Request,
   callServer: (request: Request) => Promise<Response>,
 ) {
-  const assets = getAssetsManifest().entryAssets;
-  const css = assets.css.map((href) => (
+  const assets = getAssetsManifest().entry;
+  const css = assets.deps.css.map((href) => (
     <link key={href} rel="stylesheet" href={href} precedence="high" />
+  ));
+  const js = assets.deps.js.map((href) => (
+    <link key={href} rel="modulepreload" href={href} />
   ));
 
   return routeRSCServerRequest(
@@ -27,9 +30,10 @@ export default async function handler(
         <>
           <RSCStaticRouter payload={payload} />
           {css}
+          {js}
         </>,
         {
-          bootstrapModules: assets.js,
+          bootstrapModules: assets.bootstrapModules,
         },
       ),
   );

--- a/packages/rsc/package.json
+++ b/packages/rsc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/vite-rsc",
-  "version": "0.0.1-pre.3",
+  "version": "0.0.1-pre.4",
   "homepage": "https://github.com/hi-ogawa/vite-plugins/tree/main/packages/rsc",
   "repository": {
     "type": "git",

--- a/packages/rsc/src/extra/ssr.tsx
+++ b/packages/rsc/src/extra/ssr.tsx
@@ -1,7 +1,11 @@
 import React from "react";
 import type { ReactFormState } from "react-dom/client";
 import ReactDomServer from "react-dom/server.edge";
-import { assetsManifest, createFromReadableStream, initialize } from "../ssr";
+import {
+  createFromReadableStream,
+  getAssetsManifest,
+  initialize,
+} from "../ssr";
 import type { RscPayload } from "./rsc";
 import {
   createBufferedTransformStream,
@@ -16,7 +20,7 @@ export async function renderHtml({
 
   const [stream1, stream2] = stream.tee();
 
-  const assets = assetsManifest.entryAssets;
+  const assets = getAssetsManifest().entryAssets;
 
   // flight deserialization needs to be kicked in inside SSR context
   // for ReactDomServer preinit/preloading to work
@@ -36,7 +40,7 @@ export async function renderHtml({
   }
 
   const htmlStream = await ReactDomServer.renderToReadableStream(<SsrRoot />, {
-    bootstrapModules: assetsManifest.entryAssets.js,
+    bootstrapModules: assets.js,
     // @ts-expect-error no types
     formState,
   });

--- a/packages/rsc/src/extra/ssr.tsx
+++ b/packages/rsc/src/extra/ssr.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { ReactFormState } from "react-dom/client";
 import ReactDomServer from "react-dom/server.edge";
-import { createFromReadableStream, importAssets, initialize } from "../ssr";
+import { assetsManifest, createFromReadableStream, initialize } from "../ssr";
 import type { RscPayload } from "./rsc";
 import {
   createBufferedTransformStream,
@@ -16,7 +16,7 @@ export async function renderHtml({
 
   const [stream1, stream2] = stream.tee();
 
-  const assets = await importAssets();
+  const assets = assetsManifest.entryAssets;
 
   // flight deserialization needs to be kicked in inside SSR context
   // for ReactDomServer preinit/preloading to work
@@ -36,7 +36,7 @@ export async function renderHtml({
   }
 
   const htmlStream = await ReactDomServer.renderToReadableStream(<SsrRoot />, {
-    bootstrapModules: assets.js,
+    bootstrapModules: assetsManifest.entryAssets.js,
     // @ts-expect-error no types
     formState,
   });

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -305,13 +305,6 @@ export default function vitePluginRsc({
       load(id) {
         if (id === "\0virtual:vite-rsc/assets-manifest") {
           assert(this.environment.name !== "client");
-          const entryAssets: AssetDeps = { js: [], css: [] };
-          if (this.environment.mode === "dev") {
-            entryAssets.js = ["/@id/__x00__virtual:vite-rsc/browser-entry"];
-            if (entries.css) {
-              entryAssets.css.push(entries.css);
-            }
-          }
           const manifest: AssetsManifest = {
             entry: {
               bootstrapModules: ["/@id/__x00__virtual:vite-rsc/browser-entry"],

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -693,6 +693,11 @@ function generateDynamicImportCode(map: Record<string, string>) {
 // collect client reference dependency chunk for modulepreload
 //
 
+export type AssetsManifest = {
+  entryAssets: AssetDeps;
+  clientReferenceDeps: Record<string, AssetDeps>;
+};
+
 export type AssetDeps = {
   js: string[];
   css: string[];

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -292,7 +292,6 @@ export default function vitePluginRsc({
         return;
       },
     },
-    // TODO: helper for this virtual module pattern `createVirtualPluginBuildExternal`?
     {
       name: "rsc:virtual:vite-rsc/assets-manifest",
       resolveId(source) {

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -264,7 +264,7 @@ export default function vitePluginRsc({
       },
     },
     {
-      // virtual module to externalize import to build artifact.
+      // externalize `dist/rsc/...` import as relative path in ssr build (and vice versa)
       name: "rsc:virtual:vite-rsc/import-entry",
       resolveId(source) {
         if (
@@ -286,23 +286,18 @@ export default function vitePluginRsc({
         }
       },
       renderChunk(code, chunk) {
-        const relativeFrom = path.join(
-          this.environment.config.build.outDir,
-          chunk.fileName,
-          "..",
-        );
         if (code.includes("\0virtual:vite-rsc/import-rsc")) {
           const replacement = path.relative(
-            relativeFrom,
-            path.join(config.environments.rsc!.build.outDir, "index.js"),
+            path.join("dist/ssr", chunk.fileName, ".."),
+            path.join("dist/rsc", "index.js"),
           );
           code = code.replace("\0virtual:vite-rsc/import-rsc", replacement);
           return { code };
         }
         if (code.includes("\0virtual:vite-rsc/import-ssr")) {
           const replacement = path.relative(
-            relativeFrom,
-            path.join(config.environments.ssr!.build.outDir, "index.js"),
+            path.join("dist/rsc", chunk.fileName, ".."),
+            path.join("dist/ssr", "index.js"),
           );
           code = code.replace("\0virtual:vite-rsc/import-ssr", replacement);
           return { code };

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -292,6 +292,7 @@ export default function vitePluginRsc({
         return;
       },
     },
+    // TODO: helper for this virtual module pattern `createVirtualPluginBuildExternal`?
     {
       name: "rsc:virtual:vite-rsc/assets-manifest",
       resolveId(source) {
@@ -698,7 +699,6 @@ function generateDynamicImportCode(map: Record<string, string>) {
 //
 
 export type AssetsManifest = {
-  // entryAssets: AssetDeps;
   entry: { bootstrapModules: string[]; deps: AssetDeps };
   clientReferenceDeps: Record<string, AssetDeps>;
 };

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -312,7 +312,11 @@ export default function vitePluginRsc({
               entryAssets.css.push(entries.css);
             }
           }
-          return `export const entryAssets = ${JSON.stringify(entryAssets)}`;
+          const manifest: AssetsManifest = {
+            entryAssets,
+            clientReferenceDeps: {},
+          };
+          return `export default ${JSON.stringify(manifest, null, 2)}`;
         }
       },
       // client build
@@ -337,13 +341,14 @@ export default function vitePluginRsc({
               clientReferenceDeps[key] = deps;
             }
           }
+          const manifest: AssetsManifest = {
+            entryAssets,
+            clientReferenceDeps,
+          };
           this.emitFile({
             type: "asset",
             fileName: "__vite_rsc_assets_manifest.js",
-            source: `
-              export const entryAssets = ${JSON.stringify(entryAssets, null, 2)};
-              export const clientReferenceDeps = ${JSON.stringify(clientReferenceDeps, null, 2)};
-            `,
+            source: `export default ${JSON.stringify(manifest, null, 2)}`,
           });
         }
       },

--- a/packages/rsc/src/rsc.ts
+++ b/packages/rsc/src/rsc.ts
@@ -1,4 +1,6 @@
+import * as assetsManifest from "virtual:vite-rsc/assets-manifest";
 import { setRequireModule } from "./core/rsc";
+import type { AssetsManifest } from "./plugin";
 
 export {
   createClientManifest,
@@ -34,4 +36,8 @@ export async function importSsr<T>(): Promise<T> {
   } else {
     return mod;
   }
+}
+
+export function getAssetsManifest(): AssetsManifest {
+  return (assetsManifest as any).default;
 }

--- a/packages/rsc/src/rsc.ts
+++ b/packages/rsc/src/rsc.ts
@@ -1,5 +1,4 @@
 import { setRequireModule } from "./core/rsc";
-import type { ServerAssets } from "./types";
 
 export {
   createClientManifest,
@@ -35,9 +34,4 @@ export async function importSsr<T>(): Promise<T> {
   } else {
     return mod;
   }
-}
-
-export async function importAssets(): Promise<ServerAssets> {
-  const mod = await import("virtual:vite-rsc/import-assets" as any);
-  return mod.default;
 }

--- a/packages/rsc/src/rsc.ts
+++ b/packages/rsc/src/rsc.ts
@@ -1,4 +1,5 @@
 import { setRequireModule } from "./core/rsc";
+import type { ServerAssets } from "./types";
 
 export {
   createClientManifest,
@@ -34,4 +35,9 @@ export async function importSsr<T>(): Promise<T> {
   } else {
     return mod;
   }
+}
+
+export async function importAssets(): Promise<ServerAssets> {
+  const mod = await import("virtual:vite-rsc/import-assets" as any);
+  return mod.default;
 }

--- a/packages/rsc/src/ssr.ts
+++ b/packages/rsc/src/ssr.ts
@@ -49,6 +49,6 @@ export async function importRsc<T>(): Promise<T> {
 }
 
 export async function importAssets(): Promise<ServerAssets> {
-  const mod = await import("virtual:vite-rsc/server-assets");
+  const mod = await import("virtual:vite-rsc/import-assets" as any);
   return mod.default;
 }

--- a/packages/rsc/src/ssr.ts
+++ b/packages/rsc/src/ssr.ts
@@ -2,10 +2,9 @@ import * as assetsManifest from "virtual:vite-rsc/assets-manifest";
 import * as clientReferences from "virtual:vite-rsc/client-references";
 import * as ReactDOM from "react-dom";
 import { setRequireModule } from "./core/ssr";
+import type { AssetsManifest } from "./plugin";
 
 export { createServerConsumerManifest } from "./core/ssr";
-
-export { assetsManifest };
 
 export * from "./react/ssr";
 
@@ -28,7 +27,7 @@ export function initialize(): void {
       // for unbundled dev, preventing waterfall is not practical so this is build only
       // (need to traverse entire module graph and add entire import chains to modulepreload).
       if (!import.meta.env.DEV) {
-        const deps = assetsManifest.clientReferenceDeps[id];
+        const deps = getAssetsManifest().clientReferenceDeps[id];
         if (deps) {
           for (const js of deps.js) {
             ReactDOM.preloadModule(js);
@@ -46,4 +45,8 @@ export async function importRsc<T>(): Promise<T> {
   } else {
     return mod;
   }
+}
+
+export function getAssetsManifest(): AssetsManifest {
+  return assetsManifest as any;
 }

--- a/packages/rsc/src/ssr.ts
+++ b/packages/rsc/src/ssr.ts
@@ -1,9 +1,11 @@
+import * as assetsManifest from "virtual:vite-rsc/assets-manifest";
 import * as clientReferences from "virtual:vite-rsc/client-references";
 import * as ReactDOM from "react-dom";
 import { setRequireModule } from "./core/ssr";
-import type { ServerAssets } from "./types";
 
 export { createServerConsumerManifest } from "./core/ssr";
+
+export { assetsManifest };
 
 export * from "./react/ssr";
 
@@ -26,12 +28,10 @@ export function initialize(): void {
       // for unbundled dev, preventing waterfall is not practical so this is build only
       // (need to traverse entire module graph and add entire import chains to modulepreload).
       if (!import.meta.env.DEV) {
-        if (clientReferences.assetDeps) {
-          const deps = clientReferences.assetDeps[id];
-          if (deps) {
-            for (const js of deps.js) {
-              ReactDOM.preloadModule(js);
-            }
+        const deps = assetsManifest.clientReferenceDeps[id];
+        if (deps) {
+          for (const js of deps.js) {
+            ReactDOM.preloadModule(js);
           }
         }
       }
@@ -46,9 +46,4 @@ export async function importRsc<T>(): Promise<T> {
   } else {
     return mod;
   }
-}
-
-export async function importAssets(): Promise<ServerAssets> {
-  const mod = await import("virtual:vite-rsc/import-assets" as any);
-  return mod.default;
 }

--- a/packages/rsc/src/ssr.ts
+++ b/packages/rsc/src/ssr.ts
@@ -48,5 +48,5 @@ export async function importRsc<T>(): Promise<T> {
 }
 
 export function getAssetsManifest(): AssetsManifest {
-  return assetsManifest as any;
+  return (assetsManifest as any).default;
 }

--- a/packages/rsc/src/types/index.ts
+++ b/packages/rsc/src/types/index.ts
@@ -32,8 +32,3 @@ declare global {
   var __viteRscSsrRunner: ModuleRunner;
   var __viteRscCallServer: CallServerCallback;
 }
-
-export type ServerAssets = {
-  js: string[];
-  css: string[];
-};

--- a/packages/rsc/src/types/virtual.d.ts
+++ b/packages/rsc/src/types/virtual.d.ts
@@ -1,6 +1,9 @@
-declare module "virtual:vite-rsc/server-assets" {
-  const default_: import(".").ServerAssets;
-  export default default_;
+declare module "virtual:vite-rsc/assets-manifest" {
+  export const entryAssets: import("../plugin").AssetDeps;
+  export const clientReferenceDeps: Record<
+    string,
+    import("../plugin").AssetDeps
+  >;
 }
 
 declare module "virtual:vite-rsc/client-references" {

--- a/packages/rsc/src/types/virtual.d.ts
+++ b/packages/rsc/src/types/virtual.d.ts
@@ -1,10 +1,4 @@
-declare module "virtual:vite-rsc/assets-manifest" {
-  export const entryAssets: import("../plugin").AssetDeps;
-  export const clientReferenceDeps: Record<
-    string,
-    import("../plugin").AssetDeps
-  >;
-}
+declare module "virtual:vite-rsc/assets-manifest" {}
 
 declare module "virtual:vite-rsc/client-references" {
   const default_: Record<string, () => Promise<unknown>>;


### PR DESCRIPTION
While thinking about the proper/builtin support of "prepare destination", it seems like rsc needs to be able to encode dependency chunks into flight (aka `clientReferenceMetadata`) and ssr client uses it for "prepare destination".

To avoid build order constraints, let's use server external to load build artifact from each other similar to virtual `import-ssr` and `import-rsc`.