### PR TITLE
refactor(rsc): use `sharedConfigBuild: true`

### DIFF
--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -137,6 +137,7 @@ export default function vitePluginRsc({
           },
           builder: {
             sharedPlugins: true,
+            sharedConfigBuild: true,
             async buildApp(builder) {
               builder.environments.rsc!.config.build.write = false;
               builder.environments.ssr!.config.build.write = false;


### PR DESCRIPTION
I noticed `configEnvironment` is called 9 times in total https://github.com/hi-ogawa/vite-plugins/pull/897#discussion_r2117156441. I'm not sure if this is intended to happen even if `sharedConfigBuild: false`, but in our case, we should have `sharedConfigBuild: true` anyways, so let's do that.

---

(Ah okay, probably this is expected for `sharedConfigBuild: false`)