### PR TITLE
chore: tweak react-router example

### DIFF
--- a/packages/rsc/examples/react-router/package.json
+++ b/packages/rsc/examples/react-router/package.json
@@ -19,7 +19,6 @@
   },
   "devDependencies": {
     "@react-router/dev": "0.0.0-experimental-f1dd850aa",
-    "@react-router/fs-routes": "0.0.0-experimental-f1dd850aa",
     "@tailwindcss/typography": "^0.5.16",
     "@tailwindcss/vite": "^4.1.4",
     "@types/react": "latest",

--- a/packages/rsc/examples/react-router/package.json
+++ b/packages/rsc/examples/react-router/package.json
@@ -18,6 +18,8 @@
     "react-server-dom-webpack": "latest"
   },
   "devDependencies": {
+    "@react-router/dev": "0.0.0-experimental-f1dd850aa",
+    "@react-router/fs-routes": "0.0.0-experimental-f1dd850aa",
     "@tailwindcss/typography": "^0.5.16",
     "@tailwindcss/vite": "^4.1.4",
     "@types/react": "latest",

--- a/packages/rsc/examples/react-router/src/entry.rsc.tsx
+++ b/packages/rsc/examples/react-router/src/entry.rsc.tsx
@@ -12,7 +12,9 @@ import {
   type DecodeFormActionFunction,
   matchRSCServerRequest,
 } from "react-router/rsc";
-import { routes } from "./routes";
+
+// @ts-ignore
+import routes from "./routes?react-router-routes";
 
 initialize();
 

--- a/packages/rsc/examples/react-router/src/entry.rsc.tsx
+++ b/packages/rsc/examples/react-router/src/entry.rsc.tsx
@@ -10,30 +10,11 @@ import {
 import {
   type DecodeCallServerFunction,
   type DecodeFormActionFunction,
-  type ServerRouteObject,
   matchRSCServerRequest,
 } from "react-router/rsc";
+import { routes } from "./routes";
 
 initialize();
-
-const routes: ServerRouteObject[] = [
-  {
-    id: "root",
-    lazy: () => import("./routes/root"),
-    children: [
-      {
-        id: "home",
-        index: true,
-        lazy: () => import("./routes/home"),
-      },
-      {
-        id: "about",
-        path: "about",
-        lazy: () => import("./routes/about"),
-      },
-    ],
-  },
-];
 
 const decodeCallServer: DecodeCallServerFunction = async (actionId, reply) => {
   const args = await decodeReply(reply);

--- a/packages/rsc/examples/react-router/src/plugin.ts
+++ b/packages/rsc/examples/react-router/src/plugin.ts
@@ -13,16 +13,17 @@ export default function vitePluginReactRouter(): Plugin[] {
         if (id.endsWith("?react-router-routes")) {
           const imported = await runnerImport<any>(id);
           const appDirectory = path.dirname(id);
+          const routes = [
+            {
+              id: "root",
+              path: "",
+              file: path.resolve(appDirectory, imported.module.root),
+              children: imported.module.default,
+            },
+          ];
           const code = generateRoutesCode({
             appDirectory,
-            routes: [
-              {
-                id: "root",
-                path: "",
-                file: path.resolve(appDirectory, imported.module.root),
-                children: imported.module.default,
-              },
-            ],
+            routes,
           });
           return code;
         }
@@ -48,9 +49,8 @@ function generateRoutesCode(config: {
       continue;
     }
     code += "{";
-    code += `lazy: () => import(${JSON.stringify(
-      path.resolve(config.appDirectory, route.file),
-    )}),`;
+    // TODO: route-module transform
+    code += `lazy: () => import(${JSON.stringify(path.resolve(config.appDirectory, route.file))}),`;
     code += `id: ${JSON.stringify(route.id || createRouteId(route.file, config.appDirectory))},`;
     if (typeof route.path === "string") {
       code += `path: ${JSON.stringify(route.path)},`;

--- a/packages/rsc/examples/react-router/src/plugin.ts
+++ b/packages/rsc/examples/react-router/src/plugin.ts
@@ -1,0 +1,82 @@
+import path from "node:path";
+import type { RouteConfigEntry } from "@react-router/dev/routes";
+import { type Plugin, runnerImport } from "vite";
+
+// based on
+// https://github.com/jacob-ebey/parcel-plugin-react-router/blob/9385be813534537dfb0fe640a3e5c5607be3b61d/packages/resolver/src/resolver.ts
+
+export default function vitePluginReactRouter(): Plugin[] {
+  return [
+    {
+      name: "react-router-routes",
+      async load(id) {
+        if (id.endsWith("?react-router-routes")) {
+          const imported = await runnerImport<any>(id);
+          const appDirectory = path.dirname(id);
+          const code = generateRoutesCode({
+            appDirectory,
+            routes: [
+              {
+                id: "root",
+                path: "",
+                file: path.resolve(appDirectory, imported.module.root),
+                children: imported.module.default,
+              },
+            ],
+          });
+          return code;
+        }
+      },
+    },
+  ];
+}
+
+function generateRoutesCode(config: {
+  appDirectory: string;
+  routes: RouteConfigEntry[];
+}) {
+  let code = "export default [";
+  const closeRouteSymbol = Symbol("CLOSE_ROUTE");
+  let stack: Array<typeof closeRouteSymbol | RouteConfigEntry> = [
+    ...config.routes,
+  ];
+  while (stack.length > 0) {
+    const route = stack.pop();
+    if (!route) break;
+    if (route === closeRouteSymbol) {
+      code += "]},";
+      continue;
+    }
+    code += "{";
+    code += `lazy: () => import(${JSON.stringify(
+      path.resolve(config.appDirectory, route.file),
+    )}),`;
+    code += `id: ${JSON.stringify(route.id || createRouteId(route.file, config.appDirectory))},`;
+    if (typeof route.path === "string") {
+      code += `path: ${JSON.stringify(route.path)},`;
+    }
+    if (route.index) {
+      code += `index: true,`;
+    }
+    if (route.caseSensitive) {
+      code += `caseSensitive: true,`;
+    }
+    if (route.children) {
+      code += ["children:["];
+      stack.push(closeRouteSymbol);
+      stack.push(...[...route.children].reverse());
+    } else {
+      code += "},";
+    }
+  }
+  code += "];\n";
+
+  return code;
+}
+
+function createRouteId(file: string, appDirectory: string) {
+  return path
+    .relative(appDirectory, file)
+    .replace(/\\+/, "/")
+    .slice(0, -path.extname(file).length);
+}

--- a/packages/rsc/examples/react-router/src/routes.ts
+++ b/packages/rsc/examples/react-router/src/routes.ts
@@ -1,20 +1,8 @@
-import type { ServerRouteObject } from "react-router/rsc";
+import { type RouteConfig, index, route } from "@react-router/dev/routes";
 
-export const routes: ServerRouteObject[] = [
-  {
-    id: "root",
-    lazy: () => import("./routes/root"),
-    children: [
-      {
-        id: "home",
-        index: true,
-        lazy: () => import("./routes/home"),
-      },
-      {
-        id: "about",
-        path: "about",
-        lazy: () => import("./routes/about"),
-      },
-    ],
-  },
-];
+export default [
+  index("routes/home.tsx"),
+  route("about", "routes/about.tsx"),
+] satisfies RouteConfig;
+
+export const root = "./routes/root.tsx";

--- a/packages/rsc/examples/react-router/src/routes.ts
+++ b/packages/rsc/examples/react-router/src/routes.ts
@@ -1,0 +1,20 @@
+import type { ServerRouteObject } from "react-router/rsc";
+
+export const routes: ServerRouteObject[] = [
+  {
+    id: "root",
+    lazy: () => import("./routes/root"),
+    children: [
+      {
+        id: "home",
+        index: true,
+        lazy: () => import("./routes/home"),
+      },
+      {
+        id: "about",
+        path: "about",
+        lazy: () => import("./routes/about"),
+      },
+    ],
+  },
+];

--- a/packages/rsc/examples/react-router/vite.config.ts
+++ b/packages/rsc/examples/react-router/vite.config.ts
@@ -2,9 +2,9 @@ import rsc from "@hiogawa/vite-rsc/plugin";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
+import reactRouter from "./src/plugin";
 
 export default defineConfig({
-  appType: "custom",
   clearScreen: false,
   build: {
     minify: false,
@@ -12,6 +12,7 @@ export default defineConfig({
   plugins: [
     tailwindcss(),
     react(),
+    reactRouter(),
     rsc({
       entries: {
         browser: "./src/entry.browser.tsx",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -679,6 +679,12 @@ importers:
         specifier: ^19.1.0
         version: 19.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(webpack@5.93.0(@swc/core@1.11.21)(esbuild@0.24.2))
     devDependencies:
+      '@react-router/dev':
+        specifier: 0.0.0-experimental-f1dd850aa
+        version: 0.0.0-experimental-f1dd850aa(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(react-router@0.0.0-experimental-f1dd850aa(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.39.0)(tsx@4.19.3)(typescript@5.7.3)(vite@6.3.2(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(wrangler@4.13.0(@cloudflare/workers-types@4.20250423.0))(yaml@2.7.0)
+      '@react-router/fs-routes':
+        specifier: 0.0.0-experimental-f1dd850aa
+        version: 0.0.0-experimental-f1dd850aa(@react-router/dev@0.0.0-experimental-f1dd850aa(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(react-router@0.0.0-experimental-f1dd850aa(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.39.0)(tsx@4.19.3)(typescript@5.7.3)(vite@6.3.2(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(wrangler@4.13.0(@cloudflare/workers-types@4.20250423.0))(yaml@2.7.0))(typescript@5.7.3)
       '@tailwindcss/typography':
         specifier: ^0.5.16
         version: 0.5.16(tailwindcss@4.1.4)
@@ -2149,6 +2155,9 @@ packages:
     peerDependencies:
       rollup: '>=2'
 
+  '@mjackson/node-fetch-server@0.2.0':
+    resolution: {integrity: sha512-EMlH1e30yzmTpGLQjlFmaDAjyOeZhng1/XCd7DExR8PNAnG/G1tyruZxEoUe11ClnwGhGrtsdnyyUx1frSzjng==}
+
   '@mjackson/node-fetch-server@0.6.1':
     resolution: {integrity: sha512-9ZJnk/DJjt805uv5PPv11haJIW+HHf3YEEyVXv+8iLQxLD/iXA68FH220XoiTPBC4gCg5q+IMadDw8qPqlA5wg==}
 
@@ -2390,6 +2399,44 @@ packages:
   '@quansync/fs@0.1.2':
     resolution: {integrity: sha512-ezIadUb1aFhwJLd++WVqVpi9rnlX8vnd4ju7saPhwLHJN1mJgOv0puePTGV+FbtSnWtwoHDT8lAm4kagDZmpCg==}
     engines: {node: '>=20.0.0'}
+
+  '@react-router/dev@0.0.0-experimental-f1dd850aa':
+    resolution: {integrity: sha512-1IKac86OMse7cLtB1YYQNgIrbFc3p+WByVGFgBzQi/jrRoyMXQmmudiALfBqQBgALYG54mMoHuwwq95GVFSQcA==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@react-router/serve': ^0.0.0-experimental-f1dd850aa
+      react-router: ^0.0.0-experimental-f1dd850aa
+      typescript: ^5.1.0
+      vite: ^6.3.2
+      wrangler: ^3.28.2 || ^4.0.0
+    peerDependenciesMeta:
+      '@react-router/serve':
+        optional: true
+      typescript:
+        optional: true
+      wrangler:
+        optional: true
+
+  '@react-router/fs-routes@0.0.0-experimental-f1dd850aa':
+    resolution: {integrity: sha512-YHIfLoFzPnhhZcx3rezE9NZxhcfru4oJlj36issIwE04sjRrS7ISqmekewYUxV+kWyc8dkNjqP9qG6abPmLTJg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@react-router/dev': ^0.0.0-experimental-f1dd850aa
+      typescript: ^5.1.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@react-router/node@0.0.0-experimental-f1dd850aa':
+    resolution: {integrity: sha512-GpiOm5i8VF4+jVQE4CMtRQOsdU8id2HonDOAeHA3CPyATb2gACuVR0IDhW1nHJp+PYlTapVXWAmLz3hmR8rj7A==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react-router: 0.0.0-experimental-f1dd850aa
+      typescript: ^5.1.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@remix-run/dev@2.8.1':
     resolution: {integrity: sha512-qFt4jAsAJeIOyg6ngeSnTG/9Z5N9QJfeThP/8wRHc1crqYgTiEtcI3DZ8WlAXjVSF5emgn/ZZKqzLAI02OgMfQ==}
@@ -3296,6 +3343,9 @@ packages:
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  babel-dead-code-elimination@1.0.10:
+    resolution: {integrity: sha512-DV5bdJZTzZ0zn0DC24v3jD7Mnidh6xhKa4GfKCbq3sfW8kaWhDdZjP3i81geA8T33tdYqWKw4D3fVv0CwEgKVA==}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -5908,6 +5958,10 @@ packages:
     resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
     engines: {node: '>=14.0'}
 
+  undici@6.21.3:
+    resolution: {integrity: sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==}
+    engines: {node: '>=18.17'}
+
   unenv@2.0.0-rc.15:
     resolution: {integrity: sha512-J/rEIZU8w6FOfLNz/hNKsnY+fFHWnu9MH4yRbSZF3xbbGHovcetXPs7sD+9p8L6CeNC//I9bhRYAOsBt2u7/OA==}
 
@@ -6042,6 +6096,14 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  valibot@0.41.0:
+    resolution: {integrity: sha512-igDBb8CTYr8YTQlOKgaN9nSS0Be7z+WRuaeYqGf3Cjz3aKmSnqEmYnkfVjzIuumGqfHpa3fLIvMEAfhrpqN8ng==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   valibot@1.0.0:
     resolution: {integrity: sha512-1Hc0ihzWxBar6NGeZv7fPLY0QuxFMyxwYR2sF1Blu7Wq7EnremwY2W02tit2ij2VJT8HcSkHAQqmFfl77f73Yw==}
     peerDependencies:
@@ -6086,6 +6148,11 @@ packages:
   vite-node@1.6.1:
     resolution: {integrity: sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==}
     engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite-node@3.0.0-beta.2:
+    resolution: {integrity: sha512-ofTf6cfRdL30Wbl9n/BX81EyIR5s4PReLmSurrxQ+koLaWUNOEo8E0lCM53OJkb8vpa2URM2nSrxZsIFyvY1rg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
   vite-node@3.1.1:
@@ -7148,6 +7215,8 @@ snapshots:
       - acorn
       - supports-color
 
+  '@mjackson/node-fetch-server@0.2.0': {}
+
   '@mjackson/node-fetch-server@0.6.1': {}
 
   '@napi-rs/wasm-runtime@0.2.8':
@@ -7325,6 +7394,73 @@ snapshots:
   '@quansync/fs@0.1.2':
     dependencies:
       quansync: 0.2.10
+
+  '@react-router/dev@0.0.0-experimental-f1dd850aa(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(react-router@0.0.0-experimental-f1dd850aa(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.39.0)(tsx@4.19.3)(typescript@5.7.3)(vite@6.3.2(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(wrangler@4.13.0(@cloudflare/workers-types@4.20250423.0))(yaml@2.7.0)':
+    dependencies:
+      '@babel/core': 7.26.10
+      '@babel/generator': 7.27.0
+      '@babel/parser': 7.27.0
+      '@babel/plugin-syntax-decorators': 7.25.9(@babel/core@7.26.10)
+      '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.10)
+      '@babel/preset-typescript': 7.26.0(@babel/core@7.26.10)
+      '@babel/traverse': 7.27.0
+      '@babel/types': 7.27.0
+      '@npmcli/package-json': 4.0.1
+      '@react-router/node': 0.0.0-experimental-f1dd850aa(react-router@0.0.0-experimental-f1dd850aa(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.7.3)
+      arg: 5.0.2
+      babel-dead-code-elimination: 1.0.10
+      chokidar: 4.0.3
+      dedent: 1.5.3
+      es-module-lexer: 1.7.0
+      exit-hook: 2.2.1
+      fs-extra: 10.1.0
+      jsesc: 3.0.2
+      lodash: 4.17.21
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      prettier: 2.8.8
+      react-refresh: 0.14.2
+      react-router: 0.0.0-experimental-f1dd850aa(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      semver: 7.7.1
+      set-cookie-parser: 2.7.1
+      valibot: 0.41.0(typescript@5.7.3)
+      vite: 6.3.2(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
+      vite-node: 3.0.0-beta.2(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
+    optionalDependencies:
+      typescript: 5.7.3
+      wrangler: 4.13.0(@cloudflare/workers-types@4.20250423.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - bluebird
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  '@react-router/fs-routes@0.0.0-experimental-f1dd850aa(@react-router/dev@0.0.0-experimental-f1dd850aa(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(react-router@0.0.0-experimental-f1dd850aa(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.39.0)(tsx@4.19.3)(typescript@5.7.3)(vite@6.3.2(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(wrangler@4.13.0(@cloudflare/workers-types@4.20250423.0))(yaml@2.7.0))(typescript@5.7.3)':
+    dependencies:
+      '@react-router/dev': 0.0.0-experimental-f1dd850aa(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(react-router@0.0.0-experimental-f1dd850aa(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.39.0)(tsx@4.19.3)(typescript@5.7.3)(vite@6.3.2(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(wrangler@4.13.0(@cloudflare/workers-types@4.20250423.0))(yaml@2.7.0)
+      minimatch: 9.0.5
+    optionalDependencies:
+      typescript: 5.7.3
+
+  '@react-router/node@0.0.0-experimental-f1dd850aa(react-router@0.0.0-experimental-f1dd850aa(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.7.3)':
+    dependencies:
+      '@mjackson/node-fetch-server': 0.2.0
+      react-router: 0.0.0-experimental-f1dd850aa(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      source-map-support: 0.5.21
+      stream-slice: 0.1.2
+      undici: 6.21.3
+    optionalDependencies:
+      typescript: 5.7.3
 
   '@remix-run/dev@2.8.1(patch_hash=5f3898baeffa886bc4c107d8484475b85e481b37ce98d989a505a8500b02a4b3)(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.3)(typescript@5.7.3)(vite@6.3.2(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(wrangler@4.13.0(@cloudflare/workers-types@4.20250423.0))(yaml@2.7.0)':
     dependencies:
@@ -8369,6 +8505,15 @@ snapshots:
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  babel-dead-code-elimination@1.0.10:
+    dependencies:
+      '@babel/core': 7.26.10
+      '@babel/parser': 7.27.0
+      '@babel/traverse': 7.27.0
+      '@babel/types': 7.27.0
+    transitivePeerDependencies:
+      - supports-color
 
   bail@2.0.2: {}
 
@@ -11569,6 +11714,8 @@ snapshots:
     dependencies:
       '@fastify/busboy': 2.1.1
 
+  undici@6.21.3: {}
+
   unenv@2.0.0-rc.15:
     dependencies:
       defu: 6.1.4
@@ -11763,6 +11910,10 @@ snapshots:
       kleur: 4.1.5
       sade: 1.8.1
 
+  valibot@0.41.0(typescript@5.7.3):
+    optionalDependencies:
+      typescript: 5.7.3
+
   valibot@1.0.0(typescript@5.7.3):
     optionalDependencies:
       typescript: 5.7.3
@@ -11814,6 +11965,27 @@ snapshots:
       debug: 4.4.0
       pathe: 1.1.2
       picocolors: 1.1.1
+      vite: 6.3.2(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite-node@3.0.0-beta.2(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.0
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
       vite: 6.3.2(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/node'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -682,9 +682,6 @@ importers:
       '@react-router/dev':
         specifier: 0.0.0-experimental-f1dd850aa
         version: 0.0.0-experimental-f1dd850aa(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(react-router@0.0.0-experimental-f1dd850aa(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.39.0)(tsx@4.19.3)(typescript@5.7.3)(vite@6.3.2(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(wrangler@4.13.0(@cloudflare/workers-types@4.20250423.0))(yaml@2.7.0)
-      '@react-router/fs-routes':
-        specifier: 0.0.0-experimental-f1dd850aa
-        version: 0.0.0-experimental-f1dd850aa(@react-router/dev@0.0.0-experimental-f1dd850aa(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(react-router@0.0.0-experimental-f1dd850aa(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.39.0)(tsx@4.19.3)(typescript@5.7.3)(vite@6.3.2(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(wrangler@4.13.0(@cloudflare/workers-types@4.20250423.0))(yaml@2.7.0))(typescript@5.7.3)
       '@tailwindcss/typography':
         specifier: ^0.5.16
         version: 0.5.16(tailwindcss@4.1.4)
@@ -2416,16 +2413,6 @@ packages:
       typescript:
         optional: true
       wrangler:
-        optional: true
-
-  '@react-router/fs-routes@0.0.0-experimental-f1dd850aa':
-    resolution: {integrity: sha512-YHIfLoFzPnhhZcx3rezE9NZxhcfru4oJlj36issIwE04sjRrS7ISqmekewYUxV+kWyc8dkNjqP9qG6abPmLTJg==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      '@react-router/dev': ^0.0.0-experimental-f1dd850aa
-      typescript: ^5.1.0
-    peerDependenciesMeta:
-      typescript:
         optional: true
 
   '@react-router/node@0.0.0-experimental-f1dd850aa':
@@ -7444,13 +7431,6 @@ snapshots:
       - terser
       - tsx
       - yaml
-
-  '@react-router/fs-routes@0.0.0-experimental-f1dd850aa(@react-router/dev@0.0.0-experimental-f1dd850aa(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(react-router@0.0.0-experimental-f1dd850aa(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.39.0)(tsx@4.19.3)(typescript@5.7.3)(vite@6.3.2(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(wrangler@4.13.0(@cloudflare/workers-types@4.20250423.0))(yaml@2.7.0))(typescript@5.7.3)':
-    dependencies:
-      '@react-router/dev': 0.0.0-experimental-f1dd850aa(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(react-router@0.0.0-experimental-f1dd850aa(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(terser@5.39.0)(tsx@4.19.3)(typescript@5.7.3)(vite@6.3.2(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(wrangler@4.13.0(@cloudflare/workers-types@4.20250423.0))(yaml@2.7.0)
-      minimatch: 9.0.5
-    optionalDependencies:
-      typescript: 5.7.3
 
   '@react-router/node@0.0.0-experimental-f1dd850aa(react-router@0.0.0-experimental-f1dd850aa(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.7.3)':
     dependencies:


### PR DESCRIPTION
For now, let's port `routes.ts` processing except their custom `route-module:...` transform.