### PR TITLE
fix(rsc): fix findSourceMapURL sources

### DIFF
--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -764,7 +764,7 @@ export function vitePluginFindSourceMapURL(): Plugin[] {
               server.environments.rsc!.moduleGraph.getModuleById(filename);
             const map = mod?.transformResult?.map;
             if (map) {
-              res.end(JSON.stringify(map));
+              res.end(JSON.stringify({ ...map, sources: [mod.url] }));
             } else if (fs.existsSync(filename)) {
               // line-by-line identity source map
               const content = fs.readFileSync(filename, "utf-8");


### PR DESCRIPTION
Part of https://github.com/hi-ogawa/vite-plugins/issues/780

Vite's source map object has

```
// filename: /home/hiroshi/code/personal/vite-plugins/packages/rsc/examples/basic/src/routes/root.tsx
{
  sources: ["root.tsx"],
  mappings: ....
}
```

however `sources` needs to match with Vite's module url `/src/routes/root.tsx` so that the server file also lines up with client files on devtools.

![image](https://github.com/user-attachments/assets/12690bce-e66a-4ac7-92e7-d51e7de61f21)
