### PR TITLE
fix: fix self package resolution when used as a transitive dependency

### DIFF
--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -67,8 +67,14 @@ export default function vitePluginRsc(
      */
     entries?: Partial<Record<"client" | "ssr" | "rsc", string>>;
     disableServerHandler?: boolean;
+    parentPackage?: string;
   } = {},
 ): Plugin[] {
+  let reactServerDomDep = `${PKG_NAME}/vendor/react-server-dom`;
+  if (rscPluginOptions.parentPackage) {
+    reactServerDomDep = `${rscPluginOptions.parentPackage} > ${reactServerDomDep}`;
+  }
+
   return [
     {
       name: "rsc",
@@ -94,7 +100,7 @@ export default function vitePluginRsc(
               optimizeDeps: {
                 include: [
                   "react-dom/client",
-                  `${PKG_NAME}/vendor/react-server-dom/client.browser`,
+                  `${reactServerDomDep}/client.browser`,
                 ],
                 exclude: [PKG_NAME],
               },
@@ -112,7 +118,7 @@ export default function vitePluginRsc(
                 noExternal: [PKG_NAME],
               },
               optimizeDeps: {
-                include: [`${PKG_NAME}/vendor/react-server-dom/client.edge`],
+                include: [`${reactServerDomDep}/client.edge`],
                 exclude: [PKG_NAME],
               },
             },
@@ -129,12 +135,7 @@ export default function vitePluginRsc(
               // `configEnvironment` below adds more `noExternal`
               resolve: {
                 conditions: ["react-server", ...defaultServerConditions],
-                noExternal: [
-                  "react",
-                  "react-dom",
-                  `${PKG_NAME}/vendor/react-server-dom/server.edge`,
-                  PKG_NAME,
-                ],
+                noExternal: ["react", "react-dom", PKG_NAME],
               },
               optimizeDeps: {
                 include: [
@@ -142,8 +143,8 @@ export default function vitePluginRsc(
                   "react-dom",
                   "react/jsx-runtime",
                   "react/jsx-dev-runtime",
-                  `${PKG_NAME}/vendor/react-server-dom/server.edge`,
-                  `${PKG_NAME}/vendor/react-server-dom/client.edge`,
+                  `${reactServerDomDep}/server.edge`,
+                  `${reactServerDomDep}/client.edge`,
                 ],
                 exclude: [PKG_NAME],
               },

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -74,15 +74,17 @@ export default function vitePluginRsc(
     parentPackage?: string;
   } = {},
 ): Plugin[] {
-  let reactServerDomDep = `${PKG_NAME}/vendor/react-server-dom`;
-  if (rscPluginOptions.parentPackage) {
-    reactServerDomDep = `${rscPluginOptions.parentPackage} > ${reactServerDomDep}`;
-  }
-
   return [
     {
       name: "rsc",
       config() {
+        const reactServerDomDep = [
+          rscPluginOptions.parentPackage,
+          `${PKG_NAME}/vendor/react-server-dom`,
+        ]
+          .filter(Boolean)
+          .join(">");
+
         return {
           appType: "custom",
           resolve: {

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -72,7 +72,7 @@ export default function vitePluginRsc(
     disableServerHandler?: boolean;
     /**
      * This is used to configure `optimizeDeps.include` properly when `@hiogwa/vite-rsc` is used as transitive dependency, e.g.
-     *   optimizeDeps.include: ["yourParentPackage > @higoawa/vite-rsc/xxx"]
+     *   optimizeDeps.include: ["yourFrameworkPackage > @higoawa/vite-rsc/xxx"]
      */
     parentPackage?: string;
   } = {},

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -67,6 +67,10 @@ export default function vitePluginRsc(
      */
     entries?: Partial<Record<"client" | "ssr" | "rsc", string>>;
     disableServerHandler?: boolean;
+    /**
+     * This is used to configure `optimizeDeps.include` properly when `@hiogwa/vite-rsc` is used as transitive dependency, e.g.
+     *   optimizeDeps.include: ["yourParentPackage > @higoawa/vite-rsc/xxx"]
+     */
     parentPackage?: string;
   } = {},
 ): Plugin[] {


### PR DESCRIPTION
- Closes https://github.com/hi-ogawa/vite-plugins/issues/968

## todo

- [x] `optimizeDeps.include`
  - there's likely no way to detect this in a robust manner, so let's just add a plugin option.
- [x] "use server/client" runtime
- [ ] test
  - hypothetical react-router vite pluign package?