### PR TITLE
fix(rsc): fix non-client-boundary client module hmr in tailwind example

### DIFF
--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -151,6 +151,33 @@ test("client hmr @dev", async ({ page }) => {
   await page.getByRole("button", { name: "Client Counter: 0" }).click();
 });
 
+test("non-boundary client hmr @dev", async ({ page }) => {
+  await page.goto("./");
+  await waitForHydration(page);
+
+  await page
+    .getByRole("textbox", { name: "test-client-dep-state" })
+    .fill("test");
+
+  const editor = createEditor("src/routes/client-dep.tsx");
+  editor.edit((s) =>
+    s.replace("test-client-dep-state", "test-client-[edit]-dep-state"),
+  );
+  await expect(
+    page.getByRole("textbox", { name: "test-client-[edit]-dep-state" }),
+  ).toHaveValue("test");
+
+  // check next ssr is also updated
+  const res = await page.goto("./");
+  expect(await res?.text()).toContain("test-client-[edit]-dep-state");
+
+  await waitForHydration(page);
+  editor.reset();
+  await expect(
+    page.getByRole("textbox", { name: "test-client-dep-state" }),
+  ).toBeVisible();
+});
+
 test("server hmr @dev", async ({ page }) => {
   await page.goto("./");
   await waitForHydration(page);

--- a/packages/rsc/examples/basic/src/routes/client-dep.css
+++ b/packages/rsc/examples/basic/src/routes/client-dep.css
@@ -1,0 +1,3 @@
+.test-style-client-dep {
+  color: rgb(255, 165, 0);
+}

--- a/packages/rsc/examples/basic/src/routes/client-dep.tsx
+++ b/packages/rsc/examples/basic/src/routes/client-dep.tsx
@@ -1,5 +1,10 @@
 import "./client-dep.css";
 
-export function TestStyleClientDep() {
-  return <div className="test-style-client-dep">test-style-client-dep</div>;
+export function TestClientDep() {
+  return (
+    <>
+      <div className="test-style-client-dep">test-style-client-dep</div>
+      <input placeholder="test-client-dep-state" />
+    </>
+  );
 }

--- a/packages/rsc/examples/basic/src/routes/client-dep.tsx
+++ b/packages/rsc/examples/basic/src/routes/client-dep.tsx
@@ -1,0 +1,5 @@
+import "./client-dep.css";
+
+export function TestStyleClientDep() {
+  return <div className="test-style-client-dep">test-style-client-dep</div>;
+}

--- a/packages/rsc/examples/basic/src/routes/client.tsx
+++ b/packages/rsc/examples/basic/src/routes/client.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import "./client.css";
-import { TestStyleClientDep } from "./client-dep";
+import { TestClientDep } from "./client-dep";
 import styles from "./client.module.css";
 
 export function ClientCounter(): React.ReactElement {
@@ -30,7 +30,7 @@ export function TestStyleClient() {
       <div data-testid="css-module-client" className={styles.client}>
         test-css-module-client
       </div>
-      <TestStyleClientDep />
+      <TestClientDep />
     </>
   );
 }

--- a/packages/rsc/examples/basic/src/routes/client.tsx
+++ b/packages/rsc/examples/basic/src/routes/client.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import "./client.css";
+import { TestStyleClientDep } from "./client-dep";
 import styles from "./client.module.css";
 
 export function ClientCounter(): React.ReactElement {
@@ -29,6 +30,7 @@ export function TestStyleClient() {
       <div data-testid="css-module-client" className={styles.client}>
         test-css-module-client
       </div>
+      <TestStyleClientDep />
     </>
   );
 }


### PR DESCRIPTION
Found a bug when testing https://github.com/hi-ogawa/vite-plugins/pull/876 and the same issue with transitive css import inside client boundary (EDIT: this is fixed in https://github.com/hi-ogawa/vite-plugins/pull/887). Also client hmr is actually broken for transitive component import.

---

It's very odd that `client-dep.tsx` ends up in rsc module graph. 

```
[hotUpdate] EnvironmentModuleNode {
  environment: 'rsc',
  url: '/src/routes/client-dep.tsx',
```

Ah, again this is because of tailwind :disappointed: Similar to https://github.com/hi-ogawa/vite-plugins/pull/739, but probably the opposite is happening.

---

Stale virtual ssr css and broken component hmr are different issues as the latter happens only with tailwind. They should be fixed separately.