### PR TITLE
fix(transforms): fix source map of `registerServerReference` calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist
 *.tgz
 test-results
 *.tsbuildinfo
+.debug

--- a/packages/transforms/src/server-action.ts
+++ b/packages/transforms/src/server-action.ts
@@ -14,7 +14,7 @@ export function transformServerActionServer(
     rejectNonAsyncFunction?: boolean;
   },
 ) {
-  // TODO: unify
+  // TODO: unify (generalize transformHoistInlineDirective to support top leve directive case)
   if (hasDirective(ast.body, "use server")) {
     return transformWrapExport(input, ast, options);
   }

--- a/packages/transforms/src/wrap-export.test.ts
+++ b/packages/transforms/src/wrap-export.test.ts
@@ -1,5 +1,6 @@
 import { parseAstAsync } from "vite";
 import { describe, expect, test } from "vitest";
+import { debugSourceMap } from "./test-utils";
 import { transformWrapExport } from "./wrap-export";
 
 async function testTransform(input: string) {
@@ -9,6 +10,9 @@ async function testTransform(input: string) {
       `$$wrap(${value}, "<id>", ${JSON.stringify(name)})`,
     ignoreExportAllDeclaration: true,
   });
+  if (process.env["DEBUG_SOURCEMAP"]) {
+    await debugSourceMap(output);
+  }
   return output.hasChanged() && output.toString();
 }
 
@@ -28,17 +32,17 @@ export class Cls {};
       function Fn() {};
       async function AsyncFn() {};
       class Cls {};
-      ;
-      Arrow = /* #__PURE__ */ $$wrap(Arrow, "<id>", "Arrow");
-      export { Arrow };
-      const $$wrap_$$default = /* #__PURE__ */ $$wrap($$default, "<id>", "default");
-      export { $$wrap_$$default as default };
       Fn = /* #__PURE__ */ $$wrap(Fn, "<id>", "Fn");
       export { Fn };
       AsyncFn = /* #__PURE__ */ $$wrap(AsyncFn, "<id>", "AsyncFn");
       export { AsyncFn };
       Cls = /* #__PURE__ */ $$wrap(Cls, "<id>", "Cls");
       export { Cls };
+      ;
+      Arrow = /* #__PURE__ */ $$wrap(Arrow, "<id>", "Arrow");
+      export { Arrow };
+      const $$wrap_$$default = /* #__PURE__ */ $$wrap($$default, "<id>", "default");
+      export { $$wrap_$$default as default };
       "
     `);
   });
@@ -56,11 +60,11 @@ export function changeCount() {
       function changeCount() {
         count += 1;
       }
+      changeCount = /* #__PURE__ */ $$wrap(changeCount, "<id>", "changeCount");
+      export { changeCount };
       ;
       count = /* #__PURE__ */ $$wrap(count, "<id>", "count");
       export { count };
-      changeCount = /* #__PURE__ */ $$wrap(changeCount, "<id>", "changeCount");
-      export { changeCount };
       "
     `);
   });

--- a/packages/transforms/src/wrap-export.test.ts
+++ b/packages/transforms/src/wrap-export.test.ts
@@ -32,6 +32,8 @@ export class Cls {};
       function Fn() {};
       async function AsyncFn() {};
       class Cls {};
+      Arrow = /* #__PURE__ */ $$wrap(Arrow, "<id>", "Arrow");
+      export { Arrow };
       Fn = /* #__PURE__ */ $$wrap(Fn, "<id>", "Fn");
       export { Fn };
       AsyncFn = /* #__PURE__ */ $$wrap(AsyncFn, "<id>", "AsyncFn");
@@ -39,8 +41,6 @@ export class Cls {};
       Cls = /* #__PURE__ */ $$wrap(Cls, "<id>", "Cls");
       export { Cls };
       ;
-      Arrow = /* #__PURE__ */ $$wrap(Arrow, "<id>", "Arrow");
-      export { Arrow };
       const $$wrap_$$default = /* #__PURE__ */ $$wrap($$default, "<id>", "default");
       export { $$wrap_$$default as default };
       "
@@ -60,11 +60,10 @@ export function changeCount() {
       function changeCount() {
         count += 1;
       }
-      changeCount = /* #__PURE__ */ $$wrap(changeCount, "<id>", "changeCount");
-      export { changeCount };
-      ;
       count = /* #__PURE__ */ $$wrap(count, "<id>", "count");
       export { count };
+      changeCount = /* #__PURE__ */ $$wrap(changeCount, "<id>", "changeCount");
+      export { changeCount };
       "
     `);
   });
@@ -76,7 +75,6 @@ export const { x, y: [z] } = { x: 0, y: [1] };
     expect(await testTransform(input)).toMatchInlineSnapshot(`
       "
       let { x, y: [z] } = { x: 0, y: [1] };
-      ;
       x = /* #__PURE__ */ $$wrap(x, "<id>", "x");
       export { x };
       z = /* #__PURE__ */ $$wrap(z, "<id>", "z");


### PR DESCRIPTION
Part of https://github.com/hi-ogawa/vite-plugins/issues/780

A bit of trick and I can still preserve positions for `registerServerReference`, but it feels this is getting to the limit of `MagicString` approach.

~It looks like "hoist" approach is more robust, so maybe we should just use that instead (after unifying two?)~ I think it's fine for now. Let's land this.