### PR TITLE
test(rsc): add server serialization example

### DIFF
--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -564,3 +564,11 @@ async function testActionBindAction(page: Page) {
     .getByRole("button", { name: "test-server-action-bind-reset" })
     .click();
 }
+
+test("test serialization @js", async ({ page }) => {
+  await page.goto("./");
+  await waitForHydration(page);
+  await expect(page.getByTestId("serialization")).toHaveText("?");
+  await page.getByTestId("serialization").click();
+  await expect(page.getByTestId("serialization")).toHaveText("ok");
+});

--- a/packages/rsc/examples/basic/src/routes/root.tsx
+++ b/packages/rsc/examples/basic/src/routes/root.tsx
@@ -25,6 +25,7 @@ import {
   TestServerActionBindReset,
   TestServerActionBindSimple,
 } from "./action-bind/server";
+import { TestSerializationServer } from "./serialization/server";
 import styles from "./server.module.css";
 
 export function Root(props: { url: URL }) {
@@ -78,6 +79,7 @@ export function Root(props: { url: URL }) {
         <TestServerActionBindSimple />
         <TestServerActionBindClient />
         <TestServerActionBindAction />
+        <TestSerializationServer />
       </body>
     </html>
   );

--- a/packages/rsc/examples/basic/src/routes/serialization/action.tsx
+++ b/packages/rsc/examples/basic/src/routes/serialization/action.tsx
@@ -1,0 +1,6 @@
+"use server";
+
+export async function testSerializationAction() {
+  console.log("[test-serialization-action]");
+  return "ok";
+}

--- a/packages/rsc/examples/basic/src/routes/serialization/client.tsx
+++ b/packages/rsc/examples/basic/src/routes/serialization/client.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import React from "react";
+
+export function TestSerializationClient(props: { action: () => Promise<any> }) {
+  const [state, setState] = React.useState("?");
+  return (
+    <button
+      data-testid="serialization"
+      onClick={async () => {
+        const result = await props.action();
+        setState(result);
+      }}
+    >
+      {state}
+    </button>
+  );
+}

--- a/packages/rsc/examples/basic/src/routes/serialization/server.tsx
+++ b/packages/rsc/examples/basic/src/routes/serialization/server.tsx
@@ -1,8 +1,27 @@
+import {
+  createFromReadableStream,
+  renderToReadableStream,
+} from "@hiogawa/vite-rsc/rsc";
 import { testSerializationAction } from "./action";
 import { TestSerializationClient } from "./client";
 
 export function TestSerializationServer() {
   const original = <TestSerializationClient action={testSerializationAction} />;
-  const deserialized = original;
+  let serialized = renderToReadableStream(original);
+  // debug serialization
+  if (0) {
+    serialized = serialized
+      .pipeThrough(new TextDecoderStream())
+      .pipeThrough(
+        new TransformStream({
+          transform(chunk, controller) {
+            console.log("[test-serialization]", { chunk });
+            controller.enqueue(chunk);
+          },
+        }),
+      )
+      .pipeThrough(new TextEncoderStream());
+  }
+  const deserialized = createFromReadableStream<typeof original>(serialized);
   return <div>test-serialization:{deserialized}</div>;
 }

--- a/packages/rsc/examples/basic/src/routes/serialization/server.tsx
+++ b/packages/rsc/examples/basic/src/routes/serialization/server.tsx
@@ -1,0 +1,8 @@
+import { testSerializationAction } from "./action";
+import { TestSerializationClient } from "./client";
+
+export function TestSerializationServer() {
+  const original = <TestSerializationClient action={testSerializationAction} />;
+  const deserialized = original;
+  return <div>test-serialization:{deserialized}</div>;
+}


### PR DESCRIPTION
Initially introduced for action bind encryption (https://github.com/hi-ogawa/vite-plugins/pull/896, https://github.com/hi-ogawa/vite-plugins/pull/905), but now adding an explicit server serialization as test cases.