### PR TITLE
fix(rsc): add browser entry to  `optimizeDeps.entries`

### DIFF
--- a/packages/rsc/examples/basic/vite.config.ts
+++ b/packages/rsc/examples/basic/vite.config.ts
@@ -13,8 +13,8 @@ export default defineConfig({
     react(),
     rsc({
       entries: {
-        browser: "/src/client.tsx",
-        rsc: "/src/server.tsx",
+        browser: "./src/client.tsx",
+        rsc: "./src/server.tsx",
         ssr: "@hiogawa/vite-rsc/extra/ssr",
       },
     }),

--- a/packages/rsc/examples/hono/vite.config.ts
+++ b/packages/rsc/examples/hono/vite.config.ts
@@ -8,8 +8,8 @@ export default defineConfig({
     react(),
     rsc({
       entries: {
-        browser: "/src/client.tsx",
-        rsc: "/src/server.tsx",
+        browser: "./src/client.tsx",
+        rsc: "./src/server.tsx",
         ssr: "@hiogawa/vite-rsc/extra/ssr",
       },
     }),

--- a/packages/rsc/examples/react-router/vite.config.ts
+++ b/packages/rsc/examples/react-router/vite.config.ts
@@ -14,13 +14,10 @@ export default defineConfig({
     react(),
     rsc({
       entries: {
-        browser: "/src/entry.browser.tsx",
-        ssr: "/src/entry.ssr.tsx",
-        rsc: "/src/entry.rsc.tsx",
+        browser: "./src/entry.browser.tsx",
+        ssr: "./src/entry.ssr.tsx",
+        rsc: "./src/entry.rsc.tsx",
       },
     }),
   ],
-  optimizeDeps: {
-    include: ["react-router"],
-  },
 }) as any;

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -411,15 +411,15 @@ export default function vitePluginRsc({
       // https://github.com/vitejs/vite/issues/19975
       name: "rsc:virtual-entries",
       enforce: "pre",
-      async resolveId(source) {
+      async resolveId(source, _importer, options) {
         if (source === "virtual:vite-rsc/entry-browser-inner") {
-          return this.resolve(entries.browser);
+          return this.resolve(entries.browser, undefined, options);
         }
         if (source === ENTRIES.rsc) {
-          return this.resolve(entries.rsc);
+          return this.resolve(entries.rsc, undefined, options);
         }
         if (source === ENTRIES.ssr) {
-          return this.resolve(entries.ssr);
+          return this.resolve(entries.ssr, undefined, options);
         }
       },
     },

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -79,6 +79,9 @@ export default function vitePluginRsc({
                 },
               },
               optimizeDeps: {
+                // NOTE: this needs to be a valid file path
+                // e.g. relative `./src/file` or absolute `(abs-path-roo)/src/file`
+                // but not root-absolute path `/src/file`.
                 entries: [entries.browser],
                 include: [
                   "react-dom/client",

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -79,7 +79,7 @@ export default function vitePluginRsc({
                 },
               },
               optimizeDeps: {
-                entries: [ENTRIES.browser],
+                entries: [entries.browser],
                 include: [
                   "react-dom/client",
                   "react-server-dom-webpack/client.browser",
@@ -399,10 +399,10 @@ export default function vitePluginRsc({
           window.$RefreshReg$ = () => {};
           window.$RefreshSig$ = () => (type) => type;
           window.__vite_plugin_react_preamble_installed__ = true;
-          await import(${JSON.stringify(entries.browser)});
+          await import("virtual:vite-rsc/entry-browser-inner");
         `;
       } else {
-        code += `import ${JSON.stringify(entries.browser)};\n`;
+        code += `import "virtual:vite-rsc/entry-browser-inner";\n`;
       }
       return code;
     }),
@@ -411,12 +411,15 @@ export default function vitePluginRsc({
       // https://github.com/vitejs/vite/issues/19975
       name: "rsc:virtual-entries",
       enforce: "pre",
-      resolveId(source, importer, options) {
+      async resolveId(source) {
+        if (source === "virtual:vite-rsc/entry-browser-inner") {
+          return this.resolve(entries.browser);
+        }
         if (source === ENTRIES.rsc) {
-          return this.resolve(entries.rsc, importer, options);
+          return this.resolve(entries.rsc);
         }
         if (source === ENTRIES.ssr) {
-          return this.resolve(entries.ssr, importer, options);
+          return this.resolve(entries.ssr);
         }
       },
     },

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -79,6 +79,7 @@ export default function vitePluginRsc({
                 },
               },
               optimizeDeps: {
+                entries: [ENTRIES.browser],
                 include: [
                   "react-dom/client",
                   "react-server-dom-webpack/client.browser",


### PR DESCRIPTION
Probably this is more framework concern, so we don't have to bother this since they would want to manage `optimizeDeps.entries` based on their own convention.

As a general rsc solution, what we want to actually achieve is something like crawled client references to eager trigger scan during `holdUntilCrawlEnd` phase, so there's no lazy discover happens. Is it possible? (for example, triggering `transformRequest(clientReference)` early before or during first rendering? But I guess this can work as simple as crawling `"use client"` files in local directory and put them into `optimizeDeps.entries` instead.)