### PR TITLE
refactor(rsc): simplify client reference mapping

### DIFF
--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -526,9 +526,9 @@ function vitePluginUseClient({
         return { code: `export {}`, map: null };
       }
       const clientReferences = Object.fromEntries(
-        Object.entries(clientReferenceMetaMap).map(([id, meta]) => [
+        Object.entries(clientReferenceMetaMap).map(([_id, meta]) => [
           meta.referenceKey,
-          id,
+          meta.importId,
         ]),
       );
       let code = generateDynamicImportCode(clientReferences);


### PR DESCRIPTION
Single `Record<string, string>` was too messy, so it's now enhanced to `Record</* id */ string, ClientReferenceMeta>`.

Probably this will make it easier to do things like:
- apply tree-shaking to all client references (which currently is limited to `clientPackages`)
- https://github.com/hi-ogawa/vite-plugins/pull/830