### PR TITLE
refactor!: simplify plugin options in favor of `rollupOptions.input`

### DIFF
--- a/packages/rsc/README.md
+++ b/packages/rsc/README.md
@@ -40,7 +40,7 @@ export default defineConfig() {
         // - RSC deserialization for hydration
         // - refetch and re-render RSC
         // - calling server functions
-        browser: "./src/entry.browser.tsx",
+        client: "./src/entry.browser.tsx",
       },
     })
   ]

--- a/packages/rsc/examples/basic-doc/vite.config.ts
+++ b/packages/rsc/examples/basic-doc/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   plugins: [
     rsc({
       entries: {
-        browser: "./src/entry.browser.tsx",
+        client: "./src/entry.browser.tsx",
         rsc: "./src/entry.rsc.tsx",
         ssr: "./src/entry.ssr.tsx",
       },

--- a/packages/rsc/examples/basic/vite.config.ts
+++ b/packages/rsc/examples/basic/vite.config.ts
@@ -24,9 +24,9 @@ export default defineConfig({
     react(),
     rsc({
       entries: {
-        browser: "./src/client.tsx",
-        rsc: "./src/server.tsx",
+        client: "./src/client.tsx",
         ssr: "@hiogawa/vite-rsc/extra/ssr",
+        rsc: "./src/server.tsx",
       },
     }),
     // avoid ecosystem CI fail due to vite-plugin-inspect compatibility

--- a/packages/rsc/examples/hono/vite.config.ts
+++ b/packages/rsc/examples/hono/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     react(),
     rsc({
       entries: {
-        browser: "./src/client.tsx",
+        client: "./src/client.tsx",
         rsc: "./src/server.tsx",
         ssr: "@hiogawa/vite-rsc/extra/ssr",
       },

--- a/packages/rsc/examples/react-router/cf/vite.config.ts
+++ b/packages/rsc/examples/react-router/cf/vite.config.ts
@@ -1,9 +1,27 @@
 import { cloudflare } from "@cloudflare/vite-plugin";
-import { defineConfig, mergeConfig } from "vite";
-import baseConfig from "../vite.config.ts";
+import rsc from "@hiogawa/vite-rsc/plugin";
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+import inspect from "vite-plugin-inspect";
+import { reactRouter } from "../react-router-vite/plugin";
 
-const cfConfig = defineConfig({
+export default defineConfig({
+  clearScreen: false,
+  build: {
+    minify: false,
+  },
   plugins: [
+    tailwindcss(),
+    react(),
+    reactRouter(),
+    rsc({
+      entries: {
+        client: "./react-router-vite/entry.browser.tsx",
+      },
+      disableServerHandler: true,
+    }),
+    inspect(),
     cloudflare({
       configPath: "./cf/wrangler.ssr.jsonc",
       viteEnvironment: {
@@ -42,13 +60,6 @@ const cfConfig = defineConfig({
         // workaround (fixed in Vite 7) https://github.com/vitejs/vite/pull/20077
         (config.environments as any).ssr.resolve.noExternal = true;
         (config.environments as any).rsc.resolve.noExternal = true;
-
-        // overwrite server entries
-        // TODO: better plugin API to customize?
-        (config.environments as any).ssr.build.rollupOptions.input.index =
-          "./cf/entry.ssr.tsx";
-        (config.environments as any).rsc.build.rollupOptions.input.index =
-          "./cf/entry.rsc.tsx";
       },
     },
   ],
@@ -71,5 +82,3 @@ const cfConfig = defineConfig({
     },
   },
 });
-
-export default mergeConfig(cfConfig, baseConfig) as any;

--- a/packages/rsc/examples/react-router/vite.config.ts
+++ b/packages/rsc/examples/react-router/vite.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     reactRouter(),
     rsc({
       entries: {
-        browser: "./react-router-vite/entry.browser.tsx",
+        client: "./react-router-vite/entry.browser.tsx",
         ssr: "./react-router-vite/entry.ssr.tsx",
         rsc: "./react-router-vite/entry.rsc.tsx",
       },

--- a/packages/rsc/examples/starter/src/framework/entry.rsc.tsx
+++ b/packages/rsc/examples/starter/src/framework/entry.rsc.tsx
@@ -10,8 +10,13 @@ import { Root } from "../root.tsx";
 // 3. Delegate to SSR for full HTML rendering
 
 export type RscPayload = {
+  // this demo renders/serializes/deserizlies entire root html element
+  // but this mechanism can be changed to render/fetch different parts of components
+  // based on your own route conventions.
   root: React.ReactNode;
+  // server action return value of non-progressive enhancement case
   returnValue?: unknown;
+  // server action form state (e.g. useActionState) of progressive enhancement case
   formState?: ReactFormState;
 };
 
@@ -39,6 +44,7 @@ export default async function handler(request: Request): Promise<Response> {
     } else {
       // otherwise server function is called via `<form action={...}>`
       // before hydration (e.g. when javascript is disabled).
+      // (aka progressive enhancement)
       const formData = await request.formData();
       const decodedAction = await ReactServer.decodeAction(formData);
       const result = await decodedAction();
@@ -50,9 +56,7 @@ export default async function handler(request: Request): Promise<Response> {
   // so that new render reflects updated state from server function call
   // to achieve single round trip to mutate and fetch from server.
   const rscStream = ReactServer.renderToReadableStream<RscPayload>({
-    // in this example, we always render the same `<Root />`,
-    // but this can be changed to render different components based on your own route conventions
-    // e.g. by passing `request.url`.
+    // in this example, we always render the same `<Root />`
     root: <Root />,
     returnValue,
     formState,

--- a/packages/rsc/examples/starter/vite.config.ts
+++ b/packages/rsc/examples/starter/vite.config.ts
@@ -4,45 +4,34 @@ import { defineConfig } from "vite";
 import inspect from "vite-plugin-inspect";
 
 export default defineConfig({
-  plugins: [
-    react(),
-    rsc({
-      // TODO: use rollupOptions.input instead
-      entries: {
-        browser: "./src/framework/entry.browser.tsx",
-        rsc: "./src/framework/entry.rsc.tsx",
-        ssr: "./src/framework/entry.ssr.tsx",
+  plugins: [react(), rsc(), inspect({ build: true })],
+  environments: {
+    client: {
+      build: {
+        rollupOptions: {
+          input: {
+            index: "./src/framework/entry.browser.tsx",
+          },
+        },
       },
-    }),
-    inspect({ build: true }),
-  ],
-  // environments: {
-  //   client: {
-  //     build: {
-  //       rollupOptions: {
-  //         input: {
-  //           index: "./src/framework/entry.browser.tsx",
-  //         },
-  //       },
-  //     },
-  //   },
-  //   ssr: {
-  //     build: {
-  //       rollupOptions: {
-  //         input: {
-  //           index: "./src/framework/entry.ssr.tsx",
-  //         },
-  //       },
-  //     },
-  //   },
-  //   rsc: {
-  //     build: {
-  //       rollupOptions: {
-  //         input: {
-  //           index: "./src/framework/entry.rsc.tsx",
-  //         },
-  //       },
-  //     },
-  //   },
-  // },
+    },
+    ssr: {
+      build: {
+        rollupOptions: {
+          input: {
+            index: "./src/framework/entry.ssr.tsx",
+          },
+        },
+      },
+    },
+    rsc: {
+      build: {
+        rollupOptions: {
+          input: {
+            index: "./src/framework/entry.rsc.tsx",
+          },
+        },
+      },
+    },
+  },
 });

--- a/packages/rsc/examples/starter/vite.config.ts
+++ b/packages/rsc/examples/starter/vite.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   plugins: [
     react(),
     rsc({
+      // TODO: use rollupOptions.input instead
       entries: {
         browser: "./src/framework/entry.browser.tsx",
         rsc: "./src/framework/entry.rsc.tsx",
@@ -15,4 +16,33 @@ export default defineConfig({
     }),
     inspect({ build: true }),
   ],
+  // environments: {
+  //   client: {
+  //     build: {
+  //       rollupOptions: {
+  //         input: {
+  //           index: "./src/framework/entry.browser.tsx",
+  //         },
+  //       },
+  //     },
+  //   },
+  //   ssr: {
+  //     build: {
+  //       rollupOptions: {
+  //         input: {
+  //           index: "./src/framework/entry.ssr.tsx",
+  //         },
+  //       },
+  //     },
+  //   },
+  //   rsc: {
+  //     build: {
+  //       rollupOptions: {
+  //         input: {
+  //           index: "./src/framework/entry.rsc.tsx",
+  //         },
+  //       },
+  //     },
+  //   },
+  // },
 });

--- a/packages/rsc/examples/starter/vite.config.ts
+++ b/packages/rsc/examples/starter/vite.config.ts
@@ -3,8 +3,18 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import inspect from "vite-plugin-inspect";
 
+// TODO: explain
+
 export default defineConfig({
-  plugins: [react(), rsc(), inspect({ build: true })],
+  plugins: [
+    // TODO
+    react(),
+    // TODO
+    rsc(),
+    // TODO
+    inspect({ build: true }),
+  ],
+  // TODO
   environments: {
     client: {
       build: {

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -66,6 +66,9 @@ export default function vitePluginRsc({
     rsc: string;
     ssr: string;
   };
+  ssrEntry?: string;
+  handlerEntry?: string;
+  getServerHandler?: () => Promise<string>;
 }): Plugin[] {
   return [
     {

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -424,7 +424,8 @@ export default function vitePluginRsc(
           }
 
           const assetDeps = collectAssetDeps(bundle);
-          const entry = assetDeps[browserEntryId]!;
+          const entry = assetDeps[browserEntryId];
+          assert(entry);
           const entryUrl = assetsURL(entry.chunk.fileName);
           const clientReferenceDeps: Record<string, AssetDeps> = {};
           for (const [id, meta] of Object.entries(clientReferenceMetaMap)) {

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -63,6 +63,10 @@ const VIRTUAL_ENTRIES = {
 
 export default function vitePluginRsc(
   rscPluginOptions: {
+    /**
+     * shorthand for configuring `environments.(name).build.rollupOptions.input.index`
+     */
+    entries?: Record<"client" | "ssr" | "rsc", string>;
     disableServerHandler?: boolean;
   } = {},
 ): Plugin[] {
@@ -82,6 +86,11 @@ export default function vitePluginRsc(
             client: {
               build: {
                 outDir: "dist/client",
+                rollupOptions: {
+                  input: rscPluginOptions.entries?.client && {
+                    index: rscPluginOptions.entries.client,
+                  },
+                },
               },
               optimizeDeps: {
                 include: [
@@ -94,6 +103,11 @@ export default function vitePluginRsc(
             ssr: {
               build: {
                 outDir: "dist/ssr",
+                rollupOptions: {
+                  input: rscPluginOptions.entries?.ssr && {
+                    index: rscPluginOptions.entries.ssr,
+                  },
+                },
               },
               resolve: {
                 noExternal: [PKG_NAME],
@@ -104,6 +118,15 @@ export default function vitePluginRsc(
               },
             },
             rsc: {
+              build: {
+                outDir: "dist/rsc",
+                emitAssets: true,
+                rollupOptions: {
+                  input: rscPluginOptions.entries?.rsc && {
+                    index: rscPluginOptions.entries.rsc,
+                  },
+                },
+              },
               // `configEnvironment` below adds more `noExternal`
               resolve: {
                 conditions: ["react-server", ...defaultServerConditions],
@@ -124,10 +147,6 @@ export default function vitePluginRsc(
                   `${PKG_NAME}/vendor/react-server-dom/client.edge`,
                 ],
                 exclude: [PKG_NAME],
-              },
-              build: {
-                outDir: "dist/rsc",
-                emitAssets: true,
               },
             },
           },

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -66,7 +66,7 @@ export default function vitePluginRsc(
     /**
      * shorthand for configuring `environments.(name).build.rollupOptions.input.index`
      */
-    entries?: Record<"client" | "ssr" | "rsc", string>;
+    entries?: Partial<Record<"client" | "ssr" | "rsc", string>>;
     disableServerHandler?: boolean;
   } = {},
 ): Plugin[] {

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -53,6 +53,8 @@ const clientReferenceMetaMap: Record</* id */ string, ClientReferenceMeta> = {};
 const serverResourcesMetaMap: Record<string, { key: string }> = {};
 
 const PKG_NAME = "@hiogawa/vite-rsc";
+
+// dev-only wrapper virtual module of rollupOptions.input.index
 const VIRTUAL_ENTRIES = {
   browser: "virtual:vite-rsc/entry-browser",
   rsc: "virtual:vite-rsc/entry-rsc",
@@ -381,6 +383,7 @@ export default function vitePluginRsc(
       load(id) {
         if (id === "\0virtual:vite-rsc/assets-manifest") {
           assert(this.environment.name !== "client");
+          assert(this.environment.mode === "dev");
           const entryUrl = assetsURL("@id/__x00__" + VIRTUAL_ENTRIES.browser);
           const manifest: AssetsManifest = {
             bootstrapScriptContent: `import(${JSON.stringify(entryUrl)})`,

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -63,17 +63,9 @@ const VIRTUAL_ENTRIES = {
 
 export default function vitePluginRsc(
   rscPluginOptions: {
-    entries?: {
-      browser: string;
-      rsc: string;
-      ssr: string;
-    };
-    ssrEntry?: string;
-    handlerEntry?: string;
     disableServerHandler?: boolean;
   } = {},
 ): Plugin[] {
-  // const { entries } = rscPluginOptions;
   return [
     {
       name: "rsc",

--- a/packages/rsc/src/rsc.tsx
+++ b/packages/rsc/src/rsc.tsx
@@ -37,6 +37,9 @@ export function initialize(): void {
   });
 }
 
+/**
+ * import ssr environment module specified by `environments.ssr.build.rollupOptions.input.index`
+ */
 export async function importSsr<T>(): Promise<T> {
   const mod = await import("virtual:vite-rsc/import-ssr" as any);
   if (import.meta.env.DEV) {


### PR DESCRIPTION
Part of https://github.com/hi-ogawa/vite-plugins/issues/924

## todo

- [x] replace `entries` with `rollupOptions.input.index`
  - [x] rsc
  - [x] ssr
  - [x] browser
- [x] can we still leave `rsc({ entries: { ... })` for convenience?
  - still breaking because `browser -> client` rename
- [x] ability to opt-out default server handlers
- ~simplify `getAssetsManifest().bootstrapScriptContent` API~ (later in https://github.com/hi-ogawa/vite-plugins/pull/957)
