### PR TITLE
test: fix flake hmr

### DIFF
--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -261,24 +261,38 @@ async function testAddRemoveCssClient(page: Page, options: { js: boolean }) {
     ),
   );
   if (!options.js) {
-    await page.waitForTimeout(100);
-    await page.reload();
+    await expect(async () => {
+      await page.reload();
+      await expect(page.locator(".test-style-client-dep")).toHaveCSS(
+        "color",
+        "rgb(0, 0, 0)",
+        { timeout: 10 },
+      );
+    }).toPass();
+  } else {
+    await expect(page.locator(".test-style-client-dep")).toHaveCSS(
+      "color",
+      "rgb(0, 0, 0)",
+    );
   }
-  await expect(page.locator(".test-style-client-dep")).toHaveCSS(
-    "color",
-    "rgb(0, 0, 0)",
-  );
 
   // add back css import
   editor.reset();
   if (!options.js) {
-    await page.waitForTimeout(100);
-    await page.reload();
+    await expect(async () => {
+      await page.reload();
+      await expect(page.locator(".test-style-client-dep")).toHaveCSS(
+        "color",
+        "rgb(255, 165, 0)",
+        { timeout: 10 },
+      );
+    }).toPass();
+  } else {
+    await expect(page.locator(".test-style-client-dep")).toHaveCSS(
+      "color",
+      "rgb(255, 165, 0)",
+    );
   }
-  await expect(page.locator(".test-style-client-dep")).toHaveCSS(
-    "color",
-    "rgb(255, 165, 0)",
-  );
 }
 
 test("css hmr server @dev", async ({ page }) => {

--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -106,7 +106,7 @@ async function testServerActionUpdate(page: Page, options: { js: boolean }) {
     if (!options.js) await page.goto("./");
     await expect(
       page.getByRole("button", { name: "Server Counter: 0" }),
-    ).toBeVisible({ timeout: 0 });
+    ).toBeVisible({ timeout: 10 });
   }).toPass();
 
   await page.getByRole("button", { name: "Server Counter: 0" }).click();
@@ -119,7 +119,7 @@ async function testServerActionUpdate(page: Page, options: { js: boolean }) {
     if (!options.js) await page.goto("./");
     await expect(
       page.getByRole("button", { name: "Server Counter: 0" }),
-    ).toBeVisible({ timeout: 0 });
+    ).toBeVisible({ timeout: 10 });
   }).toPass();
 }
 
@@ -259,7 +259,7 @@ async function testAddRemoveCssClient(page: Page, options: { js: boolean }) {
     await expect(page.locator(".test-style-client-dep")).toHaveCSS(
       "color",
       "rgb(0, 0, 0)",
-      { timeout: 0 },
+      { timeout: 10 },
     );
   }).toPass();
 
@@ -271,7 +271,7 @@ async function testAddRemoveCssClient(page: Page, options: { js: boolean }) {
     await expect(page.locator(".test-style-client-dep")).toHaveCSS(
       "color",
       "rgb(255, 165, 0)",
-      { timeout: 0 },
+      { timeout: 10 },
     );
   }).toPass();
 }

--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -260,10 +260,8 @@ async function testAddRemoveCssClient(page: Page, options: { js: boolean }) {
       `/* import "./client-dep.css"; */`,
     ),
   );
