### PR TITLE
fix(rsc): throw on client reference call on server

### DIFF
--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -572,7 +572,10 @@ function vitePluginUseClient(): Plugin[] {
         const result = transformDirectiveProxyExport_(ast, {
           directive: "use client",
           runtime: (name) =>
-            `$$ReactServer.registerClientReference({}, ${JSON.stringify(referenceKey)}, ${JSON.stringify(name)})`,
+            `$$ReactServer.registerClientReference(` +
+            `() => { new Error("Attempted to call client reference export '" + ${JSON.stringify(name)} + "' on server") },` +
+            `${JSON.stringify(referenceKey)},` +
+            `${JSON.stringify(name)})`,
         });
         if (!result) return;
         const { output, exportNames } = result;

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -573,7 +573,7 @@ function vitePluginUseClient(): Plugin[] {
           directive: "use client",
           runtime: (name) =>
             `$$ReactServer.registerClientReference(` +
-            `() => { new Error("Attempted to call client reference export '" + ${JSON.stringify(name)} + "' on server") },` +
+            `() => { throw new Error("Unexpectedly client reference export '" + ${JSON.stringify(name)} + "' is called on server") },` +
             `${JSON.stringify(referenceKey)},` +
             `${JSON.stringify(name)})`,
         });


### PR DESCRIPTION
- follow up https://github.com/hi-ogawa/vite-plugins/pull/899

Now we get a similar error message as Next https://github.com/hi-ogawa/reproductions/tree/main/next-rsc-client-action-bind

```sh
Error: Unexpectedly client reference export 'ActionBindClient' is called on server
```