### PR TITLE
feat(rsc): support nonce

### DIFF
--- a/packages/rsc/examples/basic/src/routes/client.tsx
+++ b/packages/rsc/examples/basic/src/routes/client.tsx
@@ -35,7 +35,7 @@ export function TestTemporaryReference(props: {
   const [result, setResult] = React.useState<React.ReactNode>("(none)");
 
   return (
-    <div style={{ display: "flex" }}>
+    <div className="flex">
       <form
         action={async () => {
           setResult(await props.action(<span>[client]</span>));

--- a/packages/rsc/examples/basic/src/server.tsx
+++ b/packages/rsc/examples/basic/src/server.tsx
@@ -5,5 +5,16 @@ import { Root } from "./routes/root";
 export default async function handler(request: Request): Promise<Response> {
   const url = new URL(request.url);
   const root = <Root url={url} />;
-  return renderRequest(request, root);
+  const nonce = !process.env.NO_CSP ? crypto.randomUUID() : undefined;
+  const response = await renderRequest(request, root, { nonce });
+  if (nonce) {
+    response.headers.set(
+      "content-security-policy",
+      `default-src 'self'; ` +
+        // `unsafe-eval` is required during dev since React uses eval for findSourceMapURL feature
+        `script-src 'self' 'nonce-${nonce}' ${import.meta.env.DEV ? `'unsafe-eval'` : ``} ; ` +
+        `style-src 'self' 'nonce-${nonce}'; `,
+    );
+  }
+  return response;
 }

--- a/packages/rsc/src/extra/rsc.tsx
+++ b/packages/rsc/src/extra/rsc.tsx
@@ -20,13 +20,14 @@ export type RscPayload = {
 export async function renderRequest(
   request: Request,
   root: React.ReactNode,
+  options?: { nonce?: string },
 ): Promise<Response> {
   initialize();
 
   function RscRoot() {
     return (
       <>
-        <Resources />
+        <Resources nonce={options?.nonce} />
         {root}
       </>
     );
@@ -80,5 +81,5 @@ export async function renderRequest(
   }
 
   const ssrEntry = await importSsr<typeof import("./ssr")>();
-  return ssrEntry.renderHtml({ stream, formState });
+  return ssrEntry.renderHtml({ stream, formState, options });
 }

--- a/packages/rsc/src/rsc.tsx
+++ b/packages/rsc/src/rsc.tsx
@@ -63,10 +63,14 @@ export async function Resources({
   const jsLinks = js.map((href) => (
     <link key={href} rel="modulepreload" href={withBase(href)} nonce={nonce} />
   ));
+  // https://vite.dev/guide/features.html#content-security-policy-csp
+  // this isn't needed if `style-src: 'unsafe-inline'` (dev) and `script-src: 'self'`
+  const viteCspNonce = nonce && <meta property="csp-nonce" nonce={nonce} />;
   return (
     <>
       {cssLinks}
       {jsLinks}
+      {viteCspNonce}
     </>
   );
 }


### PR DESCRIPTION
~This one will come up when officially doing "prepare destination", so let's test the idea here.~

~On top of `react-server-dom-webpack`, this can be also supported via "reference id" encoding hack. For `react-server-dom-vite`, we can probably extend `ModuleLoading` to pass chunks map (instead of actually embedding chunks in reference metadata).~

Actually we don't need nonce for prepare destination since that's normally covered by `script-src: 'self'`.