### PR TITLE
fix(rsc): fix `collectCssByUrl` error

### DIFF
--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -918,7 +918,8 @@ export function vitePluginRscCss({
     environment: DevEnvironment,
     entryUrl: string,
   ) {
-    const entryMod = await environment.moduleGraph.getModuleByUrl(entryUrl);
+    const resolved = await environment.moduleGraph.resolveUrl(entryUrl);
+    const entryMod = environment.moduleGraph.getModuleById(resolved![1]);
     return collectCss(environment, entryMod!.id!);
   }
 


### PR DESCRIPTION
Got this error when testing it on https://github.com/remix-run/react-router/tree/rsc/playground/rsc-vite

```
11:45:54 AM [vite] Internal server error: Cannot read properties of undefined (reading 'id')
      at collectCssByUrl (file:///home/hiroshi/code/others/react-router/node_modules/.pnpm/@hiogawa+vite-rsc@https+++pkg.pr.new+hi-ogawa+vite-plugins+@hiogawa+vite-rsc@854_react-dom@19_a3p7vxeff4cncze72c4kqjdrhi/node_modules/@hiogawa/vite-rsc/dist/plugin.js:613:43)
```

I don't see this locally, but the difference might be due to Vite version (6.2 in react-router, but 6.3 in this repo). Explicitly `moduleGraph.resolveUrl` seems to help, so let's just do that.