### PR TITLE
refactor!: rework multi environment API (ssr module)

### DIFF
--- a/packages/rsc/examples/basic-doc/src/entry.rsc.tsx
+++ b/packages/rsc/examples/basic-doc/src/entry.rsc.tsx
@@ -1,5 +1,4 @@
 import * as ReactServer from "@hiogawa/vite-rsc/rsc"; // React core API
-import { importSsr } from "@hiogawa/vite-rsc/rsc"; // Vite specifc helper
 import { Hydrated } from "./components/client.tsx";
 
 // the plugin assumes `rsc` entry having default export of request handler
@@ -27,7 +26,9 @@ export default async function handler(request: Request): Promise<Response> {
   }
 
   // delegate to SSR environment for html rendering
-  const { handleSsr } = await importSsr<typeof import("./entry.ssr.tsx")>();
+  const { handleSsr } = await import.meta.viteRsc.loadSsrModule<
+    typeof import("./entry.ssr.tsx")
+  >("index");
   const htmlStream = await handleSsr(rscStream);
 
   // respond html

--- a/packages/rsc/examples/basic/src/server.ssr.tsx
+++ b/packages/rsc/examples/basic/src/server.ssr.tsx
@@ -1,0 +1,1 @@
+export * from "@hiogawa/vite-rsc/extra/ssr";

--- a/packages/rsc/examples/basic/src/server.tsx
+++ b/packages/rsc/examples/basic/src/server.tsx
@@ -6,7 +6,7 @@ export default async function handler(request: Request): Promise<Response> {
   const url = new URL(request.url);
   const root = (
     <>
-      {import.meta.viteRscCss}
+      {import.meta.viteRsc.loadCss()}
       <Root url={url} />
     </>
   );

--- a/packages/rsc/examples/basic/vite.config.ts
+++ b/packages/rsc/examples/basic/vite.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
     rsc({
       entries: {
         client: "./src/client.tsx",
-        ssr: "@hiogawa/vite-rsc/extra/ssr",
+        ssr: "./src/server.ssr.tsx",
         rsc: "./src/server.tsx",
       },
     }),

--- a/packages/rsc/examples/react-router/app/root.tsx
+++ b/packages/rsc/examples/react-router/app/root.tsx
@@ -12,7 +12,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>React Router Vite</title>
-        {import.meta.viteRscCss}
+        {import.meta.viteRsc.loadCss()}
       </head>
       <body>
         <header className="container px-8 my-8 mx-auto">

--- a/packages/rsc/examples/react-router/app/routes/home.tsx
+++ b/packages/rsc/examples/react-router/app/routes/home.tsx
@@ -16,7 +16,7 @@ export function loader({ request }: Route.LoaderArgs) {
 export function Component({ loaderData }: Route.ComponentProps) {
   return (
     <main className="container my-8 px-8 mx-auto">
-      {import.meta.viteRscCss}
+      {import.meta.viteRsc.loadCss()}
       <article className="paper prose max-w-none">
         <h1>Home</h1>
         <p>This is the home page.</p>

--- a/packages/rsc/examples/react-router/react-router-vite/entry.rsc.node.tsx
+++ b/packages/rsc/examples/react-router/react-router-vite/entry.rsc.node.tsx
@@ -1,0 +1,8 @@
+import { callServer } from "./entry.rsc";
+
+export default async function handler(requrest: Request) {
+  const entrySsr = await import.meta.viteRsc.loadSsrModule<
+    typeof import("./entry.ssr")
+  >("index");
+  return entrySsr.default(requrest, callServer);
+}

--- a/packages/rsc/examples/react-router/react-router-vite/entry.rsc.tsx
+++ b/packages/rsc/examples/react-router/react-router-vite/entry.rsc.tsx
@@ -1,7 +1,6 @@
 import {
   decodeAction,
   decodeReply,
-  importSsr,
   loadServerAction,
   renderToReadableStream,
 } from "@hiogawa/vite-rsc/rsc";
@@ -37,9 +36,4 @@ export async function callServer(request: Request) {
       });
     },
   });
