### PR TITLE
fix(rsc): add `vary` header to avoid rsc payload on tab re-open

### DIFF
--- a/packages/rsc/src/extra/rsc.tsx
+++ b/packages/rsc/src/extra/rsc.tsx
@@ -76,7 +76,7 @@ export async function renderRequest(
     return new Response(stream, {
       headers: {
         "content-type": "text/x-component;charset=utf-8",
-        "vary": "accept",
+        vary: "accept",
       },
     });
   }

--- a/packages/rsc/src/extra/rsc.tsx
+++ b/packages/rsc/src/extra/rsc.tsx
@@ -76,6 +76,7 @@ export async function renderRequest(
     return new Response(stream, {
       headers: {
         "content-type": "text/x-component;charset=utf-8",
+        "vary": "accept",
       },
     });
   }

--- a/packages/rsc/src/extra/ssr.tsx
+++ b/packages/rsc/src/extra/ssr.tsx
@@ -57,6 +57,7 @@ export async function renderHtml({
   return new Response(responseStream, {
     headers: {
       "content-type": "text/html;charset=utf-8",
+      "vary": "accept",
     },
   });
 }

--- a/packages/rsc/src/extra/ssr.tsx
+++ b/packages/rsc/src/extra/ssr.tsx
@@ -57,7 +57,7 @@ export async function renderHtml({
   return new Response(responseStream, {
     headers: {
       "content-type": "text/html;charset=utf-8",
-      "vary": "accept",
+      vary: "accept",
     },
   });
 }


### PR DESCRIPTION
Related: https://github.com/vercel/next.js/issues/79346

I was noticing the same in some occasions such as
- open https://vite-rsc-basic.hiro18181.workers.dev/
- click "test-client-style-no-ssr", which navigates to https://vite-rsc-basic.hiro18181.workers.dev/?test-client-style-no-ssr
- close tab (e.g. control-w)
- reopen tab (e.g. control-shift-t)
- page shows rsc payload

Actually this reproduces locally by `pnpm -C packages/rsc/examples/basic cf-preview` on http://localhost:8787.

---

This is now fixed by adding `vary: accept` both locally and deployment.