### PR TITLE
chore(rsc): deploy example

### DIFF
--- a/packages/rsc/examples/basic/README.md
+++ b/packages/rsc/examples/basic/README.md
@@ -1,3 +1,5 @@
 # rsc basic
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/hi-ogawa/vite-plugins/tree/main/packages/rsc/examples/basic)
+
+https://vite-rsc-basic.hiro18181.workers.dev

--- a/packages/rsc/examples/basic/package.json
+++ b/packages/rsc/examples/basic/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build --app",
     "preview": "vite preview",
-    "cf-build": "CF_PAGES=1 pnpm build",
+    "cf-build": "CF_BUILD=1 pnpm build",
     "cf-preview": "wrangler dev",
     "cf-release": "wrangler deploy",
     "test-e2e": "playwright test",

--- a/packages/rsc/examples/basic/package.json
+++ b/packages/rsc/examples/basic/package.json
@@ -7,6 +7,9 @@
     "dev": "vite",
     "build": "vite build --app",
     "preview": "vite preview",
+    "cf-build": "CF_PAGES=1 pnpm build",
+    "cf-preview": "wrangler dev",
+    "cf-release": "wrangler deploy",
     "test-e2e": "playwright test",
     "test-e2e-preview": "E2E_PREVIEW=1 playwright test"
   },

--- a/packages/rsc/examples/basic/src/server.tsx
+++ b/packages/rsc/examples/basic/src/server.tsx
@@ -2,7 +2,7 @@ import "./styles.css";
 import { renderRequest } from "@hiogawa/vite-rsc/extra/rsc";
 import { Root } from "./routes/root";
 
