### PR TITLE
test(rsc): correctly test nojs action bind

### DIFF
--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -505,6 +505,9 @@ async function testActionBindSimple(page: Page) {
   await expect(page.getByTestId("test-server-action-bind-simple")).toHaveText(
     "true",
   );
+  await page
+    .getByRole("button", { name: "test-server-action-bind-reset" })
+    .click();
 }
 
 test("action bind client @js", async ({ page }) => {
@@ -530,6 +533,9 @@ async function testActionBindClient(page: Page) {
   await expect(page.getByTestId("test-server-action-bind-client")).toHaveText(
     "true",
   );
+  await page
+    .getByRole("button", { name: "test-server-action-bind-reset" })
+    .click();
 }
 
 test("action bind action @js", async ({ page }) => {
@@ -554,4 +560,7 @@ async function testActionBindAction(page: Page) {
   await expect(page.getByTestId("test-server-action-bind-action")).toHaveText(
     "[true,true]",
   );
+  await page
+    .getByRole("button", { name: "test-server-action-bind-reset" })
+    .click();
 }

--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -496,6 +496,9 @@ testNoJs("action bind simple @nojs", async ({ page }) => {
 });
 
 async function testActionBindSimple(page: Page) {
+  await expect(page.getByTestId("test-server-action-bind-simple")).toHaveText(
+    "[?]",
+  );
   await page
     .getByRole("button", { name: "test-server-action-bind-simple" })
     .click();
@@ -518,6 +521,9 @@ testNoJs.skip("action bind client @nojs", async ({ page }) => {
 });
 
 async function testActionBindClient(page: Page) {
+  await expect(page.getByTestId("test-server-action-bind-client")).toHaveText(
+    "[?]",
+  );
   await page
     .getByRole("button", { name: "test-server-action-bind-client" })
     .click();
@@ -539,6 +545,9 @@ testNoJs("action bind action @nojs", async ({ page }) => {
 });
 
 async function testActionBindAction(page: Page) {
+  await expect(page.getByTestId("test-server-action-bind-action")).toHaveText(
+    "[?]",
+  );
   await page
     .getByRole("button", { name: "test-server-action-bind-action" })
     .click();

--- a/packages/rsc/examples/basic/src/routes/action-bind/server.tsx
+++ b/packages/rsc/examples/basic/src/routes/action-bind/server.tsx
@@ -4,6 +4,21 @@
 import { ActionBindClient } from "./client";
 import { TestServerActionBindClientForm } from "./form";
 
+export function TestServerActionBindReset() {
+  return (
+    <form
+      action={async () => {
+        "use server";
+        testServerActionBindSimpleState = "[?]";
+        testServerActionBindActionState = "[?]";
+        testServerActionBindClientState++;
+      }}
+    >
+      <button>test-server-action-bind-reset</button>
+    </form>
+  );
+}
+
 let testServerActionBindSimpleState = "[?]";
 
 export function TestServerActionBindSimple() {
@@ -26,9 +41,12 @@ export function TestServerActionBindSimple() {
   );
 }
 
+let testServerActionBindClientState = 0;
+
 export function TestServerActionBindClient() {
   return (
     <TestServerActionBindClientForm
+      key={testServerActionBindClientState}
       action={async () => {
         "use server";
         return <ActionBindClient />;

--- a/packages/rsc/examples/basic/src/routes/root.tsx
+++ b/packages/rsc/examples/basic/src/routes/root.tsx
@@ -22,6 +22,7 @@ import "./server.css";
 import {
   TestServerActionBindAction,
   TestServerActionBindClient,
+  TestServerActionBindReset,
   TestServerActionBindSimple,
 } from "./action-bind/server";
 import styles from "./server.module.css";
@@ -73,6 +74,7 @@ export function Root(props: { url: URL }) {
         <TestActionFromClient />
         <TestUseActionState />
         <TestPayload testBinary={props.url.searchParams.has("test-binary")} />
+        <TestServerActionBindReset />
         <TestServerActionBindSimple />
         <TestServerActionBindClient />
         <TestServerActionBindAction />


### PR DESCRIPTION
The test were supposed to fail in https://github.com/hi-ogawa/vite-plugins/pull/897 but they are passing because server state is already "true" without resetting properly.