### PR TITLE
feat(transforms): support encrypt closure bind

### DIFF
--- a/packages/transforms/src/server-action.ts
+++ b/packages/transforms/src/server-action.ts
@@ -12,6 +12,8 @@ export function transformServerActionServer(
   options: {
     runtime: (value: string, name: string) => string;
     rejectNonAsyncFunction?: boolean;
+    encode?: (value: string) => string;
+    decode?: (value: string) => string;
   },
 ) {
   // TODO: unify (generalize transformHoistInlineDirective to support top leve directive case)


### PR DESCRIPTION
- part of https://github.com/hi-ogawa/vite-plugins/issues/881

## todo

- [x] implement transform
- [ ] add example https://github.com/hi-ogawa/vite-plugins/pull/897
  - [ ] no-op encode/decode
  - [ ] flight serialize without key
  - [ ] flight serialize with key