### PR TITLE
refactor(rsc)!: vendor react-server-dom

### DIFF
--- a/packages/react-server-next/README.md
+++ b/packages/react-server-next/README.md
@@ -12,8 +12,7 @@ Add following dependencies on Next.js project
     "@hiogawa/react-server": "latest",
     "next": "npm:@hiogawa/react-server-next@latest",
     "react": "latest",
-    "react-dom": "latest",
-    "react-server-dom-webpack": "latest"
+    "react-dom": "latest"
   },
   "devDependencies": {
     "vite": "latest"

--- a/packages/react-server/examples/basic/package.json
+++ b/packages/react-server/examples/basic/package.json
@@ -31,7 +31,6 @@
     "@hiogawa/test-dep-use-client": "file:deps/use-client",
     "react": "latest",
     "react-dom": "latest",
-    "react-server-dom-webpack": "latest",
     "react-tweet": "^3.2.1",
     "react-wrap-balancer": "^1.1.1",
     "shiki": "^3.0.0",

--- a/packages/react-server/misc/overrides.mjs
+++ b/packages/react-server/misc/overrides.mjs
@@ -8,6 +8,7 @@ const deps = ["react-server", "transforms", "vite-plugin-ssr-middleware"];
 const overrides = Object.fromEntries(
   deps.map((dep) => [`@hiogawa/${dep}`, `file:${resolve(packages, dep)}`]),
 );
+overrides["@hiogawa/vite-rsc"] = `file:${resolve(packages, "rsc")}`;
 
 editJson(argv[2], (pkg) => {
   Object.assign(((pkg.pnpm ??= {}).overrides ??= {}), overrides);

--- a/packages/react-server/package.json
+++ b/packages/react-server/package.json
@@ -42,20 +42,19 @@
   },
   "dependencies": {
     "@hiogawa/transforms": "workspace:*",
+    "@hiogawa/vite-rsc": "workspace:*",
     "es-module-lexer": "^1.6.0",
     "fast-glob": "^3.3.3",
     "vitefu": "^1.0.5"
   },
   "devDependencies": {
     "@edge-runtime/cookies": "^6.0.0",
-    "@hiogawa/vite-rsc": "workspace:*",
     "@tanstack/history": "^1.99.13",
     "rsc-html-stream": "^0.0.6"
   },
   "peerDependencies": {
     "react": "*",
     "react-dom": "*",
-    "react-server-dom-webpack": "*",
     "vite": "*"
   }
 }

--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -9,6 +9,7 @@ import {
   build,
   createBuilder,
   createServerModuleRunner,
+  defaultServerConditions,
   isCSSRequest,
 } from "vite";
 import { crawlFrameworkPkgs } from "vitefu";
@@ -161,11 +162,12 @@ export function vitePluginReactServer(
             "react/jsx-dev-runtime",
             "react-dom",
             "react-dom/client",
-            "react-server-dom-webpack/client.browser",
+            "@hiogawa/react-server > @hiogawa/vite-rsc/react/browser",
           ],
         },
         ssr: {
           noExternal: ["@hiogawa/react-server"],
+          external: ["@hiogawa/vite-rsc"],
           optimizeDeps: {
             exclude: ["@hiogawa/react-server"],
           },
@@ -190,7 +192,7 @@ export function vitePluginReactServer(
           rsc: {
             // external and optimizeDeps are configured by `serverDepsConfigPlugin`
             resolve: {
-              conditions: ["react-server"],
+              conditions: ["react-server", ...defaultServerConditions],
             },
             build: {
               outDir: path.join(outDir, "rsc"),
@@ -557,8 +559,7 @@ function serverDepsConfigPlugin(): Plugin {
             "react",
             "react/jsx-runtime",
             "react/jsx-dev-runtime",
-            "react-server-dom-webpack/server.edge",
-            "react-server-dom-webpack/client.edge",
+            "@hiogawa/react-server > @hiogawa/vite-rsc/react/rsc",
           ],
         },
       };

--- a/packages/react-server/src/runtime/browser.ts
+++ b/packages/react-server/src/runtime/browser.ts
@@ -1,1 +1,5 @@
-export * from "../features/server-action/browser";
+export {
+  callServer,
+  createServerReference,
+  findSourceMapURL,
+} from "../features/server-action/browser";

--- a/packages/react-server/src/runtime/ssr.ts
+++ b/packages/react-server/src/runtime/ssr.ts
@@ -1,1 +1,5 @@
-export * from "../features/server-action/ssr";
+export {
+  callServer,
+  createServerReference,
+  findSourceMapURL,
+} from "../features/server-action/ssr";

--- a/packages/rsc/examples/basic-core/package.json
+++ b/packages/rsc/examples/basic-core/package.json
@@ -9,8 +9,7 @@
   "dependencies": {
     "@hiogawa/vite-rsc": "latest",
     "react": "latest",
-    "react-dom": "latest",
-    "react-server-dom-webpack": "latest"
+    "react-dom": "latest"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.4",

--- a/packages/rsc/examples/basic-core/vite.config.ts
+++ b/packages/rsc/examples/basic-core/vite.config.ts
@@ -96,17 +96,27 @@ export default defineConfig({
     },
   ],
   environments: {
+    client: {
+      optimizeDeps: {
+        include: ["@hiogawa/vite-rsc/vendor/react-server-dom/client.browser"],
+      },
+    },
+    ssr: {
+      resolve: {
+        external: ["@hiogawa/vite-rsc/vendor/react-server-dom/client.edge"],
+      },
+    },
     rsc: {
       resolve: {
         conditions: ["react-server", ...defaultServerConditions],
-        noExternal: ["react", "react-dom", "react-server-dom-webpack"],
+        noExternal: true,
       },
       optimizeDeps: {
         include: [
           "react",
           "react/jsx-runtime",
           "react/jsx-dev-runtime",
-          "react-server-dom-webpack/server.edge",
+          "@hiogawa/vite-rsc/vendor/react-server-dom/server.edge",
         ],
       },
     },

--- a/packages/rsc/examples/basic/package.json
+++ b/packages/rsc/examples/basic/package.json
@@ -16,8 +16,7 @@
   "dependencies": {
     "@hiogawa/vite-rsc": "latest",
     "react": "latest",
-    "react-dom": "latest",
-    "react-server-dom-webpack": "latest"
+    "react-dom": "latest"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.4",

--- a/packages/rsc/examples/hono-core/package.json
+++ b/packages/rsc/examples/hono-core/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "@hiogawa/vite-rsc": "workspace:*",
     "@hono/node-server": "^1.14.1",
-    "hono": "^4.7.5",
-    "react-server-dom-webpack": "latest"
+    "hono": "^4.7.5"
   }
 }

--- a/packages/rsc/examples/hono-core/vite.config.ts
+++ b/packages/rsc/examples/hono-core/vite.config.ts
@@ -53,18 +53,21 @@ export default defineConfig({
       build: {
         outDir: "dist/client",
       },
+      optimizeDeps: {
+        include: ["@hiogawa/vite-rsc/vendor/react-server-dom/client.browser"],
+      },
     },
     ssr: {
       resolve: {
         conditions: ["react-server", ...defaultServerConditions],
-        noExternal: ["react", "react-dom", "react-server-dom-webpack"],
+        noExternal: true,
       },
       optimizeDeps: {
         include: [
           "react",
           "react/jsx-runtime",
           "react/jsx-dev-runtime",
-          "react-server-dom-webpack/server.edge",
+          "@hiogawa/vite-rsc/vendor/react-server-dom/server.edge",
         ],
       },
       build: {

--- a/packages/rsc/examples/react-router/package.json
+++ b/packages/rsc/examples/react-router/package.json
@@ -14,8 +14,7 @@
     "@hiogawa/vite-rsc": "latest",
     "react": "latest",
     "react-dom": "latest",
-    "react-router": "0.0.0-experimental-f2b42587c",
-    "react-server-dom-webpack": "latest"
+    "react-router": "0.0.0-experimental-f2b42587c"
   },
   "devDependencies": {
     "@react-router/dev": "0.0.0-experimental-f2b42587c",

--- a/packages/rsc/package.json
+++ b/packages/rsc/package.json
@@ -26,12 +26,12 @@
     "vitefu": "^1.0.5"
   },
   "devDependencies": {
+    "react-server-dom-webpack": "*",
     "rsc-html-stream": "^0.0.6"
   },
   "peerDependencies": {
     "react": "*",
     "react-dom": "*",
-    "react-server-dom-webpack": "*",
     "vite": "*"
   }
 }

--- a/packages/rsc/src/core/plugin.ts
+++ b/packages/rsc/src/core/plugin.ts
@@ -13,5 +13,20 @@ export default function vitePluginRscCore(): Plugin[] {
         }
       },
     },
+    {
+      // commonjsOptions needs to be tweaked when this is a linked dep
+      // since otherwise vendored cjs doesn't work.
+      name: "rsc:workaround-linked-dep",
+      apply: () => !import.meta.url.includes("/node_modules/"),
+      configEnvironment() {
+        return {
+          build: {
+            commonjsOptions: {
+              include: [/\/node_modules\//, /\/vendor\/react-server-dom\//],
+            },
+          },
+        };
+      },
+    },
   ];
 }

--- a/packages/rsc/src/core/rsc.ts
+++ b/packages/rsc/src/core/rsc.ts
@@ -9,7 +9,7 @@ import {
 } from "./shared";
 
 // @ts-ignore
-import * as ReactServer from "react-server-dom-webpack/server.edge";
+import * as ReactServer from "@hiogawa/vite-rsc/vendor/react-server-dom/server.edge";
 
 let init = false;
 let requireModule!: (id: string) => unknown;

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -93,7 +93,7 @@ export default function vitePluginRsc({
                 entries: [entries.browser],
                 include: [
                   "react-dom/client",
-                  "react-server-dom-webpack/client.browser",
+                  `${PKG_NAME}/vendor/react-server-dom/client.browser`,
                 ],
                 exclude: [PKG_NAME],
               },
@@ -107,6 +107,7 @@ export default function vitePluginRsc({
               },
               resolve: {
                 noExternal: [PKG_NAME],
+                external: [`${PKG_NAME}/vendor/react-server-dom/client.edge`],
               },
               optimizeDeps: {
                 exclude: [PKG_NAME],
@@ -119,7 +120,7 @@ export default function vitePluginRsc({
                 noExternal: [
                   "react",
                   "react-dom",
-                  "react-server-dom-webpack",
+                  `${PKG_NAME}/vendor/react-server-dom/server.edge`,
                   PKG_NAME,
                 ],
               },
@@ -128,8 +129,8 @@ export default function vitePluginRsc({
                   "react",
                   "react/jsx-runtime",
                   "react/jsx-dev-runtime",
-                  "react-server-dom-webpack/server.edge",
-                  "react-server-dom-webpack/client.edge",
+                  `${PKG_NAME}/vendor/react-server-dom/server.edge`,
+                  `${PKG_NAME}/vendor/react-server-dom/client.edge`,
                 ],
                 exclude: [PKG_NAME],
               },
@@ -170,11 +171,7 @@ export default function vitePluginRsc({
           root: process.cwd(),
           isBuild: env.command === "build",
           isFrameworkPkgByJson(pkgJson) {
-            if (
-              [PKG_NAME, "react-dom", "react-server-dom-webpack"].includes(
-                pkgJson.name,
-              )
-            ) {
+            if ([PKG_NAME, "react-dom"].includes(pkgJson.name)) {
               return;
             }
             const deps = pkgJson["peerDependencies"];

--- a/packages/rsc/src/react/browser.ts
+++ b/packages/rsc/src/react/browser.ts
@@ -1,5 +1,5 @@
 // @ts-ignore
-import * as ReactClient from "react-server-dom-webpack/client.browser";
+import * as ReactClient from "@hiogawa/vite-rsc/vendor/react-server-dom/client.browser";
 import type { CallServerCallback } from "../types";
 
 export { setRequireModule } from "../core/browser";

--- a/packages/rsc/src/react/rsc.ts
+++ b/packages/rsc/src/react/rsc.ts
@@ -1,7 +1,7 @@
 // @ts-ignore
-import * as ReactServer from "@hiogawa/vite-rsc/vendor/react-server-dom/client.edge";
+import * as ReactClient from "@hiogawa/vite-rsc/vendor/react-server-dom/client.edge";
 // @ts-ignore
-import * as ReactClient from "@hiogawa/vite-rsc/vendor/react-server-dom/server.edge";
+import * as ReactServer from "@hiogawa/vite-rsc/vendor/react-server-dom/server.edge";
 import type { ReactFormState } from "react-dom/client";
 import {
   createClientManifest,

--- a/packages/rsc/src/react/rsc.ts
+++ b/packages/rsc/src/react/rsc.ts
@@ -1,8 +1,8 @@
+// @ts-ignore
+import * as ReactServer from "@hiogawa/vite-rsc/vendor/react-server-dom/client.edge";
+// @ts-ignore
+import * as ReactClient from "@hiogawa/vite-rsc/vendor/react-server-dom/server.edge";
 import type { ReactFormState } from "react-dom/client";
-// @ts-ignore
-import * as ReactClient from "react-server-dom-webpack/client.edge";
-// @ts-ignore
-import * as ReactServer from "react-server-dom-webpack/server.edge";
 import {
   createClientManifest,
   createServerDecodeClientManifest,

--- a/packages/rsc/src/react/ssr.ts
+++ b/packages/rsc/src/react/ssr.ts
@@ -1,5 +1,5 @@
 // @ts-ignore
-import * as ReactClient from "react-server-dom-webpack/client.edge";
+import * as ReactClient from "@hiogawa/vite-rsc/vendor/react-server-dom/client.edge";
 import { createServerConsumerManifest } from "../core/ssr";
 
 export { setRequireModule } from "../core/ssr";

--- a/packages/rsc/tsdown.config.ts
+++ b/packages/rsc/tsdown.config.ts
@@ -1,4 +1,6 @@
+import fs from "node:fs";
 import { defineConfig } from "tsdown";
+import pkg from "./package.json" with { type: "json" };
 
 export default defineConfig({
   entry: [
@@ -19,9 +21,27 @@ export default defineConfig({
     "src/extra/rsc.tsx",
   ],
   format: ["esm"],
-  external: [/^virtual:/],
+  external: [/^virtual:/, new RegExp(`^${pkg.name}/`)],
   dts: {
     sourceMap: process.argv.slice(2).includes("--sourcemap"),
   },
   bundleDts: false,
+  plugins: [
+    {
+      name: "vendor-react-server-dom",
+      buildStart() {
+        fs.rmSync("./dist/vendor/", { recursive: true, force: true });
+        fs.mkdirSync("./dist/vendor", { recursive: true });
+        fs.cpSync(
+          "./node_modules/react-server-dom-webpack",
+          "./dist/vendor/react-server-dom",
+          { recursive: true, dereference: true },
+        );
+        fs.rmSync("./dist/vendor/react-server-dom/node_modules", {
+          recursive: true,
+          force: true,
+        });
+      },
+    },
+  ],
 }) as any;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ importers:
       '@hiogawa/transforms':
         specifier: workspace:*
         version: link:../transforms
+      '@hiogawa/vite-rsc':
+        specifier: workspace:*
+        version: link:../rsc
       es-module-lexer:
         specifier: ^1.6.0
         version: 1.7.0
@@ -161,9 +164,6 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
-      react-server-dom-webpack:
-        specifier: ^19.1.0
-        version: 19.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(webpack@5.93.0(@swc/core@1.11.29)(esbuild@0.24.2))
       vite:
         specifier: ^6.3.2
         version: 6.3.2(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
@@ -174,9 +174,6 @@ importers:
       '@edge-runtime/cookies':
         specifier: ^6.0.0
         version: 6.0.0
-      '@hiogawa/vite-rsc':
-        specifier: workspace:*
-        version: link:../rsc
       '@tanstack/history':
         specifier: ^1.99.13
         version: 1.99.13
@@ -256,9 +253,6 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
-      react-server-dom-webpack:
-        specifier: ^19.1.0
-        version: 19.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(webpack@5.93.0(@swc/core@1.11.29)(esbuild@0.24.2))
       react-tweet:
         specifier: ^3.2.1
         version: 3.2.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -555,9 +555,6 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
-      react-server-dom-webpack:
-        specifier: ^19.1.0
-        version: 19.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(webpack@5.93.0(@swc/core@1.11.29)(esbuild@0.24.2))
       vite:
         specifier: ^6.3.2
         version: 6.3.2(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
@@ -565,6 +562,9 @@ importers:
         specifier: ^1.0.5
         version: 1.0.5(vite@6.3.2(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
     devDependencies:
+      react-server-dom-webpack:
+        specifier: ^19.1.0
+        version: 19.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(webpack@5.93.0(@swc/core@1.11.29)(esbuild@0.24.2))
       rsc-html-stream:
         specifier: ^0.0.6
         version: 0.0.6
@@ -580,9 +580,6 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
-      react-server-dom-webpack:
-        specifier: ^19.1.0
-        version: 19.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(webpack@5.93.0(@swc/core@1.11.29)(esbuild@0.24.2))
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.1.4
@@ -617,9 +614,6 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
-      react-server-dom-webpack:
-        specifier: ^19.1.0
-        version: 19.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(webpack@5.93.0(@swc/core@1.11.29)(esbuild@0.24.2))
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.1.4
@@ -660,9 +654,6 @@ importers:
       hono:
         specifier: ^4.7.5
         version: 4.7.5
-      react-server-dom-webpack:
-        specifier: ^19.1.0
-        version: 19.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(webpack@5.93.0(@swc/core@1.11.29)(esbuild@0.24.2))
 
   packages/rsc/examples/react-router:
     dependencies:
@@ -678,9 +669,6 @@ importers:
       react-router:
         specifier: 0.0.0-experimental-f2b42587c
         version: 0.0.0-experimental-f2b42587c(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react-server-dom-webpack:
-        specifier: ^19.1.0
-        version: 19.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(webpack@5.93.0(@swc/core@1.11.29)(esbuild@0.24.2))
     devDependencies:
       '@react-router/dev':
         specifier: 0.0.0-experimental-f2b42587c


### PR DESCRIPTION
- related https://github.com/hi-ogawa/vite-plugins/pull/851

As usual, why not just do it while `react-server-dom-webpack`?

_todo_

- [x] `@hiogawa/vite-rsc`
- [x] `@hiogawa/react-server` https://github.com/hi-ogawa/vite-plugins/pull/855