-}
-
-export default async function handler(requrest: Request) {
-  const ssr = await importSsr<typeof import("./entry.ssr")>();
-  return ssr.default(requrest, callServer);
 }

--- a/packages/rsc/examples/react-router/vite.config.ts
+++ b/packages/rsc/examples/react-router/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
       entries: {
         client: "./react-router-vite/entry.browser.tsx",
         ssr: "./react-router-vite/entry.ssr.tsx",
-        rsc: "./react-router-vite/entry.rsc.tsx",
+        rsc: "./react-router-vite/entry.rsc.node.tsx",
       },
     }),
     inspect(),

--- a/packages/rsc/examples/starter/src/framework/entry.rsc.tsx
+++ b/packages/rsc/examples/starter/src/framework/entry.rsc.tsx
@@ -1,5 +1,4 @@
 import * as ReactServer from "@hiogawa/vite-rsc/rsc"; // RSC API
-import { importSsr } from "@hiogawa/vite-rsc/rsc"; // helper API
 import type { ReactFormState } from "react-dom/client";
 import { Root } from "../root.tsx";
 
@@ -81,10 +80,12 @@ export default async function handler(request: Request): Promise<Response> {
   }
 
   // Delegate to SSR environment for html rendering.
-  // The plugin provides `importSsr` helper to allow import SSR environment entry module
+  // The plugin provides `loadSsrModule` helper to allow loading SSR environment entry module
   // in RSC environment. however this can be customized by implementing own runtime communication
   // e.g. `@cloudflare/vite-plugin`'s service binding.
