### PR TITLE
refactor(rsc): simplify client css ssr

### DIFF
--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -1083,6 +1083,21 @@ export function vitePluginRscCss({
           const hrefs = result.hrefs.map((href) => assetsURL(href.slice(1)));
           return `export default ${JSON.stringify(hrefs)}`;
         }
+        // TODO: need to invalidate like https://github.com/hi-ogawa/vite-plugins/pull/876
+        if (id.startsWith("\0virtual:vite-rsc/client-css-browser/")) {
+          assert(this.environment.mode === 'dev')
+          id = id.slice("\0virtual:vite-rsc/client-css-browser/".length);
+          const mod =
+            await server.environments.ssr.moduleGraph.getModuleByUrl(id);
+          if (!mod?.id || !mod?.file) {
+            return `export {}`;
+          }
+          const result = collectCss(server.environments.ssr, mod.id);
+          const ids = result.ids.map((id) => id.replace(/^\0/, ""));
+          let code = ids.map((id) => `import ${JSON.stringify(id)};\n`).join("");
+          code += `if (import.meta.hot) { import.meta.hot.accept() }\n`;
+          return code;
+        }
       },
     },
   ];

--- a/packages/rsc/src/ssr.tsx
+++ b/packages/rsc/src/ssr.tsx
@@ -13,9 +13,16 @@ export function initialize(): void {
     load: async (id) => {
       if (import.meta.env.DEV) {
         const mod = await import(/* @vite-ignore */ id);
-        const modCss = await import(
-          /* @vite-ignore */ "/@id/__x00__virtual:vite-rsc/css/dev-ssr/" + id
-        );
+        // const modCss = await import(
+        //   /* @vite-ignore */ "/@id/__x00__virtual:vite-rsc/css/dev-ssr/" + id
+        // );
+        const modCss = {
+          default: [
+            "/@id/__x00__virtual:vite-rsc/client-css-browser?importer=" +
+              encodeURIComponent(id),
+          ],
+        };
+        // "/@id/__x00__virtual:vite-rsc/css/dev-ssr/"
         return wrapResourceProxy(mod, { js: [], css: modCss.default });
       } else {
         const import_ = clientReferences.default[id];


### PR DESCRIPTION
- inspired by https://github.com/hi-ogawa/vite-plugins/pull/876

This would allow avoiding dev specific client css preinit on ssr and unify it via "prepare destination".

---

Nope, obviously this doesn't work and missing the point. We need to add css links and not js proxy which injects css on csr.