### PR TITLE
feat(rsc): support `findSourceMapURL` for action

### DIFF
--- a/packages/rsc/examples/basic/src/routes/action.tsx
+++ b/packages/rsc/examples/basic/src/routes/action.tsx
@@ -1,6 +1,10 @@
 "use server";
 
-export let serverCounter = 0;
+let serverCounter = 0;
+
+export function getServerCounter() {
+  return serverCounter;
+}
 
 export async function changeServerCounter(formData: FormData): Promise<void> {
   const TEST_UPDATE = 1;

--- a/packages/rsc/examples/basic/src/routes/root.tsx
+++ b/packages/rsc/examples/basic/src/routes/root.tsx
@@ -1,8 +1,8 @@
 import type React from "react";
 import {
   changeServerCounter,
+  getServerCounter,
   resetServerCounter,
-  serverCounter,
 } from "./action";
 import {
   ClientCounter,
@@ -28,7 +28,7 @@ export function Root(props: { url: URL }) {
         <ClientCounter />
         <form action={changeServerCounter}>
           <input type="hidden" name="change" value="1" />
-          <button>Server Counter: {serverCounter}</button>
+          <button>Server Counter: {getServerCounter()}</button>
           <button formAction={resetServerCounter}>Server Reset</button>
         </form>
         <TestStyleClient />

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -591,10 +591,17 @@ function vitePluginUseServer(): Plugin[] {
           if (!output?.hasChanged()) return;
           serverReferences[normalizedId] = id;
           const name = this.environment.name === "client" ? "browser" : "ssr";
+          // TODO: need to directly call createServerReference
           output.prepend(`
             import * as $$ReactClient from "${PKG_NAME}/${name}";
             /* @__NO_SIDE_EFFECTS__ */
-            const $$proxy = (id, name) => $$ReactClient.createServerReference(${JSON.stringify(id + "#" + name)})
+            const $$proxy = (id, name) => $$ReactClient.createServerReference(
+              ${JSON.stringify(id + "#" + name)},
+              $$ReactClient.callServer,
+              undefined,
+              $$ReactClient.findSourceMapURL,
+              undefined,
+            )
           `);
           return { code: output.toString(), map: { mappings: "" } };
         }

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -566,17 +566,12 @@ function vitePluginUseServer(): Plugin[] {
         if (this.environment.name === "rsc") {
           const { output } = await transformServerActionServer(code, ast, {
             id: normalizedId,
-            runtime: "$$register",
+            runtime: "$$ReactServer.registerServerReference",
           });
           if (!output.hasChanged()) return;
           serverReferences[normalizedId] = id;
           output.prepend(`
             import * as $$ReactServer from "${PKG_NAME}/rsc";
-            /* @__NO_SIDE_EFFECTS__ */
-            const $$register = (value, id, name) => {
-              if (typeof value !== 'function') return value;
-              return $$ReactServer.registerServerReference(value, id, name);
-            }
           `);
           return {
             code: output.toString(),

--- a/packages/rsc/src/react/browser.ts
+++ b/packages/rsc/src/react/browser.ts
@@ -33,26 +33,13 @@ export function encodeReply(
   return ReactClient.encodeReply(v, options);
 }
 
-// TODO: this likely means we cannot have automatic `callServer` wrapper...?
-// https://github.com/facebook/react/pull/30741
-// The compiled output must call these directly without a wrapper function
-// because the wrapper adds a stack frame. I decided against complicated
-// and fragile dev-only options to skip n number of frames that would just
-// end up in prod code. The implementation just skips one frame - our own.
-// Otherwise it'll just point all source mapping to the wrapper.
-export function createServerReference(id: string): unknown {
-  return ReactClient.createServerReference(
-    id,
-    callServer,
-    undefined,
-    findSourceMapURL,
-  );
-}
+export const createServerReference: (...args: any[]) => unknown =
+  ReactClient.createServerReference;
 
 // use global instead of local variable  to tolerate duplicate modules
 // e.g. when `setServerCallback` is pre-bundled but `createServerReference` is not
 
-function callServer(...args: any[]): any {
+export function callServer(...args: any[]): any {
   return (globalThis as any).__viteRscCallServer(...args);
 }
 
@@ -65,7 +52,10 @@ export type { CallServerCallback };
 export const createTemporaryReferenceSet: () => unknown =
   ReactClient.createTemporaryReferenceSet;
 
-function findSourceMapURL(filename: string, environmentName: string) {
+export function findSourceMapURL(
+  filename: string,
+  environmentName: string,
+): string | null {
   if (!import.meta.env.DEV) return null;
   // TODO: respect config.server.origin and config.base?
   const url = new URL("/__vite_rsc_findSourceMapURL", window.location.origin);

--- a/packages/rsc/src/react/browser.ts
+++ b/packages/rsc/src/react/browser.ts
@@ -9,7 +9,7 @@ export function createFromReadableStream<T>(
   options: object = {},
 ): Promise<T> {
   return ReactClient.createFromReadableStream(stream, {
-    callServer: getCallServer(),
+    callServer,
     findSourceMapURL,
     ...options,
   });
@@ -20,7 +20,7 @@ export function createFromFetch<T>(
   options: object = {},
 ): Promise<T> {
   return ReactClient.createFromFetch(promiseForResponse, {
-    callServer: getCallServer(),
+    callServer,
     findSourceMapURL,
     ...options,
   });
@@ -34,16 +34,19 @@ export function encodeReply(
 }
 
 export function createServerReference(id: string): unknown {
-  return ReactClient.createServerReference(id, (...args: any[]) =>
-    getCallServer()(...args),
+  return ReactClient.createServerReference(
+    id,
+    callServer,
+    undefined,
+    findSourceMapURL,
   );
 }
 
 // use global instead of local variable  to tolerate duplicate modules
 // e.g. when `setServerCallback` is pre-bundled but `createServerReference` is not
 
-function getCallServer(): any {
-  return (globalThis as any).__viteRscCallServer;
+function callServer(...args: any[]): any {
+  return (globalThis as any).__viteRscCallServer(...args);
 }
 
 export function setServerCallback(fn: CallServerCallback): void {

--- a/packages/rsc/src/react/browser.ts
+++ b/packages/rsc/src/react/browser.ts
@@ -33,6 +33,13 @@ export function encodeReply(
   return ReactClient.encodeReply(v, options);
 }
 
+// TODO: this likely means we cannot have automatic `callServer` wrapper...?
+// https://github.com/facebook/react/pull/30741
+// The compiled output must call these directly without a wrapper function
+// because the wrapper adds a stack frame. I decided against complicated
+// and fragile dev-only options to skip n number of frames that would just
+// end up in prod code. The implementation just skips one frame - our own.
+// Otherwise it'll just point all source mapping to the wrapper.
 export function createServerReference(id: string): unknown {
   return ReactClient.createServerReference(
     id,

--- a/packages/rsc/src/react/rsc.ts
+++ b/packages/rsc/src/react/rsc.ts
@@ -24,13 +24,11 @@ export function registerClientReference<T>(
   return ReactServer.registerClientReference(proxy, id, name);
 }
 
-export function registerServerReference<T>(
+export const registerServerReference: <T>(
   ref: T,
   id: string,
   name: string,
-): T {
-  return ReactServer.registerServerReference(ref, id, name);
-}
+) => T = ReactServer.registerServerReference;
 
 export function decodeReply(
   body: string | FormData,


### PR DESCRIPTION
- Closes https://github.com/hi-ogawa/vite-plugins/issues/780

Probably our `createServerReference` wrapper is actually breaking React picking up the location properly. sigh...

> (from https://github.com/facebook/react/pull/30741)
> The compiled output must call these directly without a wrapper function because the wrapper adds a stack frame. I decided against complicated and fragile dev-only options to skip n number of frames that would just end up in prod code. The implementation just skips one frame - our own. Otherwise it'll just point all source mapping to the wrapper.

https://github.com/hi-ogawa/vite-plugins/blob/8b0ba3bbdab133205754fd526f202193336e1050/packages/rsc/src/react/browser.ts#L36-L37


Well, we have one more wrapper to make it generic transform...

https://github.com/hi-ogawa/vite-plugins/blob/27c5e8e8e65f33b82602a42da923f71db143954d/packages/rsc/src/plugin.ts#L597

---

Just like Next.js's story https://github.com/vercel/next.js/pull/71042, we just need to get refactor things around wrapper. Probably to be done separately.

---

Maybe additionally, we need to generate source map to map original action function and `registerServerReference/createServerReference` exports?