### PR TITLE
refactor: use `../` instead of `./../` path in output

### DIFF
--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -369,11 +369,13 @@ export default function vitePluginRsc(
           code = code.replaceAll(
             /['"]__vite_rsc_load_ssr_entry:(\w+)['"]/g,
             (_match, name) => {
-              const relativePath = path.relative(
-                path.join("dist/rsc", chunk.fileName, ".."),
-                path.join("dist/ssr", `${name}.js`),
+              const replacement = normalizeRelativePath(
+                path.relative(
+                  path.join("dist/rsc", chunk.fileName, ".."),
+                  path.join("dist/ssr", `${name}.js`),
+                ),
               );
-              return `(import(${JSON.stringify(normalizePath(relativePath))}))`;
+              return `(import(${JSON.stringify(replacement)}))`;
             },
           );
           return { code };
@@ -454,14 +456,12 @@ export default function vitePluginRsc(
       renderChunk(code, chunk) {
         if (code.includes("virtual:vite-rsc/assets-manifest")) {
           assert(this.environment.name !== "client");
-          let replacement = path.relative(
-            path.join(chunk.fileName, ".."),
-            BUILD_ASSETS_MANIFEST_NAME,
+          const replacement = normalizeRelativePath(
+            path.relative(
+              path.join(chunk.fileName, ".."),
+              BUILD_ASSETS_MANIFEST_NAME,
+            ),
           );
-          replacement = normalizePath(replacement);
-          if (!replacement.startsWith(".")) {
-            replacement = "./" + replacement;
-          }
           code = code.replaceAll(
             "virtual:vite-rsc/assets-manifest",
             () => replacement,
@@ -572,6 +572,11 @@ export default function vitePluginRsc(
     ...vitePluginFindSourceMapURL(),
     ...vitePluginRscCss(),
   ];
+}
+
+function normalizeRelativePath(s: string) {
+  s = normalizePath(s);
+  return s[0] === "." ? s : "./" + s;
 }
 
 function getEntrySource(

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -454,13 +454,17 @@ export default function vitePluginRsc(
       renderChunk(code, chunk) {
         if (code.includes("virtual:vite-rsc/assets-manifest")) {
           assert(this.environment.name !== "client");
-          const replacement = path.relative(
+          let replacement = path.relative(
             path.join(chunk.fileName, ".."),
             BUILD_ASSETS_MANIFEST_NAME,
           );
+          replacement = normalizePath(replacement);
+          if (!replacement.startsWith(".")) {
+            replacement = "./" + replacement;
+          }
           code = code.replaceAll(
             "virtual:vite-rsc/assets-manifest",
-            () => "./" + normalizePath(replacement),
+            () => replacement,
           );
           return { code };
         }


### PR DESCRIPTION
~I'm guessing this might be the cause of  https://github.com/hi-ogawa/rsc-movies/pull/6~

## before

```js
// packages/rsc/examples/basic/dist/rsc/assets/server-DvkQRHkL.js
import __vite_rsc_assets_manifest__ from "./../__vite_rsc_assets_manifest.js";

```

## after

```js
// packages/rsc/examples/basic/dist/rsc/assets/server-DcybpCbQ.js
import __vite_rsc_assets_manifest__ from "../__vite_rsc_assets_manifest.js";
```