### PR TITLE
feat(react-server): support prepare destination

### DIFF
--- a/packages/react-server/examples/basic/e2e/basic.test.ts
+++ b/packages/react-server/examples/basic/e2e/basic.test.ts
@@ -1305,12 +1305,13 @@ test("full client route", async ({ page }) => {
   await page.getByRole("heading", { name: '"use client" page' }).click();
 });
 
-test("preload ssr @build", async ({ request }) => {
+testNoJs("preload ssr @build", async ({ page }) => {
+  await page.goto("/test/deps");
+  const modulepreloads = await page
+    .locator(`head >> link[rel="modulepreload"]`)
+    .evaluateAll((elements) => elements.map((el) => el.getAttribute("href")));
   const file = getClientManifest()["virtual:test-use-client"].file;
-
-  const res = await request.get("/test/deps");
-  const resText = await res.text();
-  expect(resText).toContain(`<link rel="modulepreload" href="/${file}"/>`);
+  expect(modulepreloads).toContain(`/${file}`);
 });
 
 test("preload client @build", async ({ page }) => {

--- a/packages/react-server/src/entry/ssr.tsx
+++ b/packages/react-server/src/entry/ssr.tsx
@@ -115,7 +115,7 @@ export async function renderHtml(
       <RouterContext.Provider value={router}>
         <FlightDataContext.Provider value={flightDataPromise}>
           <RouteManifestContext.Provider value={routeManifest}>
-            {false && <RouteAssetLinks />}
+            <RouteAssetLinks />
             <ssrContext.Provider>
               <LayoutRoot />
             </ssrContext.Provider>

--- a/packages/react-server/src/features/client-component/ssr.tsx
+++ b/packages/react-server/src/features/client-component/ssr.tsx
@@ -27,6 +27,8 @@ export function initializeReactClientSsr() {
     prepareDestination(id) {
       if (import.meta.env.DEV) return;
       const deps = prepareDestinationManifest[id];
+      // TODO: not working?
+      // console.log("[prepareDestination]", { id, deps })
       for (const js of deps) {
         ReactDOM.preloadModule(js, {
           as: "script",

--- a/packages/react-server/src/features/client-component/ssr.tsx
+++ b/packages/react-server/src/features/client-component/ssr.tsx
@@ -18,5 +18,10 @@ async function ssrImport(id: string) {
 }
 
 export function initializeReactClientSsr() {
-  ReactClient.setRequireModule({ load: ssrImport });
+  ReactClient.setRequireModule({
+    load: ssrImport,
+    prepareDestination(id) {
+      id;
+    },
+  });
 }

--- a/packages/react-server/src/features/client-component/ssr.tsx
+++ b/packages/react-server/src/features/client-component/ssr.tsx
@@ -27,8 +27,6 @@ export function initializeReactClientSsr() {
     prepareDestination(id) {
       if (import.meta.env.DEV) return;
       const deps = prepareDestinationManifest[id];
-      // TODO: not working?
-      // console.log("[prepareDestination]", { id, deps })
       for (const js of deps) {
         ReactDOM.preloadModule(js, {
           as: "script",

--- a/packages/react-server/src/features/client-component/ssr.tsx
+++ b/packages/react-server/src/features/client-component/ssr.tsx
@@ -1,8 +1,12 @@
 import { createDebug, tinyassert } from "@hiogawa/utils";
 import * as ReactClient from "@hiogawa/vite-rsc/react/ssr";
+import * as ReactDOM from "react-dom";
 
 // @ts-ignore
 import clientReferences from "virtual:client-references";
+
+// @ts-ignore
+import prepareDestinationManifest from "virtual:prepare-destination-manifest";
 
 const debug = createDebug("react-server:ssr-import");
 
@@ -21,7 +25,14 @@ export function initializeReactClientSsr() {
   ReactClient.setRequireModule({
     load: ssrImport,
     prepareDestination(id) {
-      id;
+      if (import.meta.env.DEV) return;
+      const deps = prepareDestinationManifest[id];
+      for (const js of deps) {
+        ReactDOM.preloadModule(js, {
+          as: "script",
+          crossOrigin: "",
+        });
+      }
     },
   });
 }

--- a/packages/react-server/src/features/request-context/utils.ts
+++ b/packages/react-server/src/features/request-context/utils.ts
@@ -1,7 +1,4 @@
-import "virtual:inject-async-local-storage";
-
 // we don't require async hooks and fallbacks to sync context
-// (see virtual:inject-async-local-storage)
 
 type ContextStorage<T> = {
   run<R>(store: T, callback: () => R): R;

--- a/packages/react-server/src/features/router/client.tsx
+++ b/packages/react-server/src/features/router/client.tsx
@@ -94,7 +94,10 @@ export function routerRevalidate(v: string): HistoryState {
 
 function preloadAssetDeps(deps: AssetDeps) {
   for (const href of deps.js) {
-    ReactDom.preloadModule(href);
+    ReactDom.preloadModule(href, {
+      as: "script",
+      crossOrigin: "",
+    });
   }
   for (const href of deps.css) {
     ReactDom.preload(href, { as: "style" });
@@ -111,7 +114,7 @@ export function RouteAssetLinks() {
   return (
     <>
       {deps.js.map((href) => (
-        <link key={href} rel="modulepreload" href={href} />
+        <link key={href} rel="modulepreload" href={href} crossOrigin="" />
       ))}
       {deps.css.map((href) => (
         // precedence to force head rendering

--- a/packages/react-server/src/features/router/client.tsx
+++ b/packages/react-server/src/features/router/client.tsx
@@ -111,9 +111,11 @@ export function RouteAssetLinks() {
     () => getRouteAssetDeps(routeManifest, pathname),
     [pathname, routeManifest],
   );
+  // During SSR, modulepreload is injected via prepareDestination
+  // (which means "prepareDestination" is actually redundant, but we use it for testing.)
   return (
     <>
-      {false &&
+      {!import.meta.env.SSR &&
         deps.js.map((href) => (
           <link key={href} rel="modulepreload" href={href} crossOrigin="" />
         ))}

--- a/packages/react-server/src/features/router/client.tsx
+++ b/packages/react-server/src/features/router/client.tsx
@@ -113,9 +113,10 @@ export function RouteAssetLinks() {
   );
   return (
     <>
-      {deps.js.map((href) => (
-        <link key={href} rel="modulepreload" href={href} crossOrigin="" />
-      ))}
+      {false &&
+        deps.js.map((href) => (
+          <link key={href} rel="modulepreload" href={href} crossOrigin="" />
+        ))}
       {deps.css.map((href) => (
         // precedence to force head rendering
         // https://react.dev/reference/react-dom/components/link#special-rendering-behavior

--- a/packages/react-server/src/features/router/plugin.ts
+++ b/packages/react-server/src/features/router/plugin.ts
@@ -84,6 +84,13 @@ export function routeManifestPluginClient({
           manager.routeManifest = {
             routeTree: createFsRouteTree<RouteAssetDeps>(routeToAssetDeps).tree,
           };
+
+          const prepareDestinationManifest: Record<string, string[]> = {};
+          for (const [id, clientId] of manager.clientReferenceMap) {
+            prepareDestinationManifest[clientId] =
+              facadeModuleDeps[id]?.js ?? [];
+          }
+          manager.prepareDestinationManifest = prepareDestinationManifest;
         }
       },
     },
@@ -107,6 +114,14 @@ export function routeManifestPluginClient({
         null,
         2,
       )}`;
+    }),
+    createVirtualPlugin("prepare-destination-manifest", async function () {
+      tinyassert(manager.buildType === "ssr");
+      if (this.environment.mode === "dev") {
+        return `export default {}`;
+      }
+      tinyassert(manager.prepareDestinationManifest);
+      return `export default ${JSON.stringify(manager.prepareDestinationManifest)}`;
     }),
   ];
 }

--- a/packages/react-server/src/features/router/plugin.ts
+++ b/packages/react-server/src/features/router/plugin.ts
@@ -116,7 +116,6 @@ export function routeManifestPluginClient({
       )}`;
     }),
     createVirtualPlugin("prepare-destination-manifest", async function () {
-      tinyassert(manager.buildType === "ssr");
       if (this.environment.mode === "dev") {
         return `export default {}`;
       }

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -84,6 +84,7 @@ class PluginStateManager {
   routeToClientReferences: Record<string, string[]> = {};
   routeManifest?: RouteManifest;
   serverAssets: string[] = [];
+  prepareDestinationManifest?: Record<string, string[]> = {};
 
   // expose "use client" node modules to client via virtual modules
   // to avoid dual package due to deps optimization hash during dev

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -371,26 +371,38 @@ export function vitePluginReactServer(
     }),
     createVirtualPlugin(
       ENTRY_SERVER_WRAPPER.slice("virtual:".length),
-      // the first import doesn't necessarily guarantee the execution order depending on chunking.
-      // so, we also have it on packages/react-server/src/features/request-context/utils.ts.
-      // TODO: this might not be enough for React.cache
       () => `
-        import "virtual:inject-async-local-storage";
         export { handler } from "${entryServer}";
         export { router } from "@hiogawa/react-server/entry/server";
       `,
     ),
-    // make `AsyncLocalStorage` available globally for React.cache from edge build
-    // https://github.com/facebook/react/blob/f14d7f0d2597ea25da12bcf97772e8803f2a394c/packages/react-server/src/forks/ReactFlightServerConfig.dom-edge.js#L16-L19
-    createVirtualPlugin("inject-async-local-storage", function () {
-      if (this.environment.name !== "rsc" || options?.noAsyncLocalStorage) {
-        return "export {}";
-      }
-      return `
-        import { AsyncLocalStorage } from "node:async_hooks";
-        Object.assign(globalThis, { AsyncLocalStorage });
-      `;
-    }),
+    {
+      // make `AsyncLocalStorage` available globally for React request context on edge build (e.g. React.cache, ssr preload)
+      // https://github.com/facebook/react/blob/f14d7f0d2597ea25da12bcf97772e8803f2a394c/packages/react-server/src/forks/ReactFlightServerConfig.dom-edge.js#L16-L19
+      name: "inject-async-local-storage",
+      async configureServer() {
+        if (options?.noAsyncLocalStorage) return;
+
+        const __viteRscAyncHooks = await import("node:async_hooks");
+        (globalThis as any).AsyncLocalStorage =
+          __viteRscAyncHooks.AsyncLocalStorage;
+      },
+      banner(chunk) {
+        if (
+          !options?.noAsyncLocalStorage &&
+          (this.environment.name === "ssr" ||
+            this.environment.name === "rsc") &&
+          this.environment.mode === "build" &&
+          chunk.isEntry
+        ) {
+          return `\
+            import * as __viteRscAyncHooks from "node:async_hooks";
+            globalThis.AsyncLocalStorage = __viteRscAyncHooks.AsyncLocalStorage;
+          `;
+        }
+        return "";
+      },
+    },
     wrapServerPlugin(
       validateImportPlugin({
         "client-only": `'client-only' is included in server build`,

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -388,8 +388,9 @@ export function vitePluginReactServer(
           __viteRscAyncHooks.AsyncLocalStorage;
       },
       banner(chunk) {
+        if (options?.noAsyncLocalStorage) return "";
+
         if (
-          !options?.noAsyncLocalStorage &&
           (this.environment.name === "ssr" ||
             this.environment.name === "rsc") &&
           this.environment.mode === "build" &&


### PR DESCRIPTION
We already have per-route module prefetching, so this is redundant, but let's verify whether this works.