### PR TITLE
feat(rsc): apply tree-shaking to all client references (2nd approach)

### DIFF
--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -297,3 +297,6 @@ test("hydrate while streaming @js", async ({ page }) => {
   await expect(page.getByTestId("suspense")).toContainText("suspense-fallback");
   await expect(page.getByTestId("suspense")).toContainText("suspense-resolved");
 });
+
+// TODO: probe manifest and verify there's no `__unused_client_reference__` in build output
+test.skip("tree-shaking client reference", async () => {});

--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -297,6 +297,3 @@ test("hydrate while streaming @js", async ({ page }) => {
   await expect(page.getByTestId("suspense")).toContainText("suspense-fallback");
   await expect(page.getByTestId("suspense")).toContainText("suspense-resolved");
 });
-
-// TODO: probe manifest and verify there's no `__unused_client_reference__` in build output
-test.skip("tree-shaking client reference", async () => {});

--- a/packages/rsc/examples/basic/src/routes/client.tsx
+++ b/packages/rsc/examples/basic/src/routes/client.tsx
@@ -47,3 +47,7 @@ export function TestTemporaryReference(props: {
     </div>
   );
 }
+
+export function UnusedClientReference() {
+  console.log("__unused_client_reference__");
+}

--- a/packages/rsc/examples/basic/vite.config.ts
+++ b/packages/rsc/examples/basic/vite.config.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert";
 import rsc from "@hiogawa/vite-rsc/plugin";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
@@ -33,6 +34,17 @@ export default defineConfig({
           }
           next();
         });
+      },
+    },
+    {
+      name: "test-client-reference-tree-shaking",
+      enforce: "post",
+      writeBundle(_options, bundle) {
+        for (const chunk of Object.values(bundle)) {
+          if (chunk.type === "chunk") {
+            assert(!chunk.code.includes("__unused_client_reference__"));
+          }
+        }
       },
     },
   ],

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -487,7 +487,7 @@ function vitePluginUseClient({
             importId = `/@id/__x00__virtual:vite-rsc/client-package-proxy/${packageSource}`;
             referenceKey = importId;
           } else {
-            importId = `virtual:vite-rsc/client-package-proxy/${packageSource}`;
+            importId = packageSource;
             referenceKey = hashString(packageSource);
           }
         } else {
@@ -523,15 +523,23 @@ function vitePluginUseClient({
     },
     createVirtualPlugin("vite-rsc/client-references", function () {
       if (this.environment.mode === "dev") {
-        return { code: `export {}`, map: null };
+        return { code: `export default {}`, map: null };
       }
-      const clientReferences = Object.fromEntries(
-        Object.entries(clientReferenceMetaMap).map(([_id, meta]) => [
-          meta.referenceKey,
-          meta.importId,
-        ]),
-      );
-      let code = generateDynamicImportCode(clientReferences);
+      let code = "";
+      for (const meta of Object.values(clientReferenceMetaMap)) {
+        // vite/rollup can apply tree-shaking to dynamic import of this form
+        const key = JSON.stringify(meta.referenceKey);
+        const id = JSON.stringify(meta.importId);
+        const exports = meta.renderedExports.join(",");
+        code += `
+          ${key}: async () => {
+            const {${exports}} = await import(${id});
+            return {${exports}};
+          },
+        `;
+      }
+      code = `export default {${code}};\n`;
+      console.log(code);
       return { code, map: null };
     }),
     {
@@ -556,16 +564,14 @@ function vitePluginUseClient({
       },
       async load(id) {
         if (id.startsWith("\0virtual:vite-rsc/client-package-proxy/")) {
+          assert(this.environment.mode === 'dev')
           const source = id.slice(
             "\0virtual:vite-rsc/client-package-proxy/".length,
           );
           const meta = Object.values(clientReferenceMetaMap).find(
             (v) => v.packageSource === source,
           )!;
-          const exportNames =
-            this.environment.mode === "build"
-              ? meta.renderedExports
-              : meta.exportNames;
+          const exportNames = meta.exportNames
           return `export {${exportNames.join(",")}} from ${JSON.stringify(source)};\n`;
         }
       },

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -539,7 +539,6 @@ function vitePluginUseClient({
         `;
       }
       code = `export default {${code}};\n`;
-      console.log(code);
       return { code, map: null };
     }),
     {

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -564,14 +564,14 @@ function vitePluginUseClient({
       },
       async load(id) {
         if (id.startsWith("\0virtual:vite-rsc/client-package-proxy/")) {
-          assert(this.environment.mode === 'dev')
+          assert(this.environment.mode === "dev");
           const source = id.slice(
             "\0virtual:vite-rsc/client-package-proxy/".length,
           );
           const meta = Object.values(clientReferenceMetaMap).find(
             (v) => v.packageSource === source,
           )!;
-          const exportNames = meta.exportNames
+          const exportNames = meta.exportNames;
           return `export {${exportNames.join(",")}} from ${JSON.stringify(source)};\n`;
         }
       },


### PR DESCRIPTION
- supersedes / closes https://github.com/hi-ogawa/vite-plugins/pull/837

Simpler approach of https://github.com/hi-ogawa/vite-plugins/pull/837.

This relies on regex magic https://github.com/vitejs/vite/pull/14221, but this allows not wrapping everything with virtual module re-exports.

This also shows that the need of client reference proxy is solely for dev optimized deps.
