### PR TITLE
fix(rsc): show invalid transform error with code frame

### DIFF
--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -712,6 +712,7 @@ function withRollupError<F extends (...args: any[]) => any>(
       if (result instanceof Promise) {
         return result.catch((e: any) => processError(e));
       }
+      return result;
     } catch (e: any) {
       processError(e);
     }

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -540,7 +540,11 @@ function vitePluginUseClient(): Plugin[] {
           }
         }
 
-        const result = transformDirectiveProxyExport(ast, {
+        const transformDirectiveProxyExport_ = withRollupError(
+          this,
+          transformDirectiveProxyExport,
+        );
+        const result = transformDirectiveProxyExport_(ast, {
           directive: "use client",
           runtime: (name) =>
             `$$ReactServer.registerClientReference({}, ${JSON.stringify(referenceKey)}, ${JSON.stringify(name)})`,
@@ -634,7 +638,11 @@ function vitePluginUseServer(): Plugin[] {
         const ast = await parseAstAsync(code);
         const normalizedId = normalizeReferenceId(id, "rsc");
         if (this.environment.name === "rsc") {
-          const { output } = transformServerActionServer(code, ast, {
+          const transformServerActionServer_ = withRollupError(
+            this,
+            transformServerActionServer,
+          );
+          const { output } = transformServerActionServer_(code, ast, {
             runtime: (value, name) =>
               `$$ReactServer.registerServerReference(${value}, ${JSON.stringify(normalizedId)}, ${JSON.stringify(name)})`,
             rejectNonAsyncFunction: true,
@@ -647,7 +655,11 @@ function vitePluginUseServer(): Plugin[] {
             map: output.generateMap({ hires: "boundary" }),
           };
         } else {
-          const result = transformDirectiveProxyExport(ast, {
+          const transformDirectiveProxyExport_ = withRollupError(
+            this,
+            transformDirectiveProxyExport,
+          );
+          const result = transformDirectiveProxyExport_(ast, {
             code,
             runtime: (name) =>
               `$$ReactClient.createServerReference(` +
@@ -681,6 +693,23 @@ function vitePluginUseServer(): Plugin[] {
       return { code, map: null };
     }),
   ];
+}
+
+// Rethrow transform error through `this.error` with `error.pos` which is injected by `@hiogawa/transforms`
+function withRollupError<F extends (...args: any[]) => any>(
+  ctx: Rollup.TransformPluginContext,
+  f: F,
+): F {
+  return function (this: any, ...args: any[]) {
+    try {
+      return f.apply(this, args);
+    } catch (e: any) {
+      if (e && typeof e === "object" && typeof e.pos === "number") {
+        return ctx.error(e, e.pos);
+      }
+      throw e;
+    }
+  } as F;
 }
 
 function createVirtualPlugin(name: string, load: Plugin["load"]) {


### PR DESCRIPTION
Part of https://github.com/hi-ogawa/vite-plugins/issues/802

## example

```tsx
        <TestTemporaryReference
          action={(node: React.ReactNode) => {
            "use server";
            return (
              <span>
                [server <span>{node}</span>]
              </span>
            );
          }}
        />
```

```
$ pnpm -C packages/rsc/examples/basic build

> @hiogawa/vite-rsc-examples-basic@ build /home/hiroshi/code/personal/vite-plugins/packages/rsc/examples/basic
> vite build --app

vite v6.3.2 building SSR bundle for production...
✓ 5 modules transformed.
✗ Build failed in 71ms
error during build:
[rsc:use-server] "use server" doesn't allow non async function
file: /home/hiroshi/code/personal/vite-plugins/packages/rsc/examples/basic/src/routes/root.tsx:54:18

52:         TestTemporaryReference,
53:         {
54:           action: (node) => {
                      ^
55:             "use server";
56:             return /* @__PURE__ */ jsxs("span", { children: [

    at Object.enter (file:///home/hiroshi/code/personal/vite-plugins/packages/transforms/dist/index.js:77:13)
    at SyncWalker.visit (file:///home/hiroshi/code/personal/vite-plugins/node_modules/.pnpm/estree-walker@3.0.3/node_modules/estree-walker/src/sync.js:65:16)
    at SyncWalker.visit (file:///home/hiroshi/code/personal/vite-plugins/node_modules/.pnpm/estree-walker@3.0.3/node_modules/estree-walker/src/sync.js:107:12)
    at SyncWalker.visit (file:///home/hiroshi/code/personal/vite-plugins/node_modules/.pnpm/estree-walker@3.0.3/node_modules/estree-walker/src/sync.js:100:19)
    at SyncWalker.visit (file:///home/hiroshi/code/personal/vite-plugins/node_modules/.pnpm/estree-walker@3.0.3/node_modules/estree-walker/src/sync.js:100:19)
    at SyncWalker.visit (file:///home/hiroshi/code/personal/vite-plugins/node_modules/.pnpm/estree-walker@3.0.3/node_modules/estree-walker/src/sync.js:100:19)
    at SyncWalker.visit (file:///home/hiroshi/code/personal/vite-plugins/node_modules/.pnpm/estree-walker@3.0.3/node_modules/estree-walker/src/sync.js:107:12)
    at SyncWalker.visit (file:///home/hiroshi/code/personal/vite-plugins/node_modules/.pnpm/estree-walker@3.0.3/node_modules/estree-walker/src/sync.js:100:19)
    at SyncWalker.visit (file:///home/hiroshi/code/personal/vite-plugins/node_modules/.pnpm/estree-walker@3.0.3/node_modules/estree-walker/src/sync.js:100:19)
    at SyncWalker.visit (file:///home/hiroshi/code/personal/vite-plugins/node_modules/.pnpm/estree-walker@3.0.3/node_modules/estree-walker/src/sync.js:100:19)
 ELIFECYCLE  Command failed with exit code 1.
```