### PR TITLE
fix(transforms): disallow non async function for "use server"

### DIFF
--- a/packages/react-server/examples/basic/src/routes/test/action/_action.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/action/_action.tsx
@@ -4,18 +4,18 @@ import { sleep, tinyassert } from "@hiogawa/utils";
 
 let counter = 0;
 
-export function getCounter() {
+export async function getCounter() {
   return counter;
 }
 
-export function changeCounter(formData: FormData) {
+export async function changeCounter(formData: FormData) {
   counter += Number(formData.get("delta"));
 }
 
 let messageId = 1;
 let messages: { id: number; data: string }[] = [];
 
-export let getMessages = () => {
+export let getMessages = async () => {
   return messages;
 };
 
@@ -26,7 +26,7 @@ export const addMessage = async (formData: FormData) => {
   messages.push({ id: messageId++, data: message });
 };
 
-export function clearMessages() {
+export async function clearMessages() {
   messageId = 1;
   messages = [];
 }
@@ -53,7 +53,7 @@ export async function actionCheckAnswer(
 
 let actionBindResult = "(none)";
 
-export function getActionBindResult() {
+export async function getActionBindResult() {
   return actionBindResult;
 }
 

--- a/packages/react-server/examples/basic/src/routes/test/action/_client.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/action/_client.tsx
@@ -14,7 +14,9 @@ import {
 } from "./_action";
 import { actionReturnComponent } from "./_action2";
 
-export function Chat(props: { messages: ReturnType<typeof getMessages> }) {
+export function Chat(props: {
+  messages: Awaited<ReturnType<typeof getMessages>>;
+}) {
   // cf. https://react.dev/reference/react/useOptimistic#optimistically-updating-with-forms
   const [optMessages, addOptMessage] = React.useOptimistic(
     props.messages,

--- a/packages/react-server/examples/basic/src/routes/test/action/extra/_action.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/action/extra/_action.tsx
@@ -1,7 +1,11 @@
 "use server";
 
-export let count1 = 0;
+let count1 = 0;
 
-export function changeCount1(formData: FormData) {
+export async function getCount1() {
+  return count1;
+}
+
+export async function changeCount1(formData: FormData) {
   count1 += Number(formData.get("value"));
 }

--- a/packages/react-server/examples/basic/src/routes/test/action/extra/_action2.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/action/extra/_action2.tsx
@@ -4,7 +4,7 @@
 
 let count3 = 0;
 
-export function changeCount3(_value: unknown, formData: FormData) {
+export async function changeCount3(_value: unknown, formData: FormData) {
   count3 += Number(formData.get("value"));
   return count3;
 }

--- a/packages/react-server/examples/basic/src/routes/test/action/extra/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/action/extra/page.tsx
@@ -124,7 +124,7 @@ function Counter5() {
     <form
       className="flex items-center gap-2"
       data-testid="counter5"
-      action={(formData: FormData) => {
+      action={async (formData: FormData) => {
         "use server";
         count5 += Number(formData.get(name));
       }}

--- a/packages/react-server/examples/basic/src/routes/test/action/extra/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/action/extra/page.tsx
@@ -1,4 +1,4 @@
-import { changeCount1, count1 } from "./_action";
+import { changeCount1, getCount1 } from "./_action";
 import { Counter3 } from "./_client";
 
 export default function Page() {
@@ -26,7 +26,7 @@ export default function Page() {
           >
             +1
           </button>
-          <div>Count: {count1}</div>
+          <div>Count: {getCount1()}</div>
         </form>
       </div>
       <div className="border-t"></div>

--- a/packages/react-server/examples/basic/src/routes/test/action/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/action/page.tsx
@@ -21,7 +21,7 @@ export default async function Page() {
       <div className="flex flex-col gap-2">
         <Counter />
       </div>
-      <Chat messages={getMessages()} />
+      <Chat messages={await getMessages()} />
       <ActionDataTest />
       <NonFormActionTest />
       <div className="flex flex-col gap-2">

--- a/packages/react-server/examples/basic/src/routes/test/cache/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/cache/page.tsx
@@ -13,7 +13,7 @@ export default async function Page() {
   return (
     <div className="flex flex-col gap-2">
       <form
-        action={() => {
+        action={async () => {
           "use server";
           state = -1;
         }}

--- a/packages/react-server/examples/basic/src/routes/test/revalidate/[id]/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/revalidate/[id]/page.tsx
@@ -7,7 +7,7 @@ export default function Page(props: PageProps) {
     <div className="flex flex-col gap-2">
       <pre>params = {JSON.stringify(props.params)}</pre>
       <form
-        action={() => {
+        action={async () => {
           "use server";
           revalidatePath("/test/revalidate");
         }}

--- a/packages/react-server/examples/basic/src/routes/test/revalidate/redirect/page.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/revalidate/redirect/page.tsx
@@ -4,7 +4,7 @@ export default function Page() {
   return (
     <div>
       <form
-        action={() => {
+        action={async () => {
           "use server";
           revalidatePath("/test/revalidate");
           throw redirect("/test/revalidate");

--- a/packages/react-server/examples/basic/src/routes/test/session/_action.tsx
+++ b/packages/react-server/examples/basic/src/routes/test/session/_action.tsx
@@ -20,7 +20,7 @@ export async function signout() {
 
 let counter = 0;
 
-export function getCounter() {
+export async function getCounter() {
   return counter;
 }
 

--- a/packages/react-server/examples/minimal/app/_action.tsx
+++ b/packages/react-server/examples/minimal/app/_action.tsx
@@ -6,6 +6,6 @@ export async function changeCount() {
   count++;
 }
 
-export function getCount() {
+export async function getCount() {
   return count;
 }

--- a/packages/react-server/examples/next/app/actions/server/page.tsx
+++ b/packages/react-server/examples/next/app/actions/server/page.tsx
@@ -31,7 +31,7 @@ export default function Page() {
       <form>
         <button
           id="redirect-pages"
-          formAction={() => {
+          formAction={async () => {
             "use server";
             redirect("/");
           }}

--- a/packages/react-server/examples/postcss-tailwind/app/page.tsx
+++ b/packages/react-server/examples/postcss-tailwind/app/page.tsx
@@ -14,7 +14,7 @@ let serverCount = 0;
 function TestServer() {
   return (
     <form
-      action={() => {
+      action={async () => {
         "use server";
         serverCount += 1;
       }}

--- a/packages/react-server/src/features/server-action/plugin.tsx
+++ b/packages/react-server/src/features/server-action/plugin.tsx
@@ -109,9 +109,7 @@ export function vitePluginServerUseServer({
       const ast = await parseAstAsync(code);
       const { output } = transformServerActionServer(code, ast, {
         runtime: (value, name) =>
-          `(() => (typeof ${value} === "function"` +
-          ` ? $$ReactServer.registerServerReference(${value}, ${JSON.stringify(serverId)}, ${JSON.stringify(name)})` +
-          ` : ${value}))()`,
+          `$$ReactServer.registerServerReference(${value}, ${JSON.stringify(serverId)}, ${JSON.stringify(name)})`,
         rejectNonAsyncFunction: true,
       });
       if (output.hasChanged()) {

--- a/packages/react-server/src/features/server-action/plugin.tsx
+++ b/packages/react-server/src/features/server-action/plugin.tsx
@@ -54,6 +54,7 @@ export function vitePluginClientUseServer({
           `$$ReactClient.findSourceMapURL, ` +
           `${JSON.stringify(name)})`,
         ignoreExportAllDeclaration: true,
+        rejectNonAsyncFunction: true,
       });
       const output = result?.output;
       if (!output) {
@@ -111,6 +112,7 @@ export function vitePluginServerUseServer({
           `(() => (typeof ${value} === "function"` +
           ` ? $$ReactServer.registerServerReference(${value}, ${JSON.stringify(serverId)}, ${JSON.stringify(name)})` +
           ` : ${value}))()`,
+        rejectNonAsyncFunction: true,
       });
       if (output.hasChanged()) {
         manager.serverReferenceMap.set(id, serverId);

--- a/packages/rsc/examples/basic/src/routes/action-from-client/action.tsx
+++ b/packages/rsc/examples/basic/src/routes/action-from-client/action.tsx
@@ -2,7 +2,7 @@
 
 // test findSourceMapURL for server action imported from client
 
-export function NotThis() {
+export async function NotThis() {
   //
   //
   //

--- a/packages/rsc/examples/basic/src/routes/action-from-client/action.tsx
+++ b/packages/rsc/examples/basic/src/routes/action-from-client/action.tsx
@@ -2,22 +2,22 @@
 
 // test findSourceMapURL for server action imported from client
 
-export async function NotThis() {
+export async function notThis() {
   //
   //
   //
-  NotThis2();
+  notThis2();
 }
 
-export async function TestAction() {
+export async function testAction() {
   console.log("[test-action-from-client]");
 }
 
-function NotThis2() {
+function notThis2() {
   //
   //
 }
 
-export async function TestAction2() {
+export async function testAction2() {
   console.log("[test-action-from-client-2]");
 }

--- a/packages/rsc/examples/basic/src/routes/action-from-client/client.tsx
+++ b/packages/rsc/examples/basic/src/routes/action-from-client/client.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { TestAction, TestAction2 } from "./action";
+import { testAction, testAction2 } from "./action";
 
 export function TestActionFromClient() {
   return (
-    <form action={TestAction}>
+    <form action={testAction}>
       <button>test-action-from-client</button>
-      <button formAction={TestAction2}>test-action-from-client-2</button>
+      <button formAction={testAction2}>test-action-from-client-2</button>
     </form>
   );
 }

--- a/packages/rsc/examples/basic/src/routes/action.tsx
+++ b/packages/rsc/examples/basic/src/routes/action.tsx
@@ -1,6 +1,10 @@
 "use server";
 
-export let serverCounter = 0;
+let serverCounter = 0;
+
+export async function getServerCounter(): Promise<number> {
+  return serverCounter;
+}
 
 export async function changeServerCounter(formData: FormData): Promise<void> {
   const TEST_UPDATE = 1;

--- a/packages/rsc/examples/basic/src/routes/root.tsx
+++ b/packages/rsc/examples/basic/src/routes/root.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import {
   changeServerCounter,
+  getServerCounter,
   resetServerCounter,
-  serverCounter,
 } from "./action";
 import { TestActionFromClient } from "./action-from-client/client";
 import {
@@ -29,7 +29,7 @@ export function Root(props: { url: URL }) {
         <ClientCounter />
         <form action={changeServerCounter}>
           <input type="hidden" name="change" value="1" />
-          <button>Server Counter: {serverCounter}</button>
+          <button>Server Counter: {getServerCounter()}</button>
           <button formAction={resetServerCounter}>Server Reset</button>
         </form>
         <TestStyleClient />

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -577,6 +577,7 @@ function vitePluginUseServer(): Plugin[] {
               `(() => (typeof ${value} === "function"` +
               ` ? $$ReactServer.registerServerReference(${value}, ${JSON.stringify(normalizedId)}, ${JSON.stringify(name)})` +
               ` : ${value}))()`,
+            rejectNonAsyncFunction: true,
           });
           if (!output.hasChanged()) return;
           serverReferences[normalizedId] = id;
@@ -596,6 +597,7 @@ function vitePluginUseServer(): Plugin[] {
               `$$ReactClient.findSourceMapURL, ` +
               `${JSON.stringify(name)})`,
             directive: "use server",
+            rejectNonAsyncFunction: true,
           });
           const output = result?.output;
           if (!output?.hasChanged()) return;

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -574,9 +574,7 @@ function vitePluginUseServer(): Plugin[] {
         if (this.environment.name === "rsc") {
           const { output } = transformServerActionServer(code, ast, {
             runtime: (value, name) =>
-              `(() => (typeof ${value} === "function"` +
-              ` ? $$ReactServer.registerServerReference(${value}, ${JSON.stringify(normalizedId)}, ${JSON.stringify(name)})` +
-              ` : ${value}))()`,
+              `$$ReactServer.registerServerReference(${value}, ${JSON.stringify(normalizedId)}, ${JSON.stringify(name)})`,
             rejectNonAsyncFunction: true,
           });
           if (!output.hasChanged()) return;

--- a/packages/transforms/src/hoist.ts
+++ b/packages/transforms/src/hoist.ts
@@ -35,7 +35,6 @@ export function transformHoistInlineDirective(
           throw Object.assign(
             new Error(`"${directive}" doesn't allow non async function`),
             {
-              // metadata for rollup error handling
               pos: node.start,
             },
           );

--- a/packages/transforms/src/hoist.ts
+++ b/packages/transforms/src/hoist.ts
@@ -11,9 +11,11 @@ export function transformHoistInlineDirective(
   {
     runtime,
     directive,
+    rejectNonAsyncFunction,
   }: {
     runtime: (value: string, name: string) => string;
     directive: string;
+    rejectNonAsyncFunction?: boolean;
   },
 ) {
   const output = new MagicString(input);
@@ -29,6 +31,16 @@ export function transformHoistInlineDirective(
         node.body.type === "BlockStatement" &&
         hasDirective(node.body.body, directive)
       ) {
+        if (!node.async && rejectNonAsyncFunction) {
+          throw Object.assign(
+            new Error(`"${directive}" doesn't allow non async function`),
+            {
+              // metadata for rollup error handling
+              pos: node.start,
+            },
+          );
+        }
+
         const scope = analyzed.map.get(node);
         tinyassert(scope);
         const declName = node.type === "FunctionDeclaration" && node.id.name;

--- a/packages/transforms/src/proxy-export.ts
+++ b/packages/transforms/src/proxy-export.ts
@@ -44,6 +44,14 @@ export function transformProxyExport(
     output.update(node.start, node.end, newCode);
   }
 
+  function validateNonAsyncFunction(node: Node, ok?: boolean) {
+    if (options.rejectNonAsyncFunction && !ok) {
+      throw Object.assign(new Error(`unsupported non async function`), {
+        pos: node.start,
+      });
+    }
+  }
+
   for (const node of ast.body) {
     if (node.type === "ExportNamedDeclaration") {
       if (node.declaration) {
@@ -54,11 +62,24 @@ export function transformProxyExport(
           /**
            * export function foo() {}
            */
+          validateNonAsyncFunction(
+            node,
+            node.declaration.type === "FunctionDeclaration" &&
+              node.declaration.async,
+          );
           createExport(node, [node.declaration.id.name]);
         } else if (node.declaration.type === "VariableDeclaration") {
           /**
            * export const foo = 1, bar = 2
            */
+          validateNonAsyncFunction(
+            node,
+            node.declaration.declarations.every(
+              (decl) =>
+                decl.init?.type === "ArrowFunctionExpression" &&
+                decl.init.async,
+            ),
+          );
           const names = node.declaration.declarations.flatMap((decl) =>
             extract_names(decl.id),
           );
@@ -97,6 +118,11 @@ export function transformProxyExport(
      * export default () => {}
      */
     if (node.type === "ExportDefaultDeclaration") {
+      validateNonAsyncFunction(
+        node,
+        node.declaration.type === "FunctionDeclaration" &&
+          node.declaration.async,
+      );
       createExport(node, ["default"]);
       continue;
     }

--- a/packages/transforms/src/proxy-export.ts
+++ b/packages/transforms/src/proxy-export.ts
@@ -11,6 +11,7 @@ export function transformDirectiveProxyExport(
     code?: string;
     runtime: (name: string) => string;
     ignoreExportAllDeclaration?: boolean;
+    rejectNonAsyncFunction?: boolean;
   },
 ) {
   if (!hasDirective(ast.body, options.directive)) {
@@ -25,6 +26,7 @@ export function transformProxyExport(
     code?: string;
     runtime: (name: string) => string;
     ignoreExportAllDeclaration?: boolean;
+    rejectNonAsyncFunction?: boolean;
   },
 ) {
   const output = new MagicString(options.code ?? " ".repeat(ast.end));

--- a/packages/transforms/src/proxy-export.ts
+++ b/packages/transforms/src/proxy-export.ts
@@ -120,8 +120,9 @@ export function transformProxyExport(
     if (node.type === "ExportDefaultDeclaration") {
       validateNonAsyncFunction(
         node,
-        node.declaration.type === "FunctionDeclaration" &&
-          node.declaration.async,
+        node.declaration.type === "Identifier" ||
+          (node.declaration.type === "FunctionDeclaration" &&
+            node.declaration.async),
       );
       createExport(node, ["default"]);
       continue;

--- a/packages/transforms/src/server-action.ts
+++ b/packages/transforms/src/server-action.ts
@@ -3,6 +3,9 @@ import { transformHoistInlineDirective } from "./hoist";
 import { hasDirective } from "./utils";
 import { transformWrapExport } from "./wrap-export";
 
+// TODO
+// source map for `options.runtime` (registerServerReference) call
+// needs to match original position.
 export function transformServerActionServer(
   input: string,
   ast: Program,

--- a/packages/transforms/src/server-action.ts
+++ b/packages/transforms/src/server-action.ts
@@ -6,7 +6,10 @@ import { transformWrapExport } from "./wrap-export";
 export function transformServerActionServer(
   input: string,
   ast: Program,
-  options: { runtime: (value: string, name: string) => string },
+  options: {
+    runtime: (value: string, name: string) => string;
+    rejectNonAsyncFunction?: boolean;
+  },
 ) {
   // TODO: unify
   if (hasDirective(ast.body, "use server")) {

--- a/packages/transforms/src/wrap-export.ts
+++ b/packages/transforms/src/wrap-export.ts
@@ -9,6 +9,7 @@ export function transformWrapExport(
   options: {
     runtime: (value: string, name: string) => string;
     ignoreExportAllDeclaration?: boolean;
+    rejectNonAsyncFunction?: boolean;
   },
 ) {
   const output = new MagicString(input);
@@ -105,7 +106,9 @@ export function transformWrapExport(
       !options.ignoreExportAllDeclaration &&
       node.type === "ExportAllDeclaration"
     ) {
-      throw new Error("unsupported ExportAllDeclaration");
+      throw Object.assign(new Error("unsupported ExportAllDeclaration"), {
+        pos: node.start,
+      });
     }
 
     /**

--- a/packages/transforms/src/wrap-export.ts
+++ b/packages/transforms/src/wrap-export.ts
@@ -140,8 +140,11 @@ export function transformWrapExport(
     if (node.type === "ExportDefaultDeclaration") {
       validateNonAsyncFunction(
         node,
-        node.declaration.type === "FunctionDeclaration" &&
-          node.declaration.async,
+        // TODO: somehow identifier is allowed in next.js?
+        // (see packages/react-server/examples/next/app/actions/server/actions.ts)
+        node.declaration.type === "Identifier" ||
+          (node.declaration.type === "FunctionDeclaration" &&
+            node.declaration.async),
       );
       let localName: string;
       if (


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/vite-plugins/issues/788
- also part of https://github.com/hi-ogawa/vite-plugins/issues/780 to unwrap `registerServerReference` calls

## example

Unfortunately, the code frame cannot show original tsx file since we rely on esbuild to transpile that already.

```
12:10:26 PM [vite] Internal server error: "use server" doesn't allow non async function
  Plugin: rsc:use-server
  File: /home/hiroshi/code/personal/vite-plugins/packages/rsc/examples/basic/src/routes/root.tsx:40:19
  100|          TestTemporaryReference,
  101|          {
  102|            action: (node) => {
     |                    ^
  103|              "use server";
  104|              return /* @__PURE__ */ jsxDEV("span", { children: [
```
