### PR TITLE
fix(rsc): fix base for findSourceMapURL

### DIFF
--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -816,7 +816,7 @@ export async function findSourceMapURL(
     // and let browser devtools handle the mapping.
     // https://github.com/facebook/react/blob/4a36d3eab7d9bbbfae62699989aa95e5a0297c16/packages/react-server/src/ReactFlightStackConfigV8.js#L15-L20
     // This means it has additional +2 line offset due to Vite's module runner
-    // function wrapper. We need correct it just like Vite module runner.
+    // function wrapper. We need to correct it just like Vite module runner.
     // https://github.com/vitejs/vite/blob/d94e7b25564abb81ab7b921d4cd44d0f0d22fec4/packages/vite/src/shared/utils.ts#L58-L69
     // https://github.com/vitejs/vite/blob/d94e7b25564abb81ab7b921d4cd44d0f0d22fec4/packages/vite/src/node/ssr/fetchModule.ts#L142-L146
     map = mod?.transformResult?.map;
@@ -828,6 +828,8 @@ export async function findSourceMapURL(
   // `createServerReference(... findSourceMapURL ...)` called on browser
   if (environmentName === "Client") {
     try {
+      // TODO: base?
+      server.config.base;
       const url = new URL(filename).pathname;
       mod = server.environments.client.moduleGraph.urlToModuleMap.get(url);
       map = mod?.transformResult?.map;

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -825,19 +825,19 @@ export async function findSourceMapURL(
     }
   }
 
+  const base = server.config.base.slice(0, -1);
+
   // `createServerReference(... findSourceMapURL ...)` called on browser
   if (environmentName === "Client") {
     try {
-      // TODO: base?
-      server.config.base;
-      const url = new URL(filename).pathname;
+      const url = new URL(filename).pathname.slice(base.length);
       mod = server.environments.client.moduleGraph.urlToModuleMap.get(url);
       map = mod?.transformResult?.map;
     } catch (e) {}
   }
 
   if (mod && map) {
-    // fix sources to match Vite module url
-    return { ...map, sources: [mod.url] };
+    // fix sources to match Vite's module url on browser
+    return { ...map, sources: [base + mod.url] };
   }
 }


### PR DESCRIPTION
Vite's module url is the one without `base`, so we probably need to take that into account.