### PR TITLE
feat(rsc): support custom base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,8 @@ jobs:
       - run: pnpm -C packages/rsc/examples/basic build
       - run: pnpm -C packages/rsc/examples/basic test-e2e-preview
       - run: TEST_BASE=1 pnpm -C packages/rsc/examples/basic test-e2e
-      # - run: TEST_BASE=1 pnpm -C packages/rsc/examples/basic build
-      # - run: TEST_BASE=1 pnpm -C packages/rsc/examples/basic test-e2e-preview
+      - run: TEST_BASE=1 pnpm -C packages/rsc/examples/basic build
+      - run: TEST_BASE=1 pnpm -C packages/rsc/examples/basic test-e2e-preview
       - run: pnpm -C packages/rsc/examples/react-router test-e2e
       - run: pnpm -C packages/rsc/examples/react-router build
       - run: pnpm -C packages/rsc/examples/react-router test-e2e-preview

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - run: pnpm -C packages/rsc/examples/basic test-e2e
       - run: pnpm -C packages/rsc/examples/basic build
       - run: pnpm -C packages/rsc/examples/basic test-e2e-preview
+      - run: TEST_BASE=1 pnpm -C packages/rsc/examples/basic test-e2e
+      # - run: TEST_BASE=1 pnpm -C packages/rsc/examples/basic build
+      # - run: TEST_BASE=1 pnpm -C packages/rsc/examples/basic test-e2e-preview
       - run: pnpm -C packages/rsc/examples/react-router test-e2e
       - run: pnpm -C packages/rsc/examples/react-router build
       - run: pnpm -C packages/rsc/examples/react-router test-e2e-preview

--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -53,7 +53,9 @@ testNoJs("module preload on ssr @build", async ({ page }) => {
   const viteManifest = JSON.parse(
     fs.readFileSync("dist/client/.vite/manifest.json", "utf-8"),
   );
-  const file = "/" + viteManifest["src/counter.tsx"].file;
+  const file =
+    (process.env.TEST_BASE ? "/custom-base/" : "/") +
+    viteManifest["src/counter.tsx"].file;
   expect(srcs).toContain(file);
 });
 

--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -8,26 +8,26 @@ import {
 } from "./helper";
 
 test("basic", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("./");
   await waitForHydration(page);
 });
 
 test("client component", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("./");
   await waitForHydration(page);
   await page.getByRole("button", { name: "Client Counter: 0" }).click();
   await page.getByRole("button", { name: "Client Counter: 1" }).click();
 });
 
 test("server action @js", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("./");
   await waitForHydration(page);
   await using _ = await createReloadChecker(page);
   await testAction(page);
 });
 
 testNoJs("server action @nojs", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("./");
   await testAction(page);
 });
 
