### PR TITLE
test(rsc): test `useActionState`

### DIFF
--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -43,6 +43,28 @@ async function testAction(page: Page) {
   ).toBeVisible();
 }
 
+test("useActionState @js", async ({ page }) => {
+  await page.goto("./");
+  await waitForHydration(page);
+  await using _ = await createReloadChecker(page);
+  await testUseActionState(page);
+});
+
+testNoJs("useActionState @nojs", async ({ page }) => {
+  await page.goto("./");
+  await testUseActionState(page);
+});
+
+async function testUseActionState(page: Page) {
+  await expect(page.getByTestId("use-action-state")).toContainText(
+    "test-useActionState: 0",
+  );
+  await page.getByTestId("use-action-state").click();
+  await expect(page.getByTestId("use-action-state")).toContainText(
+    "test-useActionState: 1",
+  );
+}
+
 testNoJs("module preload on ssr @build", async ({ page }) => {
   await page.goto("./");
   const srcs = await page

--- a/packages/rsc/examples/basic/src/routes/action-from-client/action.tsx
+++ b/packages/rsc/examples/basic/src/routes/action-from-client/action.tsx
@@ -21,3 +21,7 @@ function notThis2() {
 export async function testAction2() {
   console.log("[test-action-from-client-2]");
 }
+
+export async function testActionState(prev: number) {
+  return prev + 1;
+}

--- a/packages/rsc/examples/basic/src/routes/action-from-client/client.tsx
+++ b/packages/rsc/examples/basic/src/routes/action-from-client/client.tsx
@@ -4,13 +4,22 @@ import React from "react";
 import { testAction, testAction2, testActionState } from "./action";
 
 export function TestActionFromClient() {
-  const [state, formAction] = React.useActionState(testActionState, 0);
-
   return (
     <form action={testAction}>
       <button>test-action-from-client</button>
       <button formAction={testAction2}>test-action-from-client-2</button>
-      <button formAction={formAction}>test-form-action: {state}</button>
+    </form>
+  );
+}
+
+export function TestUseActionState() {
+  const [state, formAction] = React.useActionState(testActionState, 0);
+
+  return (
+    <form action={formAction}>
+      <button data-testid="use-action-state">
+        test-useActionState: {state}
+      </button>
     </form>
   );
 }

--- a/packages/rsc/examples/basic/src/routes/action-from-client/client.tsx
+++ b/packages/rsc/examples/basic/src/routes/action-from-client/client.tsx
@@ -1,12 +1,16 @@
 "use client";
 
-import { testAction, testAction2 } from "./action";
+import React from "react";
+import { testAction, testAction2, testActionState } from "./action";
 
 export function TestActionFromClient() {
+  const [state, formAction] = React.useActionState(testActionState, 0);
+
   return (
     <form action={testAction}>
       <button>test-action-from-client</button>
       <button formAction={testAction2}>test-action-from-client-2</button>
+      <button formAction={formAction}>test-form-action: {state}</button>
     </form>
   );
 }

--- a/packages/rsc/examples/basic/src/routes/root.tsx
+++ b/packages/rsc/examples/basic/src/routes/root.tsx
@@ -4,7 +4,10 @@ import {
   getServerCounter,
   resetServerCounter,
 } from "./action";
-import { TestActionFromClient } from "./action-from-client/client";
+import {
+  TestActionFromClient,
+  TestUseActionState,
+} from "./action-from-client/client";
 import {
   ClientCounter,
   Hydrated,
@@ -50,6 +53,7 @@ export function Root(props: { url: URL }) {
         <TestReplayConsoleLogs url={props.url} />
         <TestSuspense url={props.url} />
         <TestActionFromClient />
+        <TestUseActionState />
       </body>
     </html>
   );


### PR DESCRIPTION
I realized we didn't have a test for actions import from client. It looks like `useActionState` can exercise exactly that (+ also `formState`), so let's add it.