### PR TITLE
fix(rsc): fix stale css import in non-boundary client module

### DIFF
--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -234,39 +234,19 @@ test("css hmr client @dev", async ({ page }) => {
   );
 });
 
-test("adding/removing css client @dev", async ({ page }) => {
+test("adding/removing css client @dev @js", async ({ page }) => {
   await page.goto("./");
   await waitForHydration(page);
   await using _ = await expectNoReload(page);
-
-  await expect(page.locator(".test-style-client-dep")).toHaveCSS(
-    "color",
-    "rgb(255, 165, 0)",
-  );
-
-  // remove css import
-  const editor = createEditor("src/routes/client-dep.tsx");
-  editor.edit((s) =>
-    s.replaceAll(
-      `import "./client-dep.css";`,
-      `/* import "./client-dep.css"; */`,
-    ),
-  );
-  await expect(page.locator(".test-style-client-dep")).toHaveCSS(
-    "color",
-    "rgb(0, 0, 0)",
-  );
-
-  // add back css import
-  editor.reset();
-  await expect(page.locator(".test-style-client-dep")).toHaveCSS(
-    "color",
-    "rgb(255, 165, 0)",
-  );
+  await testAddRemoveCssClient(page, { js: true });
 });
 
 testNoJs("adding/removing css client @dev @nojs", async ({ page }) => {
   await page.goto("./");
+  await testAddRemoveCssClient(page, { js: false });
+});
+
+async function testAddRemoveCssClient(page: Page, options: { js: boolean }) {
   await expect(page.locator(".test-style-client-dep")).toHaveCSS(
     "color",
     "rgb(255, 165, 0)",
@@ -280,8 +260,10 @@ testNoJs("adding/removing css client @dev @nojs", async ({ page }) => {
       `/* import "./client-dep.css"; */`,
     ),
   );
-  await page.waitForTimeout(100);
-  await page.reload();
+  if (!options.js) {
+    await page.waitForTimeout(100);
+    await page.reload();
+  }
   await expect(page.locator(".test-style-client-dep")).toHaveCSS(
     "color",
     "rgb(0, 0, 0)",
@@ -289,13 +271,15 @@ testNoJs("adding/removing css client @dev @nojs", async ({ page }) => {
 
   // add back css import
   editor.reset();
-  await page.waitForTimeout(100);
-  await page.reload();
+  if (!options.js) {
+    await page.waitForTimeout(100);
+    await page.reload();
+  }
   await expect(page.locator(".test-style-client-dep")).toHaveCSS(
     "color",
     "rgb(255, 165, 0)",
   );
-});
+}
 
 test("css hmr server @dev", async ({ page }) => {
   await page.goto("./");

--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -265,8 +265,7 @@ test("adding/removing css client @dev", async ({ page }) => {
   );
 });
 
-// TODO
-testNoJs.skip("adding/removing css client @dev @nojs", async ({ page }) => {
+testNoJs("adding/removing css client @dev @nojs", async ({ page }) => {
   await page.goto("./");
   await expect(page.locator(".test-style-client-dep")).toHaveCSS(
     "color",
@@ -281,35 +280,21 @@ testNoJs.skip("adding/removing css client @dev @nojs", async ({ page }) => {
       `/* import "./client-dep.css"; */`,
     ),
   );
+  await page.waitForTimeout(100);
   await page.reload();
   await expect(page.locator(".test-style-client-dep")).toHaveCSS(
     "color",
     "rgb(0, 0, 0)",
   );
-  // await expect(async () => {
-  //   await page.reload();
-  //   await expect(page.locator(".test-style-client-dep")).toHaveCSS(
-  //     "color",
-  //     "rgb(0, 0, 0)",
-  //     { timeout: 10 },
-  //   )
-  // }).toPass();
 
   // add back css import
   editor.reset();
+  await page.waitForTimeout(100);
   await page.reload();
   await expect(page.locator(".test-style-client-dep")).toHaveCSS(
     "color",
     "rgb(255, 165, 0)",
   );
-  // await expect(async () => {
-  //   await page.reload();
-  //   await expect(page.locator(".test-style-client-dep")).toHaveCSS(
-  //     "color",
-  //     "rgb(255, 165, 0)",
-  //     { timeout: 10 },
-  //   )
-  // }).toPass();
 });
 
 test("css hmr server @dev", async ({ page }) => {

--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -234,6 +234,84 @@ test("css hmr client @dev", async ({ page }) => {
   );
 });
 
+test("adding/removing css client @dev", async ({ page }) => {
+  await page.goto("./");
+  await waitForHydration(page);
+  await using _ = await expectNoReload(page);
+
+  await expect(page.locator(".test-style-client-dep")).toHaveCSS(
+    "color",
+    "rgb(255, 165, 0)",
+  );
+
+  // remove css import
+  const editor = createEditor("src/routes/client-dep.tsx");
+  editor.edit((s) =>
+    s.replaceAll(
+      `import "./client-dep.css";`,
+      `/* import "./client-dep.css"; */`,
+    ),
+  );
+  await expect(page.locator(".test-style-client-dep")).toHaveCSS(
+    "color",
+    "rgb(0, 0, 0)",
+  );
+
+  // add back css import
+  editor.reset();
+  await expect(page.locator(".test-style-client-dep")).toHaveCSS(
+    "color",
+    "rgb(255, 165, 0)",
+  );
+});
+
+// TODO
+testNoJs.skip("adding/removing css client @dev @nojs", async ({ page }) => {
+  await page.goto("./");
+  await expect(page.locator(".test-style-client-dep")).toHaveCSS(
+    "color",
+    "rgb(255, 165, 0)",
+  );
+
+  // remove css import
+  const editor = createEditor("src/routes/client-dep.tsx");
+  editor.edit((s) =>
+    s.replaceAll(
+      `import "./client-dep.css";`,
+      `/* import "./client-dep.css"; */`,
+    ),
+  );
+  await page.reload();
+  await expect(page.locator(".test-style-client-dep")).toHaveCSS(
+    "color",
+    "rgb(0, 0, 0)",
+  );
+  // await expect(async () => {
+  //   await page.reload();
+  //   await expect(page.locator(".test-style-client-dep")).toHaveCSS(
+  //     "color",
+  //     "rgb(0, 0, 0)",
+  //     { timeout: 10 },
+  //   )
+  // }).toPass();
+
+  // add back css import
+  editor.reset();
+  await page.reload();
+  await expect(page.locator(".test-style-client-dep")).toHaveCSS(
+    "color",
+    "rgb(255, 165, 0)",
+  );
+  // await expect(async () => {
+  //   await page.reload();
+  //   await expect(page.locator(".test-style-client-dep")).toHaveCSS(
+  //     "color",
+  //     "rgb(255, 165, 0)",
+  //     { timeout: 10 },
+  //   )
+  // }).toPass();
+});
+
 test("css hmr server @dev", async ({ page }) => {
   await page.goto("./");
   await waitForHydration(page);


### PR DESCRIPTION
The issue is that `addWatchFile(<client-boundary-file>)` only allows invalidating css on client-boundary file change, but this virtual also needs to take into account any transitive css import inside the boundary.

https://github.com/hi-ogawa/vite-plugins/blob/68d6823559e29738fa724c4e092cd0fa265e9640/packages/rsc/src/plugin.ts#L1083-L1084

This fix is for ssr css virtual. The same fix for rsc css virtual will be needed in https://github.com/hi-ogawa/vite-plugins/pull/876.