-  if (!options.js) {
-    await page.waitForTimeout(100);
-    await page.reload();
-  }
+  await page.waitForTimeout(100);
+  if (!options.js) await page.reload();
   await expect(page.locator(".test-style-client-dep")).toHaveCSS(
     "color",
     "rgb(0, 0, 0)",
@@ -271,10 +269,8 @@ async function testAddRemoveCssClient(page: Page, options: { js: boolean }) {
 
   // add back css import
   editor.reset();
-  if (!options.js) {
-    await page.waitForTimeout(100);
-    await page.reload();
-  }
+  await page.waitForTimeout(100);
+  if (!options.js) await page.reload();
   await expect(page.locator(".test-style-client-dep")).toHaveCSS(
     "color",
     "rgb(255, 165, 0)",

--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -261,38 +261,24 @@ async function testAddRemoveCssClient(page: Page, options: { js: boolean }) {
     ),
   );
   if (!options.js) {
-    await expect(async () => {
-      await page.reload();
-      await expect(page.locator(".test-style-client-dep")).toHaveCSS(
-        "color",
-        "rgb(0, 0, 0)",
-        { timeout: 10 },
-      );
-    }).toPass();
-  } else {
-    await expect(page.locator(".test-style-client-dep")).toHaveCSS(
-      "color",
-      "rgb(0, 0, 0)",
-    );
+    await page.waitForTimeout(100);
+    await page.reload();
   }
+  await expect(page.locator(".test-style-client-dep")).toHaveCSS(
+    "color",
+    "rgb(0, 0, 0)",
+  );
 
   // add back css import
   editor.reset();
   if (!options.js) {
-    await expect(async () => {
-      await page.reload();
-      await expect(page.locator(".test-style-client-dep")).toHaveCSS(
-        "color",
-        "rgb(255, 165, 0)",
-        { timeout: 10 },
-      );
-    }).toPass();
-  } else {
-    await expect(page.locator(".test-style-client-dep")).toHaveCSS(
-      "color",
-      "rgb(255, 165, 0)",
-    );
+    await page.waitForTimeout(100);
+    await page.reload();
   }
+  await expect(page.locator(".test-style-client-dep")).toHaveCSS(
+    "color",
+    "rgb(255, 165, 0)",
+  );
 }
 
 test("css hmr server @dev", async ({ page }) => {

--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -261,20 +261,26 @@ async function testAddRemoveCssClient(page: Page, options: { js: boolean }) {
     ),
   );
   await page.waitForTimeout(100);
-  if (!options.js) await page.reload();
-  await expect(page.locator(".test-style-client-dep")).toHaveCSS(
-    "color",
-    "rgb(0, 0, 0)",
-  );
+  await expect(async () => {
+    if (!options.js) await page.reload();
+    await expect(page.locator(".test-style-client-dep")).toHaveCSS(
+      "color",
+      "rgb(0, 0, 0)",
+      { timeout: 0 },
+    );
+  }).toPass();
 
   // add back css import
   editor.reset();
   await page.waitForTimeout(100);
-  if (!options.js) await page.reload();
-  await expect(page.locator(".test-style-client-dep")).toHaveCSS(
-    "color",
-    "rgb(255, 165, 0)",
-  );
+  await expect(async () => {
+    if (!options.js) await page.reload();
+    await expect(page.locator(".test-style-client-dep")).toHaveCSS(
+      "color",
+      "rgb(255, 165, 0)",
+      { timeout: 0 },
+    );
+  }).toPass();
 }
 
 test("css hmr server @dev", async ({ page }) => {

--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -82,6 +82,7 @@ testNoJs("module preload on ssr @build", async ({ page }) => {
 test("server reference update @dev @js", async ({ page }) => {
   await page.goto("./");
   await waitForHydration(page);
+  await using _ = await expectNoReload(page);
   await testServerActionUpdate(page, { js: true });
 });
 
@@ -101,14 +102,12 @@ async function testServerActionUpdate(page: Page, options: { js: boolean }) {
   editor.edit((s) =>
     s.replace("const TEST_UPDATE = 1;", "const TEST_UPDATE = 10;"),
   );
-  if (!options.js) {
-    await expect(async () => {
-      await page.goto("./");
-      await expect(
-        page.getByRole("button", { name: "Server Counter: 0" }),
-      ).toBeVisible({ timeout: 10 });
-    }).toPass();
-  }
+  await expect(async () => {
+    if (!options.js) await page.goto("./");
+    await expect(
+      page.getByRole("button", { name: "Server Counter: 0" }),
+    ).toBeVisible({ timeout: 0 });
+  }).toPass();
 
   await page.getByRole("button", { name: "Server Counter: 0" }).click();
   await expect(
@@ -116,18 +115,12 @@ async function testServerActionUpdate(page: Page, options: { js: boolean }) {
   ).toBeVisible();
 
   editor.reset();
-  if (!options.js) {
-    await expect(async () => {
-      await page.goto("./");
-      await expect(
-        page.getByRole("button", { name: "Server Counter: 0" }),
-      ).toBeVisible({ timeout: 10 });
-    }).toPass();
-  }
-
-  await expect(
-    page.getByRole("button", { name: "Server Counter: 0" }),
-  ).toBeVisible();
+  await expect(async () => {
+    if (!options.js) await page.goto("./");
+    await expect(
+      page.getByRole("button", { name: "Server Counter: 0" }),
+    ).toBeVisible({ timeout: 0 });
+  }).toPass();
 }
 
 test("client hmr @dev", async ({ page }) => {

--- a/packages/rsc/examples/basic/e2e/helper.ts
+++ b/packages/rsc/examples/basic/e2e/helper.ts
@@ -34,6 +34,7 @@ export async function expectNoReload(page: Page) {
 
 export function createEditor(filepath: string) {
   const init = readFileSync(filepath, "utf-8");
+  originalFiles[filepath] ??= init;
   let current = init;
   return {
     edit(editFn: (data: string) => string) {
@@ -47,3 +48,11 @@ export function createEditor(filepath: string) {
     },
   };
 }
+
+const originalFiles: Record<string, string> = {};
+
+test.afterAll(() => {
+  for (const [filepath, content] of Object.entries(originalFiles)) {
+    writeFileSync(filepath, content);
+  }
+});

--- a/packages/rsc/examples/basic/playwright.config.ts
+++ b/packages/rsc/examples/basic/playwright.config.ts
@@ -35,5 +35,5 @@ export default defineConfig({
   grepInvert: isPreview ? /@dev/ : /@build/,
   forbidOnly: !!process.env["CI"],
   retries: process.env["CI"] ? 2 : 0,
-  reporter: "list",
+  reporter: process.env["CI"] ? "github" : "list",
 });

--- a/packages/rsc/examples/basic/playwright.config.ts
+++ b/packages/rsc/examples/basic/playwright.config.ts
@@ -17,6 +17,9 @@ export default defineConfig({
       slowMo: process.env.E2E_SLOWMO ? 500 : 0,
     },
   },
+  expect: {
+    toPass: { timeout: 5000 },
+  },
   projects: [
     {
       name: "chromium",

--- a/packages/rsc/examples/react-router/playwright.config.ts
+++ b/packages/rsc/examples/react-router/playwright.config.ts
@@ -28,5 +28,5 @@ export default defineConfig({
   grepInvert: isPreview ? /@dev/ : /@build/,
   forbidOnly: !!process.env["CI"],
   retries: process.env["CI"] ? 2 : 0,
-  reporter: "list",
+  reporter: process.env["CI"] ? "github" : "list",
 });


### PR DESCRIPTION
Not sure why only macos is being flaky. Is this watcher thing we might need to adjust like this https://github.com/vitejs/vite/blob/c12795522fd95d3535100293f4cf53c53c3f301f/playground/hmr-ssr/__tests__/hmr-ssr.spec.ts#L1090-L1095?

For now, adding a timeout to file editing.