### PR TITLE
chore(deps): update react-router for ssr modulepreload

### DIFF
--- a/packages/rsc/examples/react-router/package.json
+++ b/packages/rsc/examples/react-router/package.json
@@ -14,7 +14,7 @@
     "@hiogawa/vite-rsc": "latest",
     "react": "latest",
     "react-dom": "latest",
-    "react-router": "0.0.0-experimental-3b3f4b74e",
+    "react-router": "0.0.0-experimental-a6d1d1d4e",
     "react-server-dom-webpack": "latest"
   },
   "devDependencies": {

--- a/packages/rsc/examples/react-router/src/entry.ssr.tsx
+++ b/packages/rsc/examples/react-router/src/entry.ssr.tsx
@@ -25,10 +25,10 @@ export default async function handler(
     request,
     callServer,
     (body) => createFromReadableStream(body),
-    (payload) =>
+    (getPayload) =>
       ReactDomServer.renderToReadableStream(
         <>
-          <RSCStaticRouter payload={payload} />
+          <RSCStaticRouter getPayload={getPayload} />
           {css}
           {js}
         </>,

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -513,7 +513,7 @@ function vitePluginUseClient({
           ) {
             const resolved = await this.resolve(source, importer, options);
             if (resolved) {
-              clientPackageMeta[resolved.id] = {
+              clientPackageMeta[resolved.id] ??= {
                 source,
                 exportNames: [],
                 renderedExports: [],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -669,8 +669,8 @@ importers:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
       react-router:
-        specifier: 0.0.0-experimental-3b3f4b74e
-        version: 0.0.0-experimental-3b3f4b74e(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 0.0.0-experimental-a6d1d1d4e
+        version: 0.0.0-experimental-a6d1d1d4e(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-server-dom-webpack:
         specifier: ^19.1.0
         version: 19.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(webpack@5.93.0(@swc/core@1.11.21)(esbuild@0.24.2))
@@ -5265,8 +5265,8 @@ packages:
       react: ^19.1.0
       react-dom: ^19.1.0
 
-  react-router@0.0.0-experimental-3b3f4b74e:
-    resolution: {integrity: sha512-skeblUYvhRDdjv9m41XzEB+bV86SVoUBYt2aZRMo5oSQDu72gV2ZA2urJoSD6MsLGTSDu8KCSejvOWrISbzfbw==}
+  react-router@0.0.0-experimental-a6d1d1d4e:
+    resolution: {integrity: sha512-4sDd8+wpgLeODHQstOS8VzDRKsG6NpSQwk5lmAu4euirivJekBFOUf+mEAH8kSdonaSWZ69/4X6caADkd31QoQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: ^19.1.0
@@ -10750,7 +10750,7 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
       react-router: 6.29.0(react@19.1.0)
 
-  react-router@0.0.0-experimental-3b3f4b74e(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  react-router@0.0.0-experimental-a6d1d1d4e(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       cookie: 1.0.2
       react: 19.1.0


### PR DESCRIPTION
- (supersedes) Closes https://github.com/hi-ogawa/vite-plugins/pull/765
- related https://github.com/remix-run/react-router/pull/13467

```sh
pnpm -C packages/rsc/examples/react-router build
pnpm -C packages/rsc/examples/react-router preview
```

Before

![image](https://github.com/user-attachments/assets/66d077c4-7b35-44cc-a871-00c7477b7a47)

After

![image](https://github.com/user-attachments/assets/c2442d8a-40fa-4228-8684-fb214b04d029)