### PR TITLE
perf(rsc): preload client reference deps before non-cached import

### DIFF
--- a/packages/rsc/examples/basic/README.md
+++ b/packages/rsc/examples/basic/README.md
@@ -3,3 +3,7 @@
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/hi-ogawa/vite-plugins/tree/main/packages/rsc/examples/basic)
 
 https://vite-rsc-basic.hiro18181.workers.dev
+
+```sh
+npx giget gh:hi-ogawa/vite-plugins/packages/rsc/examples/basic my-app
+```


### PR DESCRIPTION
I was wondering about the consequence of delaying "prepare destination" to the getter, but I realized we can just kick off early for initial async import as it's not cached.