### PR TITLE
refactor(rsc): tweak asset links api

### DIFF
--- a/packages/rsc/examples/react-router/src/entry.rsc.tsx
+++ b/packages/rsc/examples/react-router/src/entry.rsc.tsx
@@ -1,3 +1,4 @@
+import "./styles.css";
 import {
   decodeAction,
   decodeReply,

--- a/packages/rsc/examples/react-router/src/entry.ssr.tsx
+++ b/packages/rsc/examples/react-router/src/entry.ssr.tsx
@@ -3,8 +3,7 @@ import {
   createFromReadableStream,
   getAssetsManifest,
   initialize,
-} from "../../../dist/ssr";
-
+} from "@hiogawa/vite-rsc/ssr";
 // @ts-ignore
 import * as ReactDomServer from "react-dom/server.edge";
 import { RSCStaticRouter, routeRSCServerRequest } from "react-router";

--- a/packages/rsc/examples/react-router/src/entry.ssr.tsx
+++ b/packages/rsc/examples/react-router/src/entry.ssr.tsx
@@ -1,5 +1,4 @@
 import {
-  Resources,
   createFromReadableStream,
   getAssetsManifest,
   initialize,
@@ -20,10 +19,7 @@ export default async function handler(
     (body) => createFromReadableStream(body),
     (getPayload) =>
       ReactDomServer.renderToReadableStream(
-        <>
-          <RSCStaticRouter getPayload={getPayload} />
-          <Resources />
-        </>,
+        <RSCStaticRouter getPayload={getPayload} />,
         {
           bootstrapModules: getAssetsManifest().entry.bootstrapModules,
         },

--- a/packages/rsc/examples/react-router/src/entry.ssr.tsx
+++ b/packages/rsc/examples/react-router/src/entry.ssr.tsx
@@ -1,8 +1,10 @@
 import {
+  Resources,
   createFromReadableStream,
   getAssetsManifest,
   initialize,
-} from "@hiogawa/vite-rsc/ssr";
+} from "../../../dist/ssr";
+
 // @ts-ignore
 import * as ReactDomServer from "react-dom/server.edge";
 import { RSCStaticRouter, routeRSCServerRequest } from "react-router";
@@ -13,14 +15,6 @@ export default async function handler(
   request: Request,
   callServer: (request: Request) => Promise<Response>,
 ) {
-  const assets = getAssetsManifest().entry;
-  const css = assets.deps.css.map((href) => (
-    <link key={href} rel="stylesheet" href={href} precedence="high" />
-  ));
-  const js = assets.deps.js.map((href) => (
-    <link key={href} rel="modulepreload" href={href} />
-  ));
-
   return routeRSCServerRequest(
     request,
     callServer,
@@ -29,11 +23,10 @@ export default async function handler(
       ReactDomServer.renderToReadableStream(
         <>
           <RSCStaticRouter getPayload={getPayload} />
-          {css}
-          {js}
+          <Resources />
         </>,
         {
-          bootstrapModules: assets.bootstrapModules,
+          bootstrapModules: getAssetsManifest().entry.bootstrapModules,
         },
       ),
   );

--- a/packages/rsc/examples/react-router/src/routes/root.tsx
+++ b/packages/rsc/examples/react-router/src/routes/root.tsx
@@ -1,3 +1,4 @@
+import { Resources } from "@hiogawa/vite-rsc/rsc";
 import { Link, Outlet } from "react-router";
 import { TestClientState, TestHydrated } from "./client";
 import { DumpError, GlobalNavigationLoadingBar } from "./root.client";
@@ -10,6 +11,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>React Router Vite</title>
+        <Resources />
       </head>
       <body>
         <header className="container px-8 my-8 mx-auto">

--- a/packages/rsc/examples/react-router/vite.config.ts
+++ b/packages/rsc/examples/react-router/vite.config.ts
@@ -17,9 +17,11 @@ export default defineConfig({
         browser: "/src/entry.browser.tsx",
         ssr: "/src/entry.ssr.tsx",
         rsc: "/src/entry.rsc.tsx",
-        css: "/src/styles.css",
       },
       clientPackages: ["react-router"],
     }),
   ],
+  optimizeDeps: {
+    include: ["react-router"],
+  },
 }) as any;

