### PR TITLE
fix(rsc): css modules hmr

### DIFF
--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -225,15 +225,18 @@ test("css module @js", async ({ page }) => {
     "rgb(255, 165, 0)",
   );
 
-  // TODO: hmr
-  // if (process.env.E2E_PREVIEW) return;
-  // await using _ = await createReloadChecker(page);
-  // using editor = createEditor("src/routes/client.module.css");
-  // editor.edit((s) => s.replaceAll("rgb(255, 165, 0)", "rgb(0, 165, 255)"));
-  // await expect(page.getByTestId("css-module-client")).toHaveCSS(
-  //   "color",
-  //   "rgb(0, 165, 255)",
-  // );
+  if (process.env.E2E_PREVIEW) return;
+
+  // test client css module HMR
+  await using _ = await createReloadChecker(page);
+  using editor = createEditor("src/routes/client.module.css");
+  editor.edit((s) => s.replaceAll("rgb(255, 165, 0)", "rgb(0, 165, 255)"));
+  await expect(page.getByTestId("css-module-client")).toHaveCSS(
+    "color",
+    "rgb(0, 165, 255)",
+  );
+
+  // TODO: test server css module HMR
 });
 
 testNoJs("css module @nojs", async ({ page }) => {

--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -213,14 +213,10 @@ test("css client no ssr", async ({ page }) => {
   );
 });
 
-test("css module @js", async ({ page }) => {
+test("css module client @js", async ({ page }) => {
   await page.goto("./");
   await waitForHydration(page);
   await expect(page.getByTestId("css-module-client")).toHaveCSS(
-    "color",
-    "rgb(255, 165, 0)",
-  );
-  await expect(page.getByTestId("css-module-server")).toHaveCSS(
     "color",
     "rgb(255, 165, 0)",
   );
@@ -235,8 +231,26 @@ test("css module @js", async ({ page }) => {
     "color",
     "rgb(0, 165, 255)",
   );
+});
 
-  // TODO: test server css module HMR
+test("css module server @js", async ({ page }) => {
+  await page.goto("./");
+  await waitForHydration(page);
+  await expect(page.getByTestId("css-module-server")).toHaveCSS(
+    "color",
+    "rgb(255, 165, 0)",
+  );
+
+  if (process.env.E2E_PREVIEW) return;
+
+  // test server css module HMR
+  await using _ = await createReloadChecker(page);
+  using editor = createEditor("src/routes/server.module.css");
+  editor.edit((s) => s.replaceAll("rgb(255, 165, 0)", "rgb(0, 165, 255)"));
+  await expect(page.getByTestId("css-module-server")).toHaveCSS(
+    "color",
+    "rgb(0, 165, 255)",
+  );
 });
 
 testNoJs("css module @nojs", async ({ page }) => {

--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -213,6 +213,41 @@ test("css client no ssr", async ({ page }) => {
   );
 });
 
+test("css module @js", async ({ page }) => {
+  await page.goto("./");
+  await waitForHydration(page);
+  await expect(page.getByTestId("css-module-client")).toHaveCSS(
+    "color",
+    "rgb(255, 165, 0)",
+  );
+  await expect(page.getByTestId("css-module-server")).toHaveCSS(
+    "color",
+    "rgb(255, 165, 0)",
+  );
+
+  // TODO: hmr
+  // if (process.env.E2E_PREVIEW) return;
+  // await using _ = await createReloadChecker(page);
+  // using editor = createEditor("src/routes/client.module.css");
+  // editor.edit((s) => s.replaceAll("rgb(255, 165, 0)", "rgb(0, 165, 255)"));
+  // await expect(page.getByTestId("css-module-client")).toHaveCSS(
+  //   "color",
+  //   "rgb(0, 165, 255)",
+  // );
+});
+
+testNoJs("css module @nojs", async ({ page }) => {
+  await page.goto("./");
+  await expect(page.getByTestId("css-module-client")).toHaveCSS(
+    "color",
+    "rgb(255, 165, 0)",
+  );
+  await expect(page.getByTestId("css-module-server")).toHaveCSS(
+    "color",
+    "rgb(255, 165, 0)",
+  );
+});
+
 test("tailwind @js", async ({ page }) => {
   await page.goto("./");
   await waitForHydration(page);

--- a/packages/rsc/examples/basic/src/routes/client.module.css
+++ b/packages/rsc/examples/basic/src/routes/client.module.css
@@ -1,0 +1,3 @@
+.client {
+  color: rgb(255, 165, 0);
+}

--- a/packages/rsc/examples/basic/src/routes/client.tsx
+++ b/packages/rsc/examples/basic/src/routes/client.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import "./client.css";
+import styles from "./client.module.css";
 
 export function ClientCounter(): React.ReactElement {
   const [count, setCount] = React.useState(0);
@@ -22,7 +23,12 @@ export function Hydrated() {
 }
 
 export function TestStyleClient() {
-  return <div className="test-style-client">test-style-client</div>;
+  return (
+    <>
+      <div className="test-style-client">test-style-client</div>
+      <div className={styles.client}>test-css-module-client</div>
+    </>
+  );
 }
 
 export function TestTailwindClient() {

--- a/packages/rsc/examples/basic/src/routes/client.tsx
+++ b/packages/rsc/examples/basic/src/routes/client.tsx
@@ -26,7 +26,9 @@ export function TestStyleClient() {
   return (
     <>
       <div className="test-style-client">test-style-client</div>
-      <div className={styles.client}>test-css-module-client</div>
+      <div data-testid="css-module-client" className={styles.client}>
+        test-css-module-client
+      </div>
     </>
   );
 }

--- a/packages/rsc/examples/basic/src/routes/root.tsx
+++ b/packages/rsc/examples/basic/src/routes/root.tsx
@@ -18,6 +18,7 @@ import {
 } from "./client";
 import { TestStyleClient2 } from "./client2";
 import ErrorBoundary from "./error-boundary";
+import styles from "./server.module.css";
 
 export function Root(props: { url: URL }) {
   return (
@@ -39,6 +40,7 @@ export function Root(props: { url: URL }) {
         </form>
         <TestStyleClient />
         <div className="test-style-server">test-style-server</div>
+        <div className={styles.server}>test-css-module-server</div>
         <div>
           <a href="?test-client-style-no-ssr">test-client-style-no-ssr</a>{" "}
           {props.url.search.includes("test-client-style-no-ssr") && (

--- a/packages/rsc/examples/basic/src/routes/root.tsx
+++ b/packages/rsc/examples/basic/src/routes/root.tsx
@@ -40,7 +40,9 @@ export function Root(props: { url: URL }) {
         </form>
         <TestStyleClient />
         <div className="test-style-server">test-style-server</div>
-        <div className={styles.server}>test-css-module-server</div>
+        <div data-testid="css-module-server" className={styles.server}>
+          test-css-module-server
+        </div>
         <div>
           <a href="?test-client-style-no-ssr">test-client-style-no-ssr</a>{" "}
           {props.url.search.includes("test-client-style-no-ssr") && (

--- a/packages/rsc/examples/basic/src/routes/server.module.css
+++ b/packages/rsc/examples/basic/src/routes/server.module.css
@@ -1,0 +1,3 @@
+.server {
+  color: rgb(255, 165, 0);
+}

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -226,13 +226,13 @@ export default function vitePluginRsc({
         };
       },
       async hotUpdate(ctx) {
-        // css file imported by anywhere sould work based on default hmr
-        if (isCSSRequest(ctx.file)) return;
-        // if (isCSSRequest(ctx.file) && this.environment.name === "client") {
-        //   // filter out `.css?direct` (injected by SSR) to avoid browser full reload
-        //   // when changing non-self accepting css such as `module.css`.
-        //   return ctx.modules.filter((m) => !m.id?.includes("?direct"));
-        // }
+        if (isCSSRequest(ctx.file)) {
+          if (this.environment.name === "client") {
+            // filter out `.css?direct` (injected by SSR) to avoid browser full reload
+            // when changing non-self accepting css such as `module.css`.
+            return ctx.modules.filter((m) => !m.id?.includes("?direct"));
+          }
+        }
 
         const ids = ctx.modules.map((mod) => mod.id).filter((v) => v !== null);
         if (ids.length === 0) return;

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -972,14 +972,6 @@ export function vitePluginRscCss({
             "\0virtual:vite-rsc/rsc-css-browser",
           );
         }
-
-        // if (isCSSRequest(ctx.file)) {
-        //   // filter out `.css?direct` (injected by SSR) to avoid browser full reload
-        //   // when changing non-self accepting css such as `module.css`.
-        //   const modules = ctx.modules.filter((m) => !m.id?.includes("?direct"));
-        //   //
-        //   return modules;
-        // }
       },
     },
     createVirtualPlugin("vite-rsc/rsc-css", async function () {

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -1005,11 +1005,10 @@ export function vitePluginRscCss({
         ids = collected.ids;
       }
       ids = ids.map((id) => id.replace(/^\0/, ""));
-      return ids.map((id) => `import ${JSON.stringify(id)};\n`).join("");
-      // let code = ids.map((id) => `import ${JSON.stringify(id)};\n`).join("");
-      // // ensure hmr boundary since otherwise non-self accepting css (e.g. css module) causes full reload
-      // code += `if (import.meta.hot) { import.meta.hot.accept() }\n`;
-      // return code;
+      let code = ids.map((id) => `import ${JSON.stringify(id)};\n`).join("");
+      // ensure hmr boundary since otherwise non-self accepting css (e.g. css module) causes full reload
+      code += `if (import.meta.hot) { import.meta.hot.accept() }\n`;
+      return code;
     }),
     {
       name: "rsc:css/dev-ssr-virtual",

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -228,6 +228,11 @@ export default function vitePluginRsc({
       async hotUpdate(ctx) {
         // css file imported by anywhere sould work based on default hmr
         if (isCSSRequest(ctx.file)) return;
+        // if (isCSSRequest(ctx.file) && this.environment.name === "client") {
+        //   // filter out `.css?direct` (injected by SSR) to avoid browser full reload
+        //   // when changing non-self accepting css such as `module.css`.
+        //   return ctx.modules.filter((m) => !m.id?.includes("?direct"));
+        // }
 
         const ids = ctx.modules.map((mod) => mod.id).filter((v) => v !== null);
         if (ids.length === 0) return;
@@ -968,13 +973,13 @@ export function vitePluginRscCss({
           );
         }
 
-        if (isCSSRequest(ctx.file)) {
-          // filter out `.css?direct` (injected by SSR) to avoid browser full reload
-          // when changing non-self accepting css such as `module.css`.
-          const modules = ctx.modules.filter((m) => !m.id?.includes("?direct"));
-          //
-          return modules;
-        }
+        // if (isCSSRequest(ctx.file)) {
+        //   // filter out `.css?direct` (injected by SSR) to avoid browser full reload
+        //   // when changing non-self accepting css such as `module.css`.
+        //   const modules = ctx.modules.filter((m) => !m.id?.includes("?direct"));
+        //   //
+        //   return modules;
+        // }
       },
     },
     createVirtualPlugin("vite-rsc/rsc-css", async function () {

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -967,6 +967,14 @@ export function vitePluginRscCss({
             "\0virtual:vite-rsc/rsc-css-browser",
           );
         }
+
+        if (isCSSRequest(ctx.file)) {
+          // filter out `.css?direct` (injected by SSR) to avoid browser full reload
+          // when changing non-self accepting css such as `module.css`.
+          const modules = ctx.modules.filter((m) => !m.id?.includes("?direct"));
+          //
+          return modules;
+        }
       },
     },
     createVirtualPlugin("vite-rsc/rsc-css", async function () {
@@ -993,6 +1001,10 @@ export function vitePluginRscCss({
       }
       ids = ids.map((id) => id.replace(/^\0/, ""));
       return ids.map((id) => `import ${JSON.stringify(id)};\n`).join("");
+      // let code = ids.map((id) => `import ${JSON.stringify(id)};\n`).join("");
+      // // ensure hmr boundary since otherwise non-self accepting css (e.g. css module) causes full reload
+      // code += `if (import.meta.hot) { import.meta.hot.accept() }\n`;
+      // return code;
     }),
     {
       name: "rsc:css/dev-ssr-virtual",


### PR DESCRIPTION
Probably we need the same things from https://github.com/hi-ogawa/vite-plugins/pull/346. ~But there's a difference that we currently ignore server build css output and only redirect css files, which seems to break server css module.~ (EDIT: let's address that first https://github.com/hi-ogawa/vite-plugins/pull/861)

_todo_

- [x] client
  - [x] dev
  - [x] build
  - [x] hmr
- [x] server
  - [x] dev
  - [x] build
  - [x] hmr