### PR TITLE
fix(rsc): statically import client references virtual

### DIFF
--- a/packages/rsc/src/browser.ts
+++ b/packages/rsc/src/browser.ts
@@ -1,3 +1,4 @@
+import * as clientReferences from "virtual:vite-rsc/client-references";
 import { setRequireModule } from "./core/browser";
 import { withBase } from "./utils/base";
 
@@ -12,9 +13,6 @@ export function initialize(options?: {
         // @ts-ignore
         return __vite_rsc_raw_import__(withBase(id));
       } else {
-        const clientReferences = await import(
-          "virtual:vite-rsc/client-references" as any
-        );
         const import_ = clientReferences.default[id];
         if (!import_) {
           throw new Error(`client reference not found '${id}'`);


### PR DESCRIPTION
While trying to confirm no waterfall with new react-router https://github.com/hi-ogawa/vite-plugins/pull/814, I just noticed this virtual is making another round trip.