--- a/packages/rsc/src/extra/rsc.tsx
+++ b/packages/rsc/src/extra/rsc.tsx
@@ -1,5 +1,6 @@
 import type { ReactFormState } from "react-dom/client";
 import {
+  Resources,
   createTemporaryReferenceSet,
   decodeAction,
   decodeFormState,
@@ -21,6 +22,15 @@ export async function renderRequest(
   root: React.ReactNode,
 ): Promise<Response> {
   initialize();
+
+  function RscRoot() {
+    return (
+      <>
+        <Resources />
+        {root}
+      </>
+    );
+  }
 
   const url = new URL(request.url);
   const isAction = request.method === "POST";
@@ -57,7 +67,7 @@ export async function renderRequest(
     }
   }
 
-  const rscPayload: RscPayload = { root, formState, returnValue };
+  const rscPayload: RscPayload = { root: <RscRoot />, formState, returnValue };
   const rscOptions = { temporaryReferences };
   const stream = renderToReadableStream<RscPayload>(rscPayload, rscOptions);
 

--- a/packages/rsc/src/extra/ssr.tsx
+++ b/packages/rsc/src/extra/ssr.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import type { ReactFormState } from "react-dom/client";
 import ReactDomServer from "react-dom/server.edge";
 import {
+  Resources,
   createFromReadableStream,
   getAssetsManifest,
   initialize,
@@ -9,9 +10,6 @@ import {
 import { withBase } from "../utils/base";
 import type { RscPayload } from "./rsc";
 import { injectRscScript } from "./utils/rsc-script";
-
-// @ts-ignore
-import RscCss from "virtual:vite-rsc/rsc-css-ssr";
 
 export async function renderHtml({
   stream,
@@ -29,24 +27,10 @@ export async function renderHtml({
   function SsrRoot() {
     payload ??= createFromReadableStream<RscPayload>(stream1);
     const root = React.use(payload).root;
-    const css = assets.deps.css.map((href) => (
-      <link
-        key={href}
-        rel="stylesheet"
-        href={withBase(href)}
-        precedence="high"
-      />
-    ));
-    const js = assets.deps.js.map((href) => (
-      <link key={href} rel="modulepreload" href={withBase(href)} />
-    ));
     return (
       <>
         {root}
-        {/* TODO: move to rsc root? */}
-        {css}
-        {js}
-        <RscCss />
+        <Resources />
       </>
     );
   }

--- a/packages/rsc/src/extra/ssr.tsx
+++ b/packages/rsc/src/extra/ssr.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import type { ReactFormState } from "react-dom/client";
 import ReactDomServer from "react-dom/server.edge";
 import {
-  Resources,
   createFromReadableStream,
   getAssetsManifest,
   initialize,
@@ -27,12 +26,7 @@ export async function renderHtml({
   function SsrRoot() {
     payload ??= createFromReadableStream<RscPayload>(stream1);
     const root = React.use(payload).root;
-    return (
-      <>
-        {root}
-        <Resources />
-      </>
-    );
+    return root;
   }
 
   const htmlStream = await ReactDomServer.renderToReadableStream(<SsrRoot />, {

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -928,31 +928,6 @@ export function vitePluginRscCss({
         }
       },
     },
-    createVirtualPlugin("vite-rsc/rsc-css-ssr", async function () {
-      if (this.environment.mode === "build") {
-        // during build, css are injected through AssetsManifest.entry.deps.css
-        return `export default () => {}`;
-      }
-      const { hrefs } = await collectCssByUrl(
-        server.environments.rsc!,
-        entries.rsc,
-      );
-      return `
-        import * as React from "react";
-        import * as ReactDOM from "react-dom";
-
-        const CSS_HREFS = ${JSON.stringify(hrefs, null, 2)};
-
-        const BASE = import.meta.env.BASE_URL.slice(0, -1);
-
-        export default async function RscCss({ nonce }) {
-          for (const href of CSS_HREFS) {
-            ReactDOM.preinit(BASE + href, { as: "style", nonce });
-          }
-          return null;
-        }
-      `;
-    }),
     createVirtualPlugin("vite-rsc/rsc-css", async function () {
       if (this.environment.mode === "build") {
         // during build, css are injected through AssetsManifest.entry.deps.css

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -953,6 +953,17 @@ export function vitePluginRscCss({
         }
       `;
     }),
+    createVirtualPlugin("vite-rsc/rsc-css", async function () {
+      if (this.environment.mode === "build") {
+        // during build, css are injected through AssetsManifest.entry.deps.css
+        return `export default []`;
+      }
+      const { hrefs } = await collectCssByUrl(
+        server.environments.rsc!,
+        entries.rsc,
+      );
+      return `export default ${JSON.stringify(hrefs, null, 2)}`;
+    }),
     createVirtualPlugin("vite-rsc/rsc-css-browser", async function () {
       let ids: string[];
       if (this.environment.mode === "build") {

--- a/packages/rsc/src/ssr.tsx
+++ b/packages/rsc/src/ssr.tsx
@@ -67,7 +67,7 @@ export function getAssetsManifest(): AssetsManifest {
 }
 
 // TODO: should we render resources in Rsc root?
-// (if so, we need expose it from `@hiogawa/vite-rsc/rsc`)
+// (if so, we need to tweak virtual module and expose this from `@hiogawa/vite-rsc/rsc`)
 export function Resources({ nonce }: { nonce?: string }): React.ReactNode {
   const deps = getAssetsManifest().entry.deps;
   const css = deps.css.map((href) => (

--- a/packages/rsc/src/ssr.tsx
+++ b/packages/rsc/src/ssr.tsx
@@ -1,13 +1,9 @@
 import * as assetsManifest from "virtual:vite-rsc/assets-manifest";
 import * as clientReferences from "virtual:vite-rsc/client-references";
-import type React from "react";
 import * as ReactDOM from "react-dom";
 import { setRequireModule } from "./core/ssr";
 import type { AssetsManifest } from "./plugin";
 import { withBase } from "./utils/base";
-
-// @ts-ignore
-import RscCss from "virtual:vite-rsc/rsc-css-ssr";
 
 export { createServerConsumerManifest } from "./core/ssr";
 
@@ -64,29 +60,4 @@ export async function importRsc<T>(): Promise<T> {
 
 export function getAssetsManifest(): AssetsManifest {
   return (assetsManifest as any).default;
-}
-
-// TODO: should we render resources in Rsc root?
-// (if so, we need to tweak virtual module and expose this from `@hiogawa/vite-rsc/rsc`)
-export function Resources({ nonce }: { nonce?: string }): React.ReactNode {
-  const deps = getAssetsManifest().entry.deps;
-  const css = deps.css.map((href) => (
-    <link
-      key={href}
-      rel="stylesheet"
-      href={withBase(href)}
-      precedence="high"
-      nonce={nonce}
-    />
-  ));
-  const js = deps.js.map((href) => (
-    <link key={href} rel="modulepreload" href={withBase(href)} nonce={nonce} />
-  ));
-  return (
-    <>
-      {css}
-      {js}
-      <RscCss />
-    </>
-  );
 }

--- a/packages/rsc/tsdown.config.ts
+++ b/packages/rsc/tsdown.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   entry: [
     "src/plugin.ts",
     "src/browser.ts",
-    "src/ssr.ts",
+    "src/ssr.tsx",
     "src/rsc.ts",
     "src/vite-utils.ts",
     "src/core/browser.ts",

--- a/packages/rsc/tsdown.config.ts
+++ b/packages/rsc/tsdown.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     "src/plugin.ts",
     "src/browser.ts",
     "src/ssr.tsx",
-    "src/rsc.ts",
+    "src/rsc.tsx",
     "src/vite-utils.ts",
     "src/core/browser.ts",
     "src/core/ssr.ts",


### PR DESCRIPTION
React-router example doesn't use `@hiogawa/vite-rsc/extra/ssr`. We need to expose some utility from `@hiogawa/vite-rsc/ssr`.   

Actually we should have this one from `@hiogawa/vite-rsc/rsc` since that's where users should have their root component.