### PR TITLE
chore(rsc): fix example on stackblitz

### DIFF
--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -302,12 +302,12 @@ test("ssr rsc payload encoding", async ({ page }) => {
   await page.goto("./");
   await waitForHydration(page);
   await expect(page.getByTestId("ssr-rsc-payload")).toHaveText(
-    "test-payload: test1: true, test2: true, test3: true, test4: true",
+    "test-payload: test1: true, test2: true, test3: false, test4: true",
   );
 
-  await page.goto("./?test-skip-binary");
+  await page.goto("./?test-binary");
   await waitForHydration(page);
   await expect(page.getByTestId("ssr-rsc-payload")).toHaveText(
-    "test-payload: test1: true, test2: true, test3: false, test4: true",
+    "test-payload: test1: true, test2: true, test3: true, test4: true",
   );
 });

--- a/packages/rsc/examples/basic/src/routes/root.tsx
+++ b/packages/rsc/examples/basic/src/routes/root.tsx
@@ -62,9 +62,7 @@ export function Root(props: { url: URL }) {
         <TestSuspense url={props.url} />
         <TestActionFromClient />
         <TestUseActionState />
-        <TestPayload
-          skipBinary={props.url.searchParams.has("test-skip-binary")}
-        />
+        <TestPayload testBinary={props.url.searchParams.has("test-binary")} />
       </body>
     </html>
   );
@@ -110,7 +108,7 @@ function TestSuspense(props: { url: URL }) {
   return <a href="?test-suspense=1000">test-suspense</a>;
 }
 
-function TestPayload(props: { skipBinary?: boolean }) {
+function TestPayload(props: { testBinary?: boolean }) {
   return (
     <div data-testid="ssr-rsc-payload">
       test-payload:{" "}
@@ -118,7 +116,9 @@ function TestPayload(props: { skipBinary?: boolean }) {
         test1={"🙂"}
         test2={"<script>throw new Error('boom')</script>"}
         // reverse to have non-utf8 binary data
-        test3={props.skipBinary ? "" : new TextEncoder().encode("🔥").reverse()}
+        test3={
+          props.testBinary ? new TextEncoder().encode("🔥").reverse() : null
+        }
         test4={"&><\u2028\u2029"}
       />
     </div>


### PR DESCRIPTION
Part of https://github.com/hi-ogawa/vite-plugins/issues/852.

It looks like this is stackblitz bug, so just hide it from the default demo for now.