@@ -44,7 +44,7 @@ async function testAction(page: Page) {
 }
 
 testNoJs("module preload on ssr @build", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("./");
   const srcs = await Promise.all(
     (await page.locator(`head >> link[rel="modulepreload"]`).all()).map((s) =>
       s.getAttribute("href"),
@@ -58,13 +58,13 @@ testNoJs("module preload on ssr @build", async ({ page }) => {
 });
 
 test("server reference update @dev @js", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("./");
   await waitForHydration(page);
   await testServerActionUpdate(page, { js: true });
 });
 
 test("server reference update @dev @nojs", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("./");
   await testServerActionUpdate(page, { js: false });
 });
 
@@ -81,7 +81,7 @@ async function testServerActionUpdate(page: Page, options: { js: boolean }) {
   );
   if (!options.js) {
     await expect(async () => {
-      await page.goto("/");
+      await page.goto("./");
       await expect(
         page.getByRole("button", { name: "Server Counter: 0" }),
       ).toBeVisible({ timeout: 10 });
@@ -100,7 +100,7 @@ async function testServerActionUpdate(page: Page, options: { js: boolean }) {
 }
 
 test("client hmr @dev", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("./");
   await waitForHydration(page);
   await page.getByRole("button", { name: "Client Counter: 0" }).click();
   await expect(
@@ -114,12 +114,12 @@ test("client hmr @dev", async ({ page }) => {
   ).toBeVisible();
 
   // check next ssr is also updated
-  const res = await page.goto("/");
+  const res = await page.goto("./");
   expect(await res?.text()).toContain("Client [edit] Counter");
 });
 
 test("server hmr @dev", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("./");
   await waitForHydration(page);
   await page.getByRole("button", { name: "Client Counter: 0" }).click();
   await expect(
@@ -137,13 +137,13 @@ test("server hmr @dev", async ({ page }) => {
 });
 
 test("css @js", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("./");
   await waitForHydration(page);
   await testCss(page);
 });
 
 testNoJs("css @nojs", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("./");
   await testCss(page);
 });
 
@@ -153,7 +153,7 @@ async function testCss(page: Page, color = "rgb(255, 165, 0)") {
 }
 
 test("css hmr @dev", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("./");
   await waitForHydration(page);
   await testCss(page);
 
@@ -164,13 +164,13 @@ test("css hmr @dev", async ({ page }) => {
 });
 
 test("tailwind @js", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("./");
   await waitForHydration(page);
   await testTailwind(page);
 });
 
 testNoJs("tailwind @nojs", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("./");
   await testTailwind(page);
 });
 
@@ -188,7 +188,7 @@ async function testTailwind(page: Page) {
 }
 
 test("tailwind hmr @dev", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("./");
   await waitForHydration(page);
   await testTailwind(page);
 

--- a/packages/rsc/examples/basic/playwright.config.ts
+++ b/packages/rsc/examples/basic/playwright.config.ts
@@ -9,6 +9,9 @@ const command = isPreview
 export default defineConfig({
   testDir: "e2e",
   use: {
+    baseURL: process.env.TEST_BASE
+      ? `http://localhost:${port}/custom-base/`
+      : undefined,
     trace: "on-first-retry",
   },
   projects: [

--- a/packages/rsc/examples/basic/vite.config.ts
+++ b/packages/rsc/examples/basic/vite.config.ts
@@ -5,6 +5,7 @@ import { defineConfig } from "vite";
 import Inspect from "vite-plugin-inspect";
 
 export default defineConfig({
+  base: "/custom-base/",
   clearScreen: false,
   plugins: [
     tailwindcss(),

--- a/packages/rsc/examples/basic/vite.config.ts
+++ b/packages/rsc/examples/basic/vite.config.ts
@@ -5,7 +5,7 @@ import { defineConfig } from "vite";
 import Inspect from "vite-plugin-inspect";
 
 export default defineConfig({
-  base: "/custom-base/",
+  base: process.env.TEST_BASE ? "/custom-base/" : undefined,
   clearScreen: false,
   plugins: [
     tailwindcss(),

--- a/packages/rsc/src/browser.ts
+++ b/packages/rsc/src/browser.ts
@@ -9,7 +9,9 @@ export function initialize(options?: {
     load: async (id) => {
       if (import.meta.env.DEV) {
         // @ts-ignore
-        return __vite_rsc_raw_import__(id);
+        return __vite_rsc_raw_import__(
+          import.meta.env.BASE_URL.slice(0, -1) + id,
+        );
       } else {
         const clientReferences = await import(
           "virtual:vite-rsc/client-references" as any

--- a/packages/rsc/src/browser.ts
+++ b/packages/rsc/src/browser.ts
@@ -1,4 +1,5 @@
 import { setRequireModule } from "./core/browser";
+import { withBase } from "./utils/base";
 
 export * from "./react/browser";
 
@@ -9,9 +10,7 @@ export function initialize(options?: {
     load: async (id) => {
       if (import.meta.env.DEV) {
         // @ts-ignore
-        return __vite_rsc_raw_import__(
-          import.meta.env.BASE_URL.slice(0, -1) + id,
-        );
+        return __vite_rsc_raw_import__(withBase(id));
       } else {
         const clientReferences = await import(
           "virtual:vite-rsc/client-references" as any

--- a/packages/rsc/src/extra/ssr.tsx
+++ b/packages/rsc/src/extra/ssr.tsx
@@ -6,6 +6,7 @@ import {
   getAssetsManifest,
   initialize,
 } from "../ssr";
+import { withBase } from "../utils/base";
 import type { RscPayload } from "./rsc";
 import {
   createBufferedTransformStream,
@@ -29,10 +30,15 @@ export async function renderHtml({
     payload ??= createFromReadableStream<RscPayload>(stream1);
     const root = React.use(payload).root;
     const css = assets.deps.css.map((href) => (
-      <link key={href} rel="stylesheet" href={href} precedence="high" />
+      <link
+        key={href}
+        rel="stylesheet"
+        href={withBase(href)}
+        precedence="high"
+      />
     ));
     const js = assets.deps.js.map((href) => (
-      <link key={href} rel="modulepreload" href={href} />
+      <link key={href} rel="modulepreload" href={withBase(href)} />
     ));
     return (
       <>
@@ -44,7 +50,7 @@ export async function renderHtml({
   }
 
   const htmlStream = await ReactDomServer.renderToReadableStream(<SsrRoot />, {
-    bootstrapModules: assets.bootstrapModules,
+    bootstrapModules: assets.bootstrapModules.map((href) => withBase(href)),
     // @ts-expect-error no types
     formState,
   });

--- a/packages/rsc/src/extra/ssr.tsx
+++ b/packages/rsc/src/extra/ssr.tsx
@@ -22,7 +22,7 @@ export async function renderHtml({
 
   const assets = getAssetsManifest().entry;
 
-  // flight deserialization needs to be kicked in inside SSR context
+  // flight deserialization needs to be kicked off inside SSR context
   // for ReactDomServer preinit/preloading to work
   let payload: Promise<RscPayload>;
   function SsrRoot() {

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -294,15 +294,10 @@ export default function vitePluginRsc({
           assert(this.environment.name !== "client");
           const manifest: AssetsManifest = {
             entry: {
-              bootstrapModules: [
-                config.base.slice(0, -1) +
-                  "/@id/__x00__virtual:vite-rsc/browser-entry",
-              ],
+              bootstrapModules: ["/@id/__x00__virtual:vite-rsc/browser-entry"],
               deps: {
                 js: [],
-                css: entries.css
-                  ? [config.base.slice(0, -1) + entries.css]
-                  : [],
+                css: entries.css ? [entries.css] : [],
               },
             },
             clientReferenceDeps: {},
@@ -324,7 +319,7 @@ export default function vitePluginRsc({
           const entry = assetDeps["\0virtual:vite-rsc/browser-entry"]!;
           const manifest: AssetsManifest = {
             entry: {
-              bootstrapModules: [`/${entry.chunk.fileName}`],
+              bootstrapModules: [entry.chunk.fileName],
               deps: entry.deps,
             },
             clientReferenceDeps,
@@ -728,7 +723,7 @@ function collectAssetDepsInner(
 
   recurse(fileName);
   return {
-    js: [...visited].map((file) => `/${file}`),
-    css: [...new Set(css)].map((file) => `/${file}`),
+    js: [...visited],
+    css: [...new Set(css)],
   };
 }

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -319,7 +319,7 @@ export default function vitePluginRsc({
           const entry = assetDeps["\0virtual:vite-rsc/browser-entry"]!;
           const manifest: AssetsManifest = {
             entry: {
-              bootstrapModules: [entry.chunk.fileName],
+              bootstrapModules: [`/${entry.chunk.fileName}`],
               deps: entry.deps,
             },
             clientReferenceDeps,
@@ -723,7 +723,7 @@ function collectAssetDepsInner(
 
   recurse(fileName);
   return {
-    js: [...visited],
-    css: [...new Set(css)],
+    js: [...visited].map((file) => `/${file}`),
+    css: [...new Set(css)].map((file) => `/${file}`),
   };
 }

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -294,10 +294,15 @@ export default function vitePluginRsc({
           assert(this.environment.name !== "client");
           const manifest: AssetsManifest = {
             entry: {
-              bootstrapModules: ["/@id/__x00__virtual:vite-rsc/browser-entry"],
+              bootstrapModules: [
+                config.base.slice(0, -1) +
+                  "/@id/__x00__virtual:vite-rsc/browser-entry",
+              ],
               deps: {
                 js: [],
-                css: entries.css ? [entries.css] : [],
+                css: entries.css
+                  ? [config.base.slice(0, -1) + entries.css]
+                  : [],
               },
             },
             clientReferenceDeps: {},

--- a/packages/rsc/src/ssr.ts
+++ b/packages/rsc/src/ssr.ts
@@ -3,6 +3,7 @@ import * as clientReferences from "virtual:vite-rsc/client-references";
 import * as ReactDOM from "react-dom";
 import { setRequireModule } from "./core/ssr";
 import type { AssetsManifest } from "./plugin";
+import { withBase } from "./utils/base";
 
 export { createServerConsumerManifest } from "./core/ssr";
 
@@ -30,7 +31,7 @@ export function initialize(): void {
         const deps = getAssetsManifest().clientReferenceDeps[id];
         if (deps) {
           for (const js of deps.js) {
-            ReactDOM.preloadModule(js);
+            ReactDOM.preloadModule(withBase(js));
           }
         }
       }

--- a/packages/rsc/src/utils/base.ts
+++ b/packages/rsc/src/utils/base.ts
@@ -1,0 +1,9 @@
+// `base` is a build constant, but technically we could support it as runtime option instead.
+// As an (odd) convention, internally url is always prefix with "/" only on dev.
+const base = import.meta.env.DEV
+  ? import.meta.env.BASE_URL.slice(0, -1)
+  : import.meta.env.BASE_URL;
+
+export function withBase(url: string): string {
+  return base + url;
+}

--- a/packages/rsc/src/utils/base.ts
+++ b/packages/rsc/src/utils/base.ts
@@ -1,8 +1,6 @@
-// `base` is a build constant, but technically we could support it as runtime option instead.
-// As an (odd) convention, internally url is always prefix with "/" only on dev.
-const base = import.meta.env.DEV
-  ? import.meta.env.BASE_URL.slice(0, -1)
-  : import.meta.env.BASE_URL;
+// "base" is a build constant, but technically we could support it as runtime option instead.
+// internally url is ensured to be prefixed with `/`, so slice trailing slash from `BASE_URL`.
+const base = import.meta.env.BASE_URL.slice(0, -1);
 
 export function withBase(url: string): string {
   return base + url;


### PR DESCRIPTION
This only deals with browser assets prefix, which is a bundler concern. Additionally framework feature needs to be aware of base e.g. react router's `basename` option.

_todo_

- [x] dev
- [x] build
- [x] test
- [x] refactor
