### PR TITLE
chore: vendor react-server-dom

### DIFF
--- a/packages/rsc/examples/basic/README.md
+++ b/packages/rsc/examples/basic/README.md
@@ -3,3 +3,7 @@
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/hi-ogawa/vite-plugins/tree/main/packages/rsc/examples/basic)
 
 https://vite-rsc-basic.hiro18181.workers.dev
+
+```sh
+npx giget gh:hi-ogawa/vite-plugins/packages/rsc/examples/basic my-app
+```

--- a/packages/rsc/package.json
+++ b/packages/rsc/package.json
@@ -24,12 +24,13 @@
     "vitefu": "^1.0.5"
   },
   "devDependencies": {
+    "react-server-dom-vite": "*",
     "rsc-html-stream": "^0.0.6"
   },
   "peerDependencies": {
     "react": "*",
     "react-dom": "*",
-    "react-server-dom-vite": "*",
     "vite": "*"
-  }
+  },
+  "bundleDependencies": ["react-server-dom-vite"]
 }

--- a/packages/rsc/tsdown.config.ts
+++ b/packages/rsc/tsdown.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
     "src/extra/rsc.tsx",
   ],
   format: ["esm"],
-  external: [/^virtual:/],
+  external: [/^virtual:/, /^react-server-dom-vite\//],
   dts: {
     sourceMap: process.argv.slice(2).includes("--sourcemap"),
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -559,9 +559,6 @@ importers:
       react-dom:
         specifier: 0.0.0-experimental-197d6a04-20250424
         version: 0.0.0-experimental-197d6a04-20250424(react@0.0.0-experimental-197d6a04-20250424)
-      react-server-dom-vite:
-        specifier: file:../../react-server-dom-vite-19.1.0.tgz
-        version: file:react-server-dom-vite-19.1.0.tgz(react-dom@0.0.0-experimental-197d6a04-20250424(react@0.0.0-experimental-197d6a04-20250424))(react@0.0.0-experimental-197d6a04-20250424)
       vite:
         specifier: ^6.3.2
         version: 6.3.2(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
@@ -569,6 +566,9 @@ importers:
         specifier: ^1.0.5
         version: 1.0.5(vite@6.3.2(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
     devDependencies:
+      react-server-dom-vite:
+        specifier: file:../../react-server-dom-vite-19.1.0.tgz
+        version: file:react-server-dom-vite-19.1.0.tgz(react-dom@0.0.0-experimental-197d6a04-20250424(react@0.0.0-experimental-197d6a04-20250424))(react@0.0.0-experimental-197d6a04-20250424)
       rsc-html-stream:
         specifier: ^0.0.6
         version: 0.0.6


### PR DESCRIPTION
Wondering whether `bundleDependencies` would do a trick.

Since we need to keep both `development` and `production` version of react packages, it's a bit difficult to bundle them normally as a library.

Oh well, this seems like a no-go

```
$ pnpm -C packages/rsc pack
 ERR_PNPM_BUNDLED_DEPENDENCIES_WITHOUT_HOISTED  bundleDependencies does not work with node-linker=isolated

Add node-linker=hoisted to .npmrc or delete bundleDependencies from the root package.json to resolve this error
```