### PR TITLE
test(rsc): test nojs action

### DIFF
--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -483,38 +483,65 @@ test("ssr rsc payload encoding", async ({ page }) => {
   );
 });
 
-test("action bind simple", async ({ page }) => {
+test("action bind simple @js", async ({ page }) => {
   await page.goto("./");
   await waitForHydration(page);
   await using _ = await expectNoReload(page);
+  await testActionBindSimple(page);
+});
+
+testNoJs("action bind simple @nojs", async ({ page }) => {
+  await page.goto("./");
+  await testActionBindSimple(page);
+});
+
+async function testActionBindSimple(page: Page) {
   await page
     .getByRole("button", { name: "test-server-action-bind-simple" })
     .click();
   await expect(page.getByTestId("test-server-action-bind-simple")).toHaveText(
     "true",
   );
-});
+}
 
-test("action bind client", async ({ page }) => {
+test("action bind client @js", async ({ page }) => {
   await page.goto("./");
   await waitForHydration(page);
   await using _ = await expectNoReload(page);
+  await testActionBindClient(page);
+});
+
+testNoJs("action bind client @nojs", async ({ page }) => {
+  await page.goto("./");
+  await testActionBindClient(page);
+});
+
+async function testActionBindClient(page: Page) {
   await page
     .getByRole("button", { name: "test-server-action-bind-client" })
     .click();
   await expect(page.getByTestId("test-server-action-bind-client")).toHaveText(
     "true",
   );
-});
+}
 
-test("action bind action", async ({ page }) => {
+test("action bind action @js", async ({ page }) => {
   await page.goto("./");
   await waitForHydration(page);
   await using _ = await expectNoReload(page);
+  await testActionBindAction(page);
+});
+
+testNoJs("action bind action @nojs", async ({ page }) => {
+  await page.goto("./");
+  await testActionBindAction(page);
+});
+
+async function testActionBindAction(page: Page) {
   await page
     .getByRole("button", { name: "test-server-action-bind-action" })
     .click();
   await expect(page.getByTestId("test-server-action-bind-action")).toHaveText(
     "[true,true]",
   );
-});
+}

--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -511,7 +511,12 @@ test("action bind client @js", async ({ page }) => {
   await testActionBindClient(page);
 });
 
-testNoJs("action bind client @nojs", async ({ page }) => {
+// TODO: not working
+//   Failed to serialize an action for progressive enhancement:
+//   Error: React Element cannot be passed to Server Functions from the Client without a temporary reference set. Pass a TemporaryReferenceSet to the options.
+//     [</>]
+//      ^^^
+testNoJs.skip("action bind client @nojs", async ({ page }) => {
   await page.goto("./");
   await testActionBindClient(page);
 });

--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -511,11 +511,7 @@ test("action bind client @js", async ({ page }) => {
   await testActionBindClient(page);
 });
 
-// TODO: not working
-//   Failed to serialize an action for progressive enhancement:
-//   Error: React Element cannot be passed to Server Functions from the Client without a temporary reference set. Pass a TemporaryReferenceSet to the options.
-//     [</>]
-//      ^^^
+// this doesn't work on Next either https://github.com/hi-ogawa/reproductions/tree/main/next-rsc-client-action-bind
 testNoJs.skip("action bind client @nojs", async ({ page }) => {
   await page.goto("./");
   await testActionBindClient(page);


### PR DESCRIPTION
While testing https://github.com/hi-ogawa/vite-plugins/pull/897, I just noticed `test-server-action-bind-client` breaks with progressive enhancement form.

## todo

- [x] how about next?
  - got a same error https://github.com/hi-ogawa/reproductions/tree/main/next-rsc-client-action-bind