### PR TITLE
feat(rsc): support `findSourceMapURL` for `createServerReference` + feat(transforms)!: source map for proxy export transform

### DIFF
--- a/packages/react-server/src/features/client-component/plugin.ts
+++ b/packages/react-server/src/features/client-component/plugin.ts
@@ -94,7 +94,7 @@ export function vitePluginServerUseClient({
         const result = transformDirectiveProxyExport(ast, {
           directive: USE_CLIENT,
           id,
-          runtime: "$$proxy",
+          runtime: (id, name) => `$$proxy(${id}, ${name})`,
           ignoreExportAllDeclaration: true,
         });
         const output = result?.output;
@@ -152,7 +152,7 @@ export function vitePluginServerUseClient({
       const result = transformDirectiveProxyExport(ast, {
         directive: USE_CLIENT,
         id: clientId,
-        runtime: "$$proxy",
+        runtime: (id, name) => `$$proxy(${id}, ${name})`,
         ignoreExportAllDeclaration: true,
       });
       const output = result?.output;

--- a/packages/react-server/src/features/client-component/plugin.ts
+++ b/packages/react-server/src/features/client-component/plugin.ts
@@ -93,8 +93,8 @@ export function vitePluginServerUseClient({
         id = wrapId(id);
         const result = transformDirectiveProxyExport(ast, {
           directive: USE_CLIENT,
-          id,
-          runtime: (id, name) => `$$proxy(${id}, ${name})`,
+          runtime: (name) =>
+            `$$proxy(${JSON.stringify(id)}, ${JSON.stringify(name)})`,
           ignoreExportAllDeclaration: true,
         });
         const output = result?.output;
@@ -151,8 +151,8 @@ export function vitePluginServerUseClient({
       const ast = await parseAstAsync(code);
       const result = transformDirectiveProxyExport(ast, {
         directive: USE_CLIENT,
-        id: clientId,
-        runtime: (id, name) => `$$proxy(${id}, ${name})`,
+        runtime: (name) =>
+          `$$proxy(${JSON.stringify(clientId)}, ${JSON.stringify(name)})`,
         ignoreExportAllDeclaration: true,
       });
       const output = result?.output;

--- a/packages/react-server/src/features/server-action/browser.tsx
+++ b/packages/react-server/src/features/server-action/browser.tsx
@@ -1,8 +1,1 @@
-import * as ReactClient from "@hiogawa/vite-rsc/react/browser";
-
-// https://github.com/facebook/react/blob/c8a035036d0f257c514b3628e927dd9dd26e5a09/packages/react-client/src/ReactFlightReplyClient.js#L758
-
-/* @__NO_SIDE_EFFECTS__ */
-export function createServerReference(id: string) {
-  return ReactClient.createServerReference(id);
-}
+export * from "@hiogawa/vite-rsc/react/browser";

--- a/packages/react-server/src/features/server-action/plugin.tsx
+++ b/packages/react-server/src/features/server-action/plugin.tsx
@@ -45,8 +45,8 @@ export function vitePluginClientUseServer({
       const ast = await parseAstAsync(code);
       const result = transformDirectiveProxyExport(ast, {
         directive: USE_SERVER,
-        id: serverId,
-        runtime: (id, name) => `$$proxy(${id}, ${name})`,
+        runtime: (name) =>
+          `$$proxy(${JSON.stringify(serverId)}, ${JSON.stringify(name)})`,
         ignoreExportAllDeclaration: true,
       });
       const output = result?.output;

--- a/packages/react-server/src/features/server-action/plugin.tsx
+++ b/packages/react-server/src/features/server-action/plugin.tsx
@@ -46,7 +46,7 @@ export function vitePluginClientUseServer({
       const result = transformDirectiveProxyExport(ast, {
         directive: USE_SERVER,
         id: serverId,
-        runtime: "$$proxy",
+        runtime: (id, name) => `$$proxy(${id}, ${name})`,
         ignoreExportAllDeclaration: true,
       });
       const output = result?.output;

--- a/packages/react-server/src/features/server-action/ssr.tsx
+++ b/packages/react-server/src/features/server-action/ssr.tsx
@@ -1,6 +1,1 @@
-import * as ReactClient from "@hiogawa/vite-rsc/react/ssr";
-
-/* @__NO_SIDE_EFFECTS__ */
-export function createServerReference(id: string) {
-  return ReactClient.createServerReference(id);
-}
+export * from "@hiogawa/vite-rsc/react/ssr";

--- a/packages/react-server/src/runtime/browser.ts
+++ b/packages/react-server/src/runtime/browser.ts
@@ -1,1 +1,1 @@
-export { createServerReference } from "../features/server-action/browser";
+export * from "../features/server-action/browser";

--- a/packages/react-server/src/runtime/ssr.ts
+++ b/packages/react-server/src/runtime/ssr.ts
@@ -1,1 +1,1 @@
-export { createServerReference } from "../features/server-action/ssr";
+export * from "../features/server-action/ssr";

--- a/packages/rsc/examples/basic/src/routes/action-from-client/action.tsx
+++ b/packages/rsc/examples/basic/src/routes/action-from-client/action.tsx
@@ -1,0 +1,5 @@
+"use server";
+
+export async function TestAction() {
+  console.log("[test-action-from-client]");
+}

--- a/packages/rsc/examples/basic/src/routes/action-from-client/action.tsx
+++ b/packages/rsc/examples/basic/src/routes/action-from-client/action.tsx
@@ -1,5 +1,23 @@
 "use server";
 
+// test findSourceMapURL for server action imported from client
+
+export function NotThis() {
+  //
+  //
+  //
+  NotThis2();
+}
+
 export async function TestAction() {
   console.log("[test-action-from-client]");
+}
+
+function NotThis2() {
+  //
+  //
+}
+
+export async function TestAction2() {
+  console.log("[test-action-from-client-2]");
 }

--- a/packages/rsc/examples/basic/src/routes/action-from-client/client.tsx
+++ b/packages/rsc/examples/basic/src/routes/action-from-client/client.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { TestAction } from "./action";
+
+export function TestActionFromClient() {
+  return (
+    <form action={TestAction}>
+      <button>test-action-from-client</button>
+    </form>
+  );
+}

--- a/packages/rsc/examples/basic/src/routes/action-from-client/client.tsx
+++ b/packages/rsc/examples/basic/src/routes/action-from-client/client.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { TestAction } from "./action";
+import { TestAction, TestAction2 } from "./action";
 
 export function TestActionFromClient() {
   return (
     <form action={TestAction}>
       <button>test-action-from-client</button>
+      <button formAction={TestAction2}>test-action-from-client-2</button>
     </form>
   );
 }

--- a/packages/rsc/examples/basic/src/routes/root.tsx
+++ b/packages/rsc/examples/basic/src/routes/root.tsx
@@ -4,6 +4,7 @@ import {
   resetServerCounter,
   serverCounter,
 } from "./action";
+import { TestActionFromClient } from "./action-from-client/client";
 import {
   ClientCounter,
   Hydrated,
@@ -48,6 +49,7 @@ export function Root(props: { url: URL }) {
         <TestServerActionError />
         <TestReplayConsoleLogs url={props.url} />
         <TestSuspense url={props.url} />
+        <TestActionFromClient />
       </body>
     </html>
   );

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -482,7 +482,7 @@ function vitePluginUseClient({
         const result = transformDirectiveProxyExport(ast, {
           directive: "use client",
           id: referenceKey,
-          runtime: "$$register",
+          runtime: (id, name) => `$$register(${id}, ${name})`,
         });
         if (!result) return;
         const { output, exportNames } = result;
@@ -595,7 +595,7 @@ function vitePluginUseServer(): Plugin[] {
         } else {
           const result = transformDirectiveProxyExport(ast, {
             id: normalizedId,
-            runtime: "$$proxy",
+            runtime: (id, name) => `$$proxy(${id}, ${name})`,
             directive: "use server",
           });
           const output = result?.output;

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -481,7 +481,6 @@ function vitePluginUseClient({
         }
 
         const result = transformDirectiveProxyExport(ast, {
-          code,
           directive: "use client",
           runtime: (name) =>
             `$$ReactServer.registerClientReference({}, ${JSON.stringify(referenceKey)}, ${JSON.stringify(name)})`,
@@ -563,6 +562,7 @@ function vitePluginUseClient({
 }
 
 function vitePluginUseServer(): Plugin[] {
+  // TODO: reject non async function export
   return [
     {
       name: "rsc:use-server",

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -821,7 +821,6 @@ export async function findSourceMapURL(
     try {
       const url = new URL(filename).pathname;
       mod = server.environments.client.moduleGraph.urlToModuleMap.get(url);
-      console.log(mod?.transformResult?.map);
     } catch (e) {}
   }
 

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -593,7 +593,7 @@ function vitePluginUseServer(): Plugin[] {
           const result = transformDirectiveProxyExport(ast, {
             id: normalizedId,
             runtime: (id, name) =>
-              `$$ReactClient.createServerReference(${id} + "#" + ${name}, $$ReactClient.callServer, undefined, undefined, undefined)`,
+              `$$ReactClient.createServerReference(${id} + "#" + ${name}, $$ReactClient.callServer, undefined, $$ReactClient.findSourceMapURL, ${name})`,
             directive: "use server",
           });
           const output = result?.output;
@@ -603,7 +603,6 @@ function vitePluginUseServer(): Plugin[] {
           output.prepend(
             `import * as $$ReactClient from "${PKG_NAME}/${name}";\n`,
           );
-          console.log(normalizedId + "\n", output.toString());
           return { code: output.toString(), map: { mappings: "" } };
         }
       },

--- a/packages/rsc/src/react/rsc.ts
+++ b/packages/rsc/src/react/rsc.ts
@@ -24,13 +24,11 @@ export function registerClientReference<T>(
   return ReactServer.registerClientReference(proxy, id, name);
 }
 
-export function registerServerReference<T>(
+export const registerServerReference: <T>(
   ref: T,
   id: string,
   name: string,
-): T {
-  return ReactServer.registerServerReference(ref, id, name);
-}
+) => T = ReactServer.registerServerReference;
 
 export function decodeReply(
   body: string | FormData,

--- a/packages/rsc/src/react/ssr.ts
+++ b/packages/rsc/src/react/ssr.ts
@@ -17,3 +17,6 @@ export function createFromReadableStream<T>(
 export function createServerReference(id: string): unknown {
   return ReactClient.createServerReference(id);
 }
+
+export const callServer = null;
+export const findSourceMapURL = null;

--- a/packages/transforms/src/proxy-export.test.ts
+++ b/packages/transforms/src/proxy-export.test.ts
@@ -6,8 +6,7 @@ import { transformWrapExport } from "./wrap-export";
 async function testTransform(input: string) {
   const ast = await parseAstAsync(input);
   const result = transformProxyExport(ast, {
-    id: "<id>",
-    runtime: (id, name) => `$$proxy(${id}, ${name})`,
+    runtime: (name) => `$$proxy("<id>", ${JSON.stringify(name)})`,
   });
   return { ...result, output: result.output.toString() };
 }

--- a/packages/transforms/src/proxy-export.test.ts
+++ b/packages/transforms/src/proxy-export.test.ts
@@ -30,11 +30,11 @@ export class Cls {};
           "AsyncFn",
           "Cls",
         ],
-        "output": "export const Arrow = $$proxy("<id>", "Arrow");
-      export default $$proxy("<id>", "default");
-      export const Fn = $$proxy("<id>", "Fn");
-      export const AsyncFn = $$proxy("<id>", "AsyncFn");
-      export const Cls = $$proxy("<id>", "Cls");
+        "output": "export const Arrow = /* #__PURE__ */ $$proxy("<id>", "Arrow");
+      export default /* #__PURE__ */ $$proxy("<id>", "default");
+      export const Fn = /* #__PURE__ */ $$proxy("<id>", "Fn");
+      export const AsyncFn = /* #__PURE__ */ $$proxy("<id>", "AsyncFn");
+      export const Cls = /* #__PURE__ */ $$proxy("<id>", "Cls");
       ",
       }
     `);
@@ -50,8 +50,8 @@ export const { x, y: [z] } = { x: 0, y: [1] };
           "x",
           "z",
         ],
-        "output": "export const x = $$proxy("<id>", "x");
-      export const z = $$proxy("<id>", "z");
+        "output": "export const x = /* #__PURE__ */ $$proxy("<id>", "x");
+      export const z = /* #__PURE__ */ $$proxy("<id>", "z");
       ",
       }
     `);
@@ -65,7 +65,7 @@ export const { x, y: [z] } = { x: 0, y: [1] };
         "exportNames": [
           "default",
         ],
-        "output": "export default $$proxy("<id>", "default");
+        "output": "export default /* #__PURE__ */ $$proxy("<id>", "default");
       ",
       }
     `,
@@ -80,7 +80,7 @@ export const { x, y: [z] } = { x: 0, y: [1] };
         "exportNames": [
           "default",
         ],
-        "output": "export default $$proxy("<id>", "default");
+        "output": "export default /* #__PURE__ */ $$proxy("<id>", "default");
       ",
       }
     `,
@@ -95,7 +95,7 @@ export const { x, y: [z] } = { x: 0, y: [1] };
         "exportNames": [
           "default",
         ],
-        "output": "export default $$proxy("<id>", "default");
+        "output": "export default /* #__PURE__ */ $$proxy("<id>", "default");
       ",
       }
     `,
@@ -112,7 +112,7 @@ export { x }
         "exportNames": [
           "x",
         ],
-        "output": "export const x = $$proxy("<id>", "x");
+        "output": "export const x = /* #__PURE__ */ $$proxy("<id>", "x");
       ",
       }
     `);
@@ -128,7 +128,7 @@ export { x as y }
         "exportNames": [
           "y",
         ],
-        "output": "export const y = $$proxy("<id>", "y");
+        "output": "export const y = /* #__PURE__ */ $$proxy("<id>", "y");
       ",
       }
     `);
@@ -141,7 +141,7 @@ export { x as y }
         "exportNames": [
           "x",
         ],
-        "output": "export const x = $$proxy("<id>", "x");
+        "output": "export const x = /* #__PURE__ */ $$proxy("<id>", "x");
       ",
       }
     `);
@@ -154,7 +154,7 @@ export { x as y }
         "exportNames": [
           "y",
         ],
-        "output": "export const y = $$proxy("<id>", "y");
+        "output": "export const y = /* #__PURE__ */ $$proxy("<id>", "y");
       ",
       }
     `);

--- a/packages/transforms/src/proxy-export.test.ts
+++ b/packages/transforms/src/proxy-export.test.ts
@@ -6,6 +6,7 @@ import { transformWrapExport } from "./wrap-export";
 async function testTransform(input: string) {
   const ast = await parseAstAsync(input);
   const result = transformProxyExport(ast, {
+    code: input,
     runtime: (name) => `$$proxy("<id>", ${JSON.stringify(name)})`,
   });
   return { ...result, output: result.output.toString() };
@@ -29,11 +30,17 @@ export class Cls {};
           "AsyncFn",
           "Cls",
         ],
-        "output": "export const Arrow = /* #__PURE__ */ $$proxy("<id>", "Arrow");
+        "output": "
+      export const Arrow = /* #__PURE__ */ $$proxy("<id>", "Arrow");
+
       export default /* #__PURE__ */ $$proxy("<id>", "default");
+
       export const Fn = /* #__PURE__ */ $$proxy("<id>", "Fn");
+
       export const AsyncFn = /* #__PURE__ */ $$proxy("<id>", "AsyncFn");
+
       export const Cls = /* #__PURE__ */ $$proxy("<id>", "Cls");
+
       ",
       }
     `);
@@ -49,8 +56,10 @@ export const { x, y: [z] } = { x: 0, y: [1] };
           "x",
           "z",
         ],
-        "output": "export const x = /* #__PURE__ */ $$proxy("<id>", "x");
+        "output": "
+      export const x = /* #__PURE__ */ $$proxy("<id>", "x");
       export const z = /* #__PURE__ */ $$proxy("<id>", "z");
+
       ",
       }
     `);
@@ -111,7 +120,10 @@ export { x }
         "exportNames": [
           "x",
         ],
-        "output": "export const x = /* #__PURE__ */ $$proxy("<id>", "x");
+        "output": "
+
+      export const x = /* #__PURE__ */ $$proxy("<id>", "x");
+
       ",
       }
     `);
@@ -127,7 +139,10 @@ export { x as y }
         "exportNames": [
           "y",
         ],
-        "output": "export const y = /* #__PURE__ */ $$proxy("<id>", "y");
+        "output": "
+
+      export const y = /* #__PURE__ */ $$proxy("<id>", "y");
+
       ",
       }
     `);

--- a/packages/transforms/src/proxy-export.test.ts
+++ b/packages/transforms/src/proxy-export.test.ts
@@ -7,7 +7,7 @@ async function testTransform(input: string) {
   const ast = await parseAstAsync(input);
   const result = transformProxyExport(ast, {
     id: "<id>",
-    runtime: "$$proxy",
+    runtime: (id, name) => `$$proxy(${id}, ${name})`,
   });
   return { ...result, output: result.output.toString() };
 }

--- a/packages/transforms/src/proxy-export.test.ts
+++ b/packages/transforms/src/proxy-export.test.ts
@@ -1,6 +1,7 @@
 import { parseAstAsync } from "vite";
 import { describe, expect, test } from "vitest";
 import { transformProxyExport } from "./proxy-export";
+import { debugSourceMap } from "./test-utils";
 import { transformWrapExport } from "./wrap-export";
 
 async function testTransform(input: string) {
@@ -9,16 +10,27 @@ async function testTransform(input: string) {
     code: input,
     runtime: (name) => `$$proxy("<id>", ${JSON.stringify(name)})`,
   });
+  if (process.env["DEBUG_SOURCEMAP"]) {
+    await debugSourceMap(result.output);
+  }
   return { ...result, output: result.output.toString() };
 }
 
 describe(transformWrapExport, () => {
   test("basic", async () => {
     const input = `
-export const Arrow = () => {};
+export const Arrow = () => {
+
+};
 export default "hi";
-export function Fn() {};
-export async function AsyncFn() {};
+export function Fn() {
+};
+
+export async function AsyncFn() {
+
+
+};
+
 export class Cls {};
 `;
     expect(await testTransform(input)).toMatchInlineSnapshot(`
@@ -37,7 +49,9 @@ export class Cls {};
 
       export const Fn = /* #__PURE__ */ $$proxy("<id>", "Fn");
 
+
       export const AsyncFn = /* #__PURE__ */ $$proxy("<id>", "AsyncFn");
+
 
       export const Cls = /* #__PURE__ */ $$proxy("<id>", "Cls");
 

--- a/packages/transforms/src/proxy-export.ts
+++ b/packages/transforms/src/proxy-export.ts
@@ -7,7 +7,7 @@ export function transformDirectiveProxyExport(
   options: {
     directive: string;
     id: string;
-    runtime: string;
+    runtime: (id: string, name: string) => string;
     ignoreExportAllDeclaration?: boolean;
   },
 ) {
@@ -21,7 +21,7 @@ export function transformProxyExport(
   ast: Program,
   options: {
     id: string;
-    runtime: string;
+    runtime: (id: string, name: string) => string;
     ignoreExportAllDeclaration?: boolean;
   },
 ) {
@@ -29,12 +29,11 @@ export function transformProxyExport(
   const { exportNames } = getExportNames(ast, options);
   const output = new MagicString("");
   for (const name of exportNames) {
-    const expr = `/* #__PURE__ */ ${options.runtime}("${options.id}", "${name}")`;
-    if (name === "default") {
-      output.append(`export default ${expr};\n`);
-    } else {
-      output.append(`export const ${name} = ${expr};\n`);
-    }
+    const decl =
+      (name === "default" ? `export default` : `export const ${name} =`) +
+      ` /* #__PURE__ */ ` +
+      options.runtime(JSON.stringify(options.id), JSON.stringify(name));
+    output.append(decl + ";\n");
   }
   return { exportNames, output };
 }

--- a/packages/transforms/src/proxy-export.ts
+++ b/packages/transforms/src/proxy-export.ts
@@ -29,7 +29,7 @@ export function transformProxyExport(
   const { exportNames } = getExportNames(ast, options);
   const output = new MagicString("");
   for (const name of exportNames) {
-    const expr = `${options.runtime}("${options.id}", "${name}")`;
+    const expr = `/* #__PURE__ */ ${options.runtime}("${options.id}", "${name}")`;
     if (name === "default") {
       output.append(`export default ${expr};\n`);
     } else {

--- a/packages/transforms/src/proxy-export.ts
+++ b/packages/transforms/src/proxy-export.ts
@@ -1,6 +1,8 @@
-import type { Program } from "estree";
+import { tinyassert } from "@hiogawa/utils";
+import type { Node, Program } from "estree";
 import MagicString from "magic-string";
-import { getExportNames, hasDirective } from "./utils";
+import { extract_names } from "periscopic";
+import { hasDirective } from "./utils";
 
 export function transformDirectiveProxyExport(
   ast: Program,
@@ -25,15 +27,81 @@ export function transformProxyExport(
     ignoreExportAllDeclaration?: boolean;
   },
 ) {
-  // TODO: preserve `export` location
-  const { exportNames } = getExportNames(ast, options);
-  const output = new MagicString("");
-  for (const name of exportNames) {
-    const decl =
-      (name === "default" ? `export default` : `export const ${name} =`) +
-      ` /* #__PURE__ */ ` +
-      options.runtime(name);
-    output.append(decl + ";\n");
+  const output = new MagicString(options.code ?? " ".repeat(ast.end));
+  const exportNames: string[] = [];
+
+  function createExport(node: Node, names: string[]) {
+    exportNames.push(...names);
+    const newCode = names
+      .map(
+        (name) =>
+          (name === "default" ? `export default` : `export const ${name} =`) +
+          ` /* #__PURE__ */ ${options.runtime(name)};\n`,
+      )
+      .join("");
+    output.update(node.start, node.end, newCode);
   }
+
+  for (const node of ast.body) {
+    if (node.type === "ExportNamedDeclaration") {
+      if (node.declaration) {
+        if (
+          node.declaration.type === "FunctionDeclaration" ||
+          node.declaration.type === "ClassDeclaration"
+        ) {
+          /**
+           * export function foo() {}
+           */
+          createExport(node, [node.declaration.id.name]);
+        } else if (node.declaration.type === "VariableDeclaration") {
+          /**
+           * export const foo = 1, bar = 2
+           */
+          const names = node.declaration.declarations.flatMap((decl) =>
+            extract_names(decl.id),
+          );
+          createExport(node, names);
+        } else {
+          node.declaration satisfies never;
+        }
+      } else {
+        /**
+         * export { foo, bar as car } from './foo'
+         * export { foo, bar as car }
+         */
+        const names: string[] = [];
+        for (const spec of node.specifiers) {
+          tinyassert(spec.exported.type === "Identifier");
+          names.push(spec.exported.name);
+        }
+        createExport(node, names);
+      }
+      continue;
+    }
+
+    /**
+     * export * from './foo'
+     */
+    if (
+      !options.ignoreExportAllDeclaration &&
+      node.type === "ExportAllDeclaration"
+    ) {
+      throw new Error("unsupported ExportAllDeclaration");
+    }
+
+    /**
+     * export default function foo() {}
+     * export default class Foo {}
+     * export default () => {}
+     */
+    if (node.type === "ExportDefaultDeclaration") {
+      createExport(node, ["default"]);
+      continue;
+    }
+
+    // remove all other nodes
+    output.remove(node.start, node.end);
+  }
+
   return { exportNames, output };
 }

--- a/packages/transforms/src/proxy-export.ts
+++ b/packages/transforms/src/proxy-export.ts
@@ -6,8 +6,8 @@ export function transformDirectiveProxyExport(
   ast: Program,
   options: {
     directive: string;
-    id: string;
-    runtime: (id: string, name: string) => string;
+    code?: string;
+    runtime: (name: string) => string;
     ignoreExportAllDeclaration?: boolean;
   },
 ) {
@@ -20,19 +20,19 @@ export function transformDirectiveProxyExport(
 export function transformProxyExport(
   ast: Program,
   options: {
-    id: string;
-    runtime: (id: string, name: string) => string;
+    code?: string;
+    runtime: (name: string) => string;
     ignoreExportAllDeclaration?: boolean;
   },
 ) {
-  // TODO: preserve `name` location
+  // TODO: preserve `export` location
   const { exportNames } = getExportNames(ast, options);
   const output = new MagicString("");
   for (const name of exportNames) {
     const decl =
       (name === "default" ? `export default` : `export const ${name} =`) +
       ` /* #__PURE__ */ ` +
-      options.runtime(JSON.stringify(options.id), JSON.stringify(name));
+      options.runtime(name);
     output.append(decl + ";\n");
   }
   return { exportNames, output };


### PR DESCRIPTION
- Part of https://github.com/hi-ogawa/vite-plugins/issues/780
- Supersedes https://github.com/hi-ogawa/vite-plugins/pull/783

_todo_

- [x] generalize "runtime" wrapper
- [x] tweak `createServerReference` with multiple arguments
- [x] handle `environmentName=client` in `findSourceMapURL`
- [x] generate source map for proxy export transform
- [x] test (verify manually on react dev tools)

_examples_

https://github.com/user-attachments/assets/fd7d63d6-3a43-4fa3-89a7-be40774e49fe


