### PR TITLE
chore: release v0.2.0

### DIFF
--- a/packages/rsc/CHANGELOG.md
+++ b/packages/rsc/CHANGELOG.md
@@ -2,21 +2,17 @@
 
 ## v0.2.0 (2025-05-12)
 
-- fix(rsc): handle html escape and binary data in ssr rsc payload ([#839](https://github.com/hi-ogawa/vite-plugins/pull/839))
 - feat(rsc): apply tree-shaking to all client references (2nd approach) ([#838](https://github.com/hi-ogawa/vite-plugins/pull/838))
-- refactor(rsc): simplify client reference mapping ([#836](https://github.com/hi-ogawa/vite-plugins/pull/836))
-- chore(rsc): add __nojs debug ([#835](https://github.com/hi-ogawa/vite-plugins/pull/835))
 - feat(rsc): support nonce ([#813](https://github.com/hi-ogawa/vite-plugins/pull/813))
-- chore(rsc): tweak examples ([#833](https://github.com/hi-ogawa/vite-plugins/pull/833))
-- fix(rsc): wrap virtual to  workaround module runner entry issues ([#832](https://github.com/hi-ogawa/vite-plugins/pull/832))
-- refactor(rsc)!: remove `entries.css` ([#831](https://github.com/hi-ogawa/vite-plugins/pull/831))
-- refactor(rsc): client reference ssr preinit/preload via proxy and remove `prepareDestination` ([#828](https://github.com/hi-ogawa/vite-plugins/pull/828))
-- test(rsc): test client reference css without ssr ([#829](https://github.com/hi-ogawa/vite-plugins/pull/829))
-- test(rsc): test server restart ([#827](https://github.com/hi-ogawa/vite-plugins/pull/827))
-- refactor(rsc): tweak asset links api ([#826](https://github.com/hi-ogawa/vite-plugins/pull/826))
 - feat(rsc): support css in rsc environment ([#825](https://github.com/hi-ogawa/vite-plugins/pull/825))
 - feat(rsc): support css in client references ([#823](https://github.com/hi-ogawa/vite-plugins/pull/823))
+- fix(rsc): handle html escape and binary data in ssr rsc payload ([#839](https://github.com/hi-ogawa/vite-plugins/pull/839))
+- fix(rsc): wrap virtual to workaround module runner entry issues ([#832](https://github.com/hi-ogawa/vite-plugins/pull/832))
 - fix(rsc): scan build in two environments ([#820](https://github.com/hi-ogawa/vite-plugins/pull/820))
+- refactor(rsc): simplify client reference mapping ([#836](https://github.com/hi-ogawa/vite-plugins/pull/836))
+- refactor(rsc)!: remove `entries.css` ([#831](https://github.com/hi-ogawa/vite-plugins/pull/831))
+- refactor(rsc): client reference ssr preinit/preload via proxy and remove `prepareDestination` ([#828](https://github.com/hi-ogawa/vite-plugins/pull/828))
+- refactor(rsc): tweak asset links api ([#826](https://github.com/hi-ogawa/vite-plugins/pull/826))
 
 ## v0.1.1 (2025-05-07)
 

--- a/packages/rsc/CHANGELOG.md
+++ b/packages/rsc/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## v0.2.0 (2025-05-12)
+
+- fix(rsc): handle html escape and binary data in ssr rsc payload ([#839](https://github.com/hi-ogawa/vite-plugins/pull/839))
+- feat(rsc): apply tree-shaking to all client references (2nd approach) ([#838](https://github.com/hi-ogawa/vite-plugins/pull/838))
+- refactor(rsc): simplify client reference mapping ([#836](https://github.com/hi-ogawa/vite-plugins/pull/836))
+- chore(rsc): add __nojs debug ([#835](https://github.com/hi-ogawa/vite-plugins/pull/835))
+- feat(rsc): support nonce ([#813](https://github.com/hi-ogawa/vite-plugins/pull/813))
+- chore(rsc): tweak examples ([#833](https://github.com/hi-ogawa/vite-plugins/pull/833))
+- fix(rsc): wrap virtual to  workaround module runner entry issues ([#832](https://github.com/hi-ogawa/vite-plugins/pull/832))
+- refactor(rsc)!: remove `entries.css` ([#831](https://github.com/hi-ogawa/vite-plugins/pull/831))
+- refactor(rsc): client reference ssr preinit/preload via proxy and remove `prepareDestination` ([#828](https://github.com/hi-ogawa/vite-plugins/pull/828))
+- test(rsc): test client reference css without ssr ([#829](https://github.com/hi-ogawa/vite-plugins/pull/829))
+- test(rsc): test server restart ([#827](https://github.com/hi-ogawa/vite-plugins/pull/827))
+- refactor(rsc): tweak asset links api ([#826](https://github.com/hi-ogawa/vite-plugins/pull/826))
+- feat(rsc): support css in rsc environment ([#825](https://github.com/hi-ogawa/vite-plugins/pull/825))
+- feat(rsc): support css in client references ([#823](https://github.com/hi-ogawa/vite-plugins/pull/823))
+- fix(rsc): scan build in two environments ([#820](https://github.com/hi-ogawa/vite-plugins/pull/820))
+
 ## v0.1.1 (2025-05-07)
 
 - fix: statically import client references virtual ([#815](https://github.com/hi-ogawa/vite-plugins/pull/815))

--- a/packages/rsc/package.json
+++ b/packages/rsc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/vite-rsc",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "homepage": "https://github.com/hi-ogawa/vite-plugins/tree/main/packages/rsc",
   "repository": {
     "type": "git",


### PR DESCRIPTION
FOUC happens on stackblitz probably because async local storage is not implemented properly on web container :sob: 
https://stackblitz.com/github/hi-ogawa/vite-plugins/tree/05-12-chore_release_v0.2.0/packages/rsc/examples/basic?file=README.md