### PR TITLE
test: tweak hmr tests

### DIFF
--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -196,6 +196,11 @@ test("css hmr client @dev", async ({ page }) => {
     "color",
     "rgb(0, 165, 255)",
   );
+  editor.reset();
+  await expect(page.locator(".test-style-client")).toHaveCSS(
+    "color",
+    "rgb(255, 165, 0)",
+  );
 });
 
 test("css hmr server @dev", async ({ page }) => {
@@ -209,6 +214,11 @@ test("css hmr server @dev", async ({ page }) => {
   await expect(page.locator(".test-style-server")).toHaveCSS(
     "color",
     "rgb(0, 165, 255)",
+  );
+  editor.reset();
+  await expect(page.locator(".test-style-server")).toHaveCSS(
+    "color",
+    "rgb(255, 165, 0)",
   );
 });
 
@@ -241,6 +251,11 @@ test("css module client @js", async ({ page }) => {
     "color",
     "rgb(0, 165, 255)",
   );
+  editor.reset();
+  await expect(page.getByTestId("css-module-client")).toHaveCSS(
+    "color",
+    "rgb(255, 165, 0)",
+  );
 });
 
 test("css module server @js", async ({ page }) => {
@@ -260,6 +275,11 @@ test("css module server @js", async ({ page }) => {
   await expect(page.getByTestId("css-module-server")).toHaveCSS(
     "color",
     "rgb(0, 165, 255)",
+  );
+  editor.reset();
+  await expect(page.getByTestId("css-module-server")).toHaveCSS(
+    "color",
+    "rgb(255, 165, 0)",
   );
 });
 
@@ -312,12 +332,22 @@ test("tailwind hmr @dev", async ({ page }) => {
     "color",
     "oklch(0.546 0.245 262.881)",
   );
+  clientFile.reset();
+  await expect(page.locator(".test-tw-client")).toHaveCSS(
+    "color",
+    "oklch(0.623 0.214 259.815)",
+  );
 
   using serverFile = createEditor("src/routes/root.tsx");
   serverFile.edit((s) => s.replaceAll("text-red-500", "text-red-600"));
   await expect(page.locator(".test-tw-server")).toHaveCSS(
     "color",
     "oklch(0.577 0.245 27.325)",
+  );
+  serverFile.reset();
+  await expect(page.locator(".test-tw-server")).toHaveCSS(
+    "color",
+    "oklch(0.637 0.237 25.331)",
   );
 });
 

--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -147,6 +147,8 @@ test("client hmr @dev", async ({ page }) => {
   // check next ssr is also updated
   const res = await page.goto("./");
   expect(await res?.text()).toContain("Client [edit] Counter");
+  editor.reset();
+  await page.getByRole("button", { name: "Client Counter: 0" }).click();
 });
 
 test("server hmr @dev", async ({ page }) => {
@@ -157,6 +159,10 @@ test("server hmr @dev", async ({ page }) => {
   editor.edit((s) => s.replace("Server Counter", "Server [edit] Counter"));
   await expect(
     page.getByRole("button", { name: "Server [edit] Counter: 0" }),
+  ).toBeVisible();
+  editor.reset();
+  await expect(
+    page.getByRole("button", { name: "Server Counter: 0" }),
   ).toBeVisible();
 });
 

--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -97,7 +97,7 @@ async function testServerActionUpdate(page: Page, options: { js: boolean }) {
   ).toBeVisible();
 
   // update server code
-  using editor = createEditor("src/routes/action.tsx");
+  const editor = createEditor("src/routes/action.tsx");
   editor.edit((s) =>
     s.replace("const TEST_UPDATE = 1;", "const TEST_UPDATE = 10;"),
   );
@@ -138,7 +138,7 @@ test("client hmr @dev", async ({ page }) => {
     page.getByRole("button", { name: "Client Counter: 1" }),
   ).toBeVisible();
 
-  using editor = createEditor("src/routes/client.tsx");
+  const editor = createEditor("src/routes/client.tsx");
   editor.edit((s) => s.replace("Client Counter", "Client [edit] Counter"));
   await expect(
     page.getByRole("button", { name: "Client [edit] Counter: 1" }),
@@ -153,19 +153,11 @@ test("server hmr @dev", async ({ page }) => {
   await page.goto("./");
   await waitForHydration(page);
   await using _ = await expectNoReload(page);
-  // await page.getByRole("button", { name: "Client Counter: 0" }).click();
-  // await expect(
-  //   page.getByRole("button", { name: "Client Counter: 1" }),
-  // ).toBeVisible();
-
-  using editor = createEditor("src/routes/root.tsx");
+  const editor = createEditor("src/routes/root.tsx");
   editor.edit((s) => s.replace("Server Counter", "Server [edit] Counter"));
   await expect(
     page.getByRole("button", { name: "Server [edit] Counter: 0" }),
   ).toBeVisible();
-  // await expect(
-  //   page.getByRole("button", { name: "Client Counter: 1" }),
-  // ).toBeVisible();
 });
 
 test("css @js", async ({ page }) => {
@@ -190,7 +182,7 @@ test("css hmr client @dev", async ({ page }) => {
   await testCss(page);
 
   await using _ = await expectNoReload(page);
-  using editor = createEditor("src/routes/client.css");
+  const editor = createEditor("src/routes/client.css");
   editor.edit((s) => s.replaceAll("rgb(255, 165, 0)", "rgb(0, 165, 255)"));
   await expect(page.locator(".test-style-client")).toHaveCSS(
     "color",
@@ -209,7 +201,7 @@ test("css hmr server @dev", async ({ page }) => {
   await testCss(page);
 
   await using _ = await expectNoReload(page);
-  using editor = createEditor("src/styles.css");
+  const editor = createEditor("src/styles.css");
   editor.edit((s) => s.replaceAll("rgb(255, 165, 0)", "rgb(0, 165, 255)"));
   await expect(page.locator(".test-style-server")).toHaveCSS(
     "color",
@@ -245,7 +237,7 @@ test("css module client @js", async ({ page }) => {
 
   // test client css module HMR
   await using _ = await expectNoReload(page);
-  using editor = createEditor("src/routes/client.module.css");
+  const editor = createEditor("src/routes/client.module.css");
   editor.edit((s) => s.replaceAll("rgb(255, 165, 0)", "rgb(0, 165, 255)"));
   await expect(page.getByTestId("css-module-client")).toHaveCSS(
     "color",
@@ -270,7 +262,7 @@ test("css module server @js", async ({ page }) => {
 
   // test server css module HMR
   await using _ = await expectNoReload(page);
-  using editor = createEditor("src/routes/server.module.css");
+  const editor = createEditor("src/routes/server.module.css");
   editor.edit((s) => s.replaceAll("rgb(255, 165, 0)", "rgb(0, 165, 255)"));
   await expect(page.getByTestId("css-module-server")).toHaveCSS(
     "color",
@@ -326,7 +318,7 @@ test("tailwind hmr @dev", async ({ page }) => {
 
   await using _ = await expectNoReload(page);
 
-  using clientFile = createEditor("src/routes/client.tsx");
+  const clientFile = createEditor("src/routes/client.tsx");
   clientFile.edit((s) => s.replaceAll("text-blue-500", "text-blue-600"));
   await expect(page.locator(".test-tw-client")).toHaveCSS(
     "color",
@@ -338,7 +330,7 @@ test("tailwind hmr @dev", async ({ page }) => {
     "oklch(0.623 0.214 259.815)",
   );
 
-  using serverFile = createEditor("src/routes/root.tsx");
+  const serverFile = createEditor("src/routes/root.tsx");
   serverFile.edit((s) => s.replaceAll("text-red-500", "text-red-600"));
   await expect(page.locator(".test-tw-server")).toHaveCSS(
     "color",

--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -199,7 +199,7 @@ test("css hmr server @dev", async ({ page }) => {
   await waitForHydration(page);
 
   await using _ = await expectNoReload(page);
-  const editor = createEditor("src/styles.css");
+  const editor = createEditor("src/routes/server.css");
   editor.edit((s) => s.replaceAll("rgb(255, 165, 0)", "rgb(0, 165, 255)"));
   await expect(page.locator(".test-style-server")).toHaveCSS(
     "color",

--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -179,7 +179,6 @@ async function testCss(page: Page, color = "rgb(255, 165, 0)") {
 test("css hmr client @dev", async ({ page }) => {
   await page.goto("./");
   await waitForHydration(page);
-  await testCss(page);
 
   await using _ = await expectNoReload(page);
   const editor = createEditor("src/routes/client.css");
@@ -198,7 +197,6 @@ test("css hmr client @dev", async ({ page }) => {
 test("css hmr server @dev", async ({ page }) => {
   await page.goto("./");
   await waitForHydration(page);
-  await testCss(page);
 
   await using _ = await expectNoReload(page);
   const editor = createEditor("src/styles.css");

--- a/packages/rsc/examples/basic/e2e/helper.ts
+++ b/packages/rsc/examples/basic/e2e/helper.ts
@@ -18,11 +18,15 @@ export async function createReloadChecker(page: Page) {
     document.head.append(el);
   });
 
+  // TODO: playwright prints a weird error on dispose error, so maybe this approach is bad :(
   return {
     [Symbol.asyncDispose]: async () => {
       // check if meta is preserved
       await expect(page.locator(`meta[name="x-reload-check"]`)).toBeAttached({
         timeout: 1,
+      });
+      await page.evaluate(() => {
+        document.querySelector(`meta[name="x-reload-check"]`)!.remove();
       });
     },
   };

--- a/packages/rsc/examples/basic/e2e/helper.ts
+++ b/packages/rsc/examples/basic/e2e/helper.ts
@@ -45,9 +45,6 @@ export function createEditor(filepath: string) {
     reset() {
       writeFileSync(filepath, init);
     },
-    [Symbol.dispose]() {
-      // writeFileSync(filepath, init);
-    },
   };
 }
 

--- a/packages/rsc/examples/basic/e2e/helper.ts
+++ b/packages/rsc/examples/basic/e2e/helper.ts
@@ -34,8 +34,6 @@ export async function expectNoReload(page: Page) {
 
 export function createEditor(filepath: string) {
   const init = readFileSync(filepath, "utf-8");
-  originalFiles[filepath] ??= init;
-
   return {
     edit(editFn: (data: string) => string) {
       const next = editFn(init);
@@ -47,11 +45,3 @@ export function createEditor(filepath: string) {
     },
   };
 }
-
-const originalFiles: Record<string, string> = {};
-
-test.afterAll(() => {
-  for (const [filepath, content] of Object.entries(originalFiles)) {
-    writeFileSync(filepath, content);
-  }
-});

--- a/packages/rsc/examples/basic/e2e/helper.ts
+++ b/packages/rsc/examples/basic/e2e/helper.ts
@@ -18,7 +18,7 @@ export async function createReloadChecker(page: Page) {
     document.head.append(el);
   });
 
-  // TODO: playwright prints a weird error on dispose error, so maybe this approach is bad :(
+  // TODO: playwright prints a weird error on dispose error, so maybe we should avoid this pattern :(
   return {
     [Symbol.asyncDispose]: async () => {
       // check if meta is preserved

--- a/packages/rsc/examples/basic/playwright.config.ts
+++ b/packages/rsc/examples/basic/playwright.config.ts
@@ -13,6 +13,9 @@ export default defineConfig({
       ? `http://localhost:${port}/custom-base/`
       : undefined,
     trace: "on-first-retry",
+    launchOptions: {
+      slowMo: process.env.E2E_SLOWMO ? 500 : 0,
+    },
   },
   projects: [
     {
@@ -27,6 +30,7 @@ export default defineConfig({
   webServer: {
     command,
     port,
+    stdout: process.env.E2E_STDOUT ? "pipe" : undefined,
   },
   grepInvert: isPreview ? /@dev/ : /@build/,
   forbidOnly: !!process.env["CI"],

--- a/packages/rsc/examples/basic/src/routes/root.tsx
+++ b/packages/rsc/examples/basic/src/routes/root.tsx
@@ -18,6 +18,7 @@ import {
 } from "./client";
 import { TestStyleClient2 } from "./client2";
 import ErrorBoundary from "./error-boundary";
+import "./server.css";
 import styles from "./server.module.css";
 
 export function Root(props: { url: URL }) {

--- a/packages/rsc/examples/basic/src/routes/server.css
+++ b/packages/rsc/examples/basic/src/routes/server.css
@@ -1,0 +1,3 @@
+.test-style-server {
+  color: rgb(255, 165, 0);
+}

--- a/packages/rsc/examples/basic/src/styles.css
+++ b/packages/rsc/examples/basic/src/styles.css
@@ -13,7 +13,3 @@ input {
 a {
   @apply text-gray-500 underline hover:text-gray-700;
 }
-
-.test-style-server {
-  color: rgb(255, 165, 0);
-}


### PR DESCRIPTION
This has been quite flaky and I think partly this is because of `createEditor` resets files back and go to next test immediately.

Thinking about we should do either:
- make sure reset is resolved
- remove auto reset for each test and use `afterAll` (👈 going with this)
- restart server after each test

---

It looks like "css hmr server" is flaky regardless. Locally it fails too. Likely it's related to tailwind `styles.css`, but not sure. For now, separating `server.css` helps.