-async function handler(request: Request): Promise<Response> {
+export default async function handler(request: Request): Promise<Response> {
   const url = new URL(request.url);
   const root = <Root url={url} />;
   const nonce = !process.env.NO_CSP ? crypto.randomUUID() : undefined;
@@ -18,6 +18,3 @@ async function handler(request: Request): Promise<Response> {
   }
   return response;
 }
-
-// make it compatible with cloudflare worker
-export default { fetch: handler }

--- a/packages/rsc/examples/basic/src/server.tsx
+++ b/packages/rsc/examples/basic/src/server.tsx
@@ -2,7 +2,7 @@ import "./styles.css";
 import { renderRequest } from "@hiogawa/vite-rsc/extra/rsc";
 import { Root } from "./routes/root";
 
-export default async function handler(request: Request): Promise<Response> {
+async function handler(request: Request): Promise<Response> {
   const url = new URL(request.url);
   const root = <Root url={url} />;
   const nonce = !process.env.NO_CSP ? crypto.randomUUID() : undefined;
@@ -18,3 +18,6 @@ export default async function handler(request: Request): Promise<Response> {
   }
   return response;
 }
+
+// make it compatible with cloudflare worker
+export default { fetch: handler }

--- a/packages/rsc/examples/basic/src/styles.css
+++ b/packages/rsc/examples/basic/src/styles.css
@@ -3,7 +3,7 @@
 @import "tailwindcss";
 
 button {
-  @apply bg-gray-200 mx-1 px-2 border;
+  @apply bg-gray-100 mx-1 px-2 border hover:bg-gray-200 active:bg-gray-300;
 }
 
 input {

--- a/packages/rsc/examples/basic/vite.config.ts
+++ b/packages/rsc/examples/basic/vite.config.ts
@@ -2,7 +2,7 @@ import assert from "node:assert";
 import rsc from "@hiogawa/vite-rsc/plugin";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
-import { defineConfig, createBuilder } from "vite";
+import { defineConfig } from "vite";
 import Inspect from "vite-plugin-inspect";
 
 export default defineConfig({
@@ -51,43 +51,27 @@ export default defineConfig({
       name: "cf-build",
       enforce: "post",
       apply: () => !!process.env.CF_BUILD,
-      config(config) {
-        const buildApp = config.builder!.buildApp!;
+      configEnvironment() {
         return {
-          builder: {
-            async buildApp(builder) {
-              await buildApp(builder);
-
-              // bundle server again for cf deployment
-              // const cfBuilder = await createBuilder({
-              //   configFile: false,
-              //   envDir: false,
-              //   publicDir: false,
-              //   environments: {
-              //     ssr: {
-              //       resolve: {
-              //         noExternal: true,
-              //       },
-              //       build: {
-              //         outDir: 'dist/cf',
-              //         rollupOptions: {
-              //           input: {
-              //             index: 'dist/rsc/index.js'
-              //           },
-              //           // output: {
-              //           //   inlineDynamicImports: true,
-              //           // }
-              //         }
-              //       },
-              //     }
-              //   },
-              // });
-              // await cfBuilder.build(cfBuilder.environments.ssr);
-            },
-          }
+          keepProcessEnv: false,
+          define: {
+            "process.env.NO_CSP": "false",
+          },
+          resolve: {
+            noExternal: true,
+          },
+        };
+      },
+      generateBundle() {
+        if (this.environment.name === "rsc") {
+          this.emitFile({
+            type: "asset",
+            fileName: "cloudflare.js",
+            source: `import handler from './index.js'; export default { fetch: handler };`,
+          });
         }
       },
-    }
+    },
   ],
   build: {
     minify: false,

--- a/packages/rsc/examples/basic/vite.config.ts
+++ b/packages/rsc/examples/basic/vite.config.ts
@@ -2,7 +2,7 @@ import assert from "node:assert";
 import rsc from "@hiogawa/vite-rsc/plugin";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import { defineConfig, createBuilder } from "vite";
 import Inspect from "vite-plugin-inspect";
 
 export default defineConfig({
@@ -47,6 +47,47 @@ export default defineConfig({
         }
       },
     },
+    {
+      name: "cf-build",
+      enforce: "post",
+      apply: () => !!process.env.CF_BUILD,
+      config(config) {
+        const buildApp = config.builder!.buildApp!;
+        return {
+          builder: {
+            async buildApp(builder) {
+              await buildApp(builder);
+
+              // bundle server again for cf deployment
+              // const cfBuilder = await createBuilder({
+              //   configFile: false,
+              //   envDir: false,
+              //   publicDir: false,
+              //   environments: {
+              //     ssr: {
+              //       resolve: {
+              //         noExternal: true,
+              //       },
+              //       build: {
+              //         outDir: 'dist/cf',
+              //         rollupOptions: {
+              //           input: {
+              //             index: 'dist/rsc/index.js'
+              //           },
+              //           // output: {
+              //           //   inlineDynamicImports: true,
+              //           // }
+              //         }
+              //       },
+              //     }
+              //   },
+              // });
+              // await cfBuilder.build(cfBuilder.environments.ssr);
+            },
+          }
+        }
+      },
+    }
   ],
   build: {
     minify: false,

--- a/packages/rsc/examples/basic/vite.config.ts
+++ b/packages/rsc/examples/basic/vite.config.ts
@@ -67,7 +67,23 @@ export default defineConfig({
           this.emitFile({
             type: "asset",
             fileName: "cloudflare.js",
-            source: `import handler from './index.js'; export default { fetch: handler };`,
+            source: `\
+import handler from './index.js';
+export default { fetch: handler };
+`,
+          });
+        }
+        if (this.environment.name === "client") {
+          // https://developers.cloudflare.com/workers/static-assets/headers/#custom-headers
+          this.emitFile({
+            type: "asset",
+            fileName: "_headers",
+            source: `\
+/favicon.ico
+  Cache-Control: public, max-age=3600, s-maxage=3600
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+`,
           });
         }
       },

--- a/packages/rsc/examples/basic/wrangler.jsonc
+++ b/packages/rsc/examples/basic/wrangler.jsonc
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://www.unpkg.com/wrangler@3.114.0/config-schema.json",
+  "name": "vite-rsc-basic",
+  "main": "dist/main.js",
+  "assets": {
+    "directory": "dist/client"
+  },
+  "workers_dev": true,
+  "compatibility_date": "2025-04-01",
+  "compatibility_flags": ["nodejs_als"]
+}

--- a/packages/rsc/examples/basic/wrangler.jsonc
+++ b/packages/rsc/examples/basic/wrangler.jsonc
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.unpkg.com/wrangler@3.114.0/config-schema.json",
   "name": "vite-rsc-basic",
-  "main": "dist/rsc/index.js",
+  "main": "dist/rsc/cloudflare.js",
   "assets": {
     "directory": "dist/client"
   },

--- a/packages/rsc/examples/basic/wrangler.jsonc
+++ b/packages/rsc/examples/basic/wrangler.jsonc
@@ -1,7 +1,7 @@
 {
   "$schema": "https://www.unpkg.com/wrangler@3.114.0/config-schema.json",
   "name": "vite-rsc-basic",
-  "main": "dist/main.js",
+  "main": "dist/rsc/index.js",
   "assets": {
     "directory": "dist/client"
   },

--- a/packages/rsc/examples/basic/wrangler.jsonc
+++ b/packages/rsc/examples/basic/wrangler.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://www.unpkg.com/wrangler@3.114.0/config-schema.json",
+  "$schema": "https://www.unpkg.com/wrangler@4.13.0/config-schema.json",
   "name": "vite-rsc-basic",
   "main": "dist/rsc/cloudflare.js",
   "assets": {


### PR DESCRIPTION
I didn't know cf deployment became this easy with `wrangler.jsonc`.
https://vite-rsc-basic.hiro18181.workers.dev