### PR TITLE
chore(rsc): debug ci fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,13 @@ jobs:
       - run: pnpm -C packages/rsc/examples/react-router test-e2e
       - run: pnpm -C packages/rsc/examples/react-router build
       - run: pnpm -C packages/rsc/examples/react-router test-e2e-preview
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results
+          path: |
+            packages/rsc/examples/basic/test-results
+            packages/rsc/examples/react-router/test-results
 
   test-react-server-basic:
     runs-on: ubuntu-latest

--- a/packages/rsc/examples/basic/playwright.config.ts
+++ b/packages/rsc/examples/basic/playwright.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
   webServer: {
     command,
     port,
+    stdout: "pipe",
   },
   grepInvert: isPreview ? /@dev/ : /@build/,
   forbidOnly: !!process.env["CI"],


### PR DESCRIPTION
It looks like this became flaky after https://github.com/hi-ogawa/vite-plugins/pull/860.

~Actually, it happens consistently locally too. Not sure why it was fine previously.~ Probably we have a duplicate css due to ssr and hmr, which are conflicting each other.