### PR TITLE
refactor(react-server): simplify ssr client reference import

### DIFF
--- a/packages/react-server/src/features/client-component/ssr.tsx
+++ b/packages/react-server/src/features/client-component/ssr.tsx
@@ -6,9 +6,6 @@ const debug = createDebug("react-server:ssr-import");
 async function ssrImport(id: string) {
   debug("[__webpack_require__]", { id });
   if (import.meta.env.DEV) {
-    // strip off `?t=` added for browser by noramlizeClientReferenceId
-    id = id.split("?t=")[0]!;
-    // transformed to "ssrLoadModule" during dev
     return import(/* @vite-ignore */ id);
   } else {
     const clientReferences = await import(


### PR DESCRIPTION
I don't remember why exactly we needed to strip it (cf. https://github.com/hi-ogawa/vite-plugins/pull/316). This is probably fixed after switching to module runner.