### PR TITLE
feat(rsc): support css in rsc environment

### DIFF
--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -174,7 +174,7 @@ async function testCss(page: Page, color = "rgb(255, 165, 0)") {
   await expect(page.locator(".test-style-server")).toHaveCSS("color", color);
 }
 
-test("css hmr @dev", async ({ page }) => {
+test("css hmr client @dev", async ({ page }) => {
   await page.goto("./");
   await waitForHydration(page);
   await testCss(page);
@@ -182,7 +182,24 @@ test("css hmr @dev", async ({ page }) => {
   await using _ = await createReloadChecker(page);
   using editor = createEditor("src/routes/counter.css");
   editor.edit((s) => s.replaceAll("rgb(255, 165, 0)", "rgb(0, 165, 255)"));
-  await testCss(page, "rgb(0, 165, 255)");
+  await expect(page.locator(".test-style-client")).toHaveCSS(
+    "color",
+    "rgb(0, 165, 255)",
+  );
+});
+
+test("css hmr server @dev", async ({ page }) => {
+  await page.goto("./");
+  await waitForHydration(page);
+  await testCss(page);
+
+  await using _ = await createReloadChecker(page);
+  using editor = createEditor("src/styles.css");
+  editor.edit((s) => s.replaceAll("rgb(255, 165, 0)", "rgb(0, 165, 255)"));
+  await expect(page.locator(".test-style-server")).toHaveCSS(
+    "color",
+    "rgb(0, 165, 255)",
+  );
 });
 
 test("tailwind @js", async ({ page }) => {

--- a/packages/rsc/examples/basic/src/routes/counter.css
+++ b/packages/rsc/examples/basic/src/routes/counter.css
@@ -1,6 +1,4 @@
-.test-style-server {
-  color: rgb(255, 165, 0);
-}
+/* css imported by client references */
 
 .test-style-client {
   color: rgb(255, 165, 0);

--- a/packages/rsc/examples/basic/src/server.tsx
+++ b/packages/rsc/examples/basic/src/server.tsx
@@ -1,3 +1,4 @@
+import "./styles.css";
 import { renderRequest } from "@hiogawa/vite-rsc/extra/rsc";
 import { Root } from "./routes/root";
 

--- a/packages/rsc/examples/basic/src/styles.css
+++ b/packages/rsc/examples/basic/src/styles.css
@@ -1,6 +1,6 @@
-@import "tailwindcss";
+/* css imported by rsc environment */
 
-/* TODO: test hmr here */
+@import "tailwindcss";
 
 button {
   @apply bg-gray-200 mx-1 px-2 border;
@@ -8,4 +8,8 @@ button {
 
 input {
   @apply mx-1 px-2 border;
+}
+
+.test-style-server {
+  color: rgb(255, 165, 0);
 }

--- a/packages/rsc/examples/basic/src/styles.css
+++ b/packages/rsc/examples/basic/src/styles.css
@@ -1,5 +1,7 @@
 @import "tailwindcss";
 
+/* TODO: test hmr here */
+
 button {
   @apply bg-gray-200 mx-1 px-2 border;
 }

--- a/packages/rsc/examples/basic/vite.config.ts
+++ b/packages/rsc/examples/basic/vite.config.ts
@@ -15,7 +15,6 @@ export default defineConfig({
         browser: "/src/client.tsx",
         rsc: "/src/server.tsx",
         ssr: "@hiogawa/vite-rsc/extra/ssr",
-        css: "/src/styles.css",
       },
     }),
     Inspect(),

--- a/packages/rsc/src/extra/ssr.tsx
+++ b/packages/rsc/src/extra/ssr.tsx
@@ -43,7 +43,7 @@ export async function renderHtml({
     return (
       <>
         {root}
-        {/* TODO: move to rsc root */}
+        {/* TODO: move to rsc root? */}
         {css}
         {js}
         <RscCss />

--- a/packages/rsc/src/extra/ssr.tsx
+++ b/packages/rsc/src/extra/ssr.tsx
@@ -10,6 +10,9 @@ import { withBase } from "../utils/base";
 import type { RscPayload } from "./rsc";
 import { injectRscScript } from "./utils/rsc-script";
 
+// @ts-ignore
+import RscCss from "virtual:vite-rsc/css/rsc";
+
 export async function renderHtml({
   stream,
   formState,
@@ -42,6 +45,7 @@ export async function renderHtml({
         {root}
         {css}
         {js}
+        <RscCss />
       </>
     );
   }

--- a/packages/rsc/src/extra/ssr.tsx
+++ b/packages/rsc/src/extra/ssr.tsx
@@ -10,6 +10,7 @@ import { withBase } from "../utils/base";
 import type { RscPayload } from "./rsc";
 import { injectRscScript } from "./utils/rsc-script";
 
+// TODO: move to extra/rsc.tsx
 // @ts-ignore
 import RscCss from "virtual:vite-rsc/css/rsc";
 

--- a/packages/rsc/src/extra/ssr.tsx
+++ b/packages/rsc/src/extra/ssr.tsx
@@ -10,9 +10,8 @@ import { withBase } from "../utils/base";
 import type { RscPayload } from "./rsc";
 import { injectRscScript } from "./utils/rsc-script";
 
-// TODO: move to extra/rsc.tsx
 // @ts-ignore
-import RscCss from "virtual:vite-rsc/css/rsc";
+import RscCss from "virtual:vite-rsc/rsc-css-ssr";
 
 export async function renderHtml({
   stream,
@@ -44,6 +43,7 @@ export async function renderHtml({
     return (
       <>
         {root}
+        {/* TODO: move to rsc root */}
         {css}
         {js}
         <RscCss />

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -920,6 +920,19 @@ export function vitePluginRscCss(): Plugin[] {
         }
       },
     },
+    createVirtualPlugin("vite-rsc/css/rsc", function () {
+      if (this.environment.mode === "dev") {
+      }
+      return `
+        import * as React from "react"
+        export default function RscCss() {
+          // TODO: inject via preload script
+          // ReactDOM.preloadModule("/@id/__x00__virtual:vite-rsc/css/proxy.js");
+          // for (const href of rscCss) { ReactDOM.preinit(href, { as: "style" }) }
+          return null;
+        }
+      `;
+    }),
     {
       name: "rsc:css/dev-ssr-virtual",
       resolveId(source) {

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -20,7 +20,10 @@ import {
 import type { ModuleRunner } from "vite/module-runner";
 import { crawlFrameworkPkgs } from "vitefu";
 import vitePluginRscCore from "./core/plugin";
-import { normalizeViteImportAnalysisUrl } from "./vite-utils";
+import {
+  normalizeResolvedIdToUrl,
+  normalizeViteImportAnalysisUrl,
+} from "./vite-utils";
 
 // state for build orchestration
 let clientReferences: Record<string, string> = {};
@@ -842,8 +845,81 @@ export async function findSourceMapURL(
 // css support
 //
 
+// [known input sources]
+// entries.rsc, entries.ssr
+// entries.browser
+// client references (discovered through "entries.rsc" or "server references")
+// server references (discovered through "client references")
+
+// [dev]
+// - entries.rsc, entries.ssr
+//   - traverse module graph from entries
+//   - collect all css imports
+//   - ...todo
+// - entries.browser
+//   - traverse module graph from entries
+// - client references
+//   - traverse module graph
+
+// [build]
+// TODO
+
+// [dev]
+// - is it possible to lazily collect as modules are imported and rendered?
+//   then inject it lazily as wrapper css link
+//     <link rel="stylesheet" href="/@id/__x00__vite-rsc/collect-css" />
+//   and proxy js which imports css as side effect to setup css hmr
+//     <link rel="stylesheet" href="/@id/__x00__vite-rsc/collect-css-proxy.js" />
+//
+// - wrapper css link is difficult (especially how to block and release),
+//   but in principle, we should be able to inject React.preinit(..., { as: "stylesheet" }) to inject css link
+//   as modules are discovered (e.g. via transform hooks.)
+
+// TODO:
+// - we only need a trick to solve first SSR FOUC after server start?
+//   after that, we already have css in module graph, so we can just send it easily.
+
+// NOTE:
+// - on client entries
+//     (don't need to support. by convention put it in server component or client component)
+// - on ssr (client compoennt)
+//     static import should be executed before rendering copmonent.
+//     we know "use client" is a component marker, so we can split css there.
+// - on rsc
+
 export function vitePluginRscCss(): Plugin[] {
+  // const cssIds: string[] = [];
+  const rscCssIds = new Set<string>();
+
+  // TODO: filter out removed id (e.g. deleted file during dev)
+  // server.environments.client;
+  normalizeResolvedIdToUrl;
+
   return [
+    {
+      name: "rsc:css",
+      transform(_code, id) {
+        if (isCSSRequest(id)) {
+          if (this.environment.name === "rsc") {
+            if (!rscCssIds.has(id)) {
+              rscCssIds.add(id);
+              // send event to runtime to trigger ReactDOM.preinit?
+            }
+            // we can collect but how to handle after deleted for example?
+            // we can filter out by moduleGraph existance? e.g.
+            // if (this.environment.mode === 'dev') {
+            //   this.environment.moduleGraph.idToModuleMap
+            // }
+          }
+          if (this.environment.name === "ssr") {
+            id;
+          }
+          if (this.environment.name === "client") {
+            id;
+          }
+        }
+      },
+    },
     {
       name: "rsc:css/dev-ssr-virtual",
       resolveId(source) {

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -943,12 +943,14 @@ export function vitePluginRscCss({
       `;
     }),
     createVirtualPlugin("vite-rsc/rsc-css-browser", async function () {
+      let ids: string[];
       if (this.environment.mode === "build") {
-        return [...rscCssIdsBuild]
-          .map((href) => `import ${JSON.stringify(href)};\n`)
-          .join("\n");
+        ids = [...rscCssIdsBuild];
+      } else {
+        const collected = await collectCssDev(server.environments.rsc!);
+        ids = collected.ids;
       }
-      const { ids } = await collectCssDev(server.environments.rsc!);
+      ids = ids.map((id) => id.replace(/^\0/, ""));
       return ids.map((id) => `import ${JSON.stringify(id)};\n`).join("");
     }),
     {

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -197,6 +197,9 @@ export default function vitePluginRsc({
         };
       },
       async hotUpdate(ctx) {
+        // css file imported by anywhere sould work based on default hmr
+        if (isCSSRequest(ctx.file)) return;
+
         const ids = ctx.modules.map((mod) => mod.id).filter((v) => v !== null);
         if (ids.length === 0) return;
 
@@ -954,7 +957,8 @@ export function vitePluginRscCss({
           for (const href of CSS_HREFS) {
             ReactDOM.preinit(base + href, { as: "style" });
           }
-          ReactDOM.preloadModule(base + "/@id/__x00__virtual:vite-rsc/css/browser");
+          // TODO: this can be bootstrap scripts
+          ReactDOM.preinitModule(base + "/@id/__x00__virtual:vite-rsc/css/browser");
           return null;
         }
       `;


### PR DESCRIPTION
## todo

There's no "RSC" convention on how to split css on server side, so this depends on frameworks (e.g. Parcel's `"use server entry"`). Here, we implement a simple sweep of css files from server entry.

- [x] dev
  - [x] ssr
  - [x] hmr
- [x] build
- [x] refactor