-  const ssrEntryModule = await importSsr<typeof import("./entry.ssr.tsx")>();
+  const ssrEntryModule = await import.meta.viteRsc.loadSsrModule<
+    typeof import("./entry.ssr.tsx")
+  >("index");
   const htmlStream = await ssrEntryModule.renderHTML({
     stream: rscStream,
     formState,

--- a/packages/rsc/examples/starter/src/root.tsx
+++ b/packages/rsc/examples/starter/src/root.tsx
@@ -17,7 +17,7 @@ export function Root() {
           and render associated resources inside server components.
           In this case, this will include `<link rel="stylesheet" />` for `index.css`.
         */}
-        {import.meta.viteRscCss}
+        {import.meta.viteRsc.loadCss()}
       </head>
       <body>
         <App />

--- a/packages/rsc/src/browser.ts
+++ b/packages/rsc/src/browser.ts
@@ -5,7 +5,7 @@ export * from "./react/browser";
 
 initialize();
 
-export function initialize(): void {
+function initialize(): void {
   setRequireModule({
     load: async (id) => {
       if (import.meta.env.DEV) {

--- a/packages/rsc/src/extra/rsc.tsx
+++ b/packages/rsc/src/extra/rsc.tsx
@@ -4,7 +4,6 @@ import {
   decodeAction,
   decodeFormState,
   decodeReply,
-  importSsr,
   loadServerAction,
   renderToReadableStream,
 } from "../rsc";
@@ -82,7 +81,9 @@ export async function renderRequest(
     });
   }
 
-  const ssrEntry = await importSsr<typeof import("./ssr")>();
+  const ssrEntry = await import.meta.viteRsc.loadSsrModule<
+    typeof import("./ssr")
+  >("index");
   return ssrEntry.renderHtml({
     stream,
     formState,

--- a/packages/rsc/src/rsc.tsx
+++ b/packages/rsc/src/rsc.tsx
@@ -1,7 +1,5 @@
-import * as assetsManifest from "virtual:vite-rsc/assets-manifest";
 import * as serverReferences from "virtual:vite-rsc/server-references";
 import { setRequireModule } from "./core/rsc";
-import type { AssetsManifest } from "./plugin";
 import { createFromReadableStream, renderToReadableStream } from "./react/rsc";
 import {
   arrayToStream,
@@ -21,7 +19,7 @@ export * from "./react/rsc";
 
 initialize();
 
-export function initialize(): void {
+function initialize(): void {
   setRequireModule({
     load: async (id) => {
       if (import.meta.env.DEV) {
@@ -35,22 +33,6 @@ export function initialize(): void {
       }
     },
   });
-}
-
-/**
- * import ssr environment module specified by `environments.ssr.build.rollupOptions.input.index`
- */
-export async function importSsr<T>(): Promise<T> {
-  const mod = await import("virtual:vite-rsc/import-ssr" as any);
-  if (import.meta.env.DEV) {
-    return mod.default();
-  } else {
-    return mod;
-  }
-}
-
-export function getAssetsManifest(): AssetsManifest {
-  return (assetsManifest as any).default;
 }
 
 // based on

--- a/packages/rsc/src/ssr.tsx
+++ b/packages/rsc/src/ssr.tsx
@@ -10,7 +10,7 @@ export * from "./react/ssr";
 
 initialize();
 
-export function initialize(): void {
+function initialize(): void {
   setRequireModule({
     load: async (id) => {
       if (import.meta.env.DEV) {
@@ -61,15 +61,6 @@ function preloadDeps(deps: AssetDeps) {
   }
   for (const href of deps.css) {
     ReactDOM.preinit(href, { as: "style" });
-  }
-}
-
-export async function importRsc<T>(): Promise<T> {
-  const mod = await import("virtual:vite-rsc/import-rsc" as any);
-  if (import.meta.env.DEV) {
-    return mod.default();
-  } else {
-    return mod;
   }
 }
 

--- a/packages/rsc/tsconfig.json
+++ b/packages/rsc/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": ["src", "e2e", "*.ts"],
+  "include": ["src", "e2e", "*.ts", "types"],
   "compilerOptions": {
     "noPropertyAccessFromIndexSignature": false,
     "noImplicitReturns": false,

--- a/packages/rsc/types/index.d.ts
+++ b/packages/rsc/types/index.d.ts
@@ -1,6 +1,9 @@
 declare global {
   interface ImportMeta {
-    readonly viteRscCss: import("react").JSX.Element;
+    readonly viteRsc: {
+      loadCss: () => import("react").ReactNode;
+      loadSsrModule: <T>(entry: string) => Promise<T>;
+    };
   }
 }
 


### PR DESCRIPTION
Brainstorming for https://github.com/hi-ogawa/vite-plugins/issues/924

```js
import.meta.viteRsc.importSsrEntry("index"); // picks up build.rollupOptions.index
import.meta.viteRsc.importSsr("./entry.ssr.tsx"); // arbitrary
```

Obviously 2nd one is nicer but it would involve discovery techniques. For now, let's start with `importSsrEntry` to make API less implicit than what we have now (i.e. assuming `input.index` everywhere).

Similarly, it's nice to have a way to reference bootstrap script instead of current `getAssetManifest` API. This should probably make injecting hmr preamble slightly easier without virtual module internally.

```js
import.meta.viteRsc.bootstrapBrowserEntry("index")
```

## todo

- [x] `loadCss`
  - just making it as a function so maybe there's some option we can squeeze later on without breaking change :)
- [x] `loadSsrModuleByEntry`
- [ ] ~`loadRscEntry`~ we don't need this for now
- [ ] `getBootstrapScriptContentByEntry` https://github.com/hi-ogawa/vite-plugins/pull/958

actually we should use virtual module anyways? e.g.

```js
await import("virtual:vite-rsc/load-ssr-entry/index")
await import("virtual:vite-rsc/get-bootstrap-entry/index")
```

I think anything do-able is fine other than needing to `import { importSsr } from "@hiogawa/vite-rsc/rsc` as package exports.

---

The down side of `import.meta.viteRsc` transform is that this transform can kick in even if the code is not used.