### PR TITLE
refactor: resolve self runtime import instead of `dedupe`

### DIFF
--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert";
 import { createHash } from "node:crypto";
 import fs from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import {
@@ -27,6 +28,8 @@ import { crawlFrameworkPkgs } from "vitefu";
 import vitePluginRscCore from "./core/plugin";
 import { generateEncryptionKey, toBase64 } from "./utils/encryption-utils";
 import { normalizeViteImportAnalysisUrl } from "./vite-utils";
+
+const require = createRequire(import.meta.url);
 
 // state for build orchestration
 let serverReferences: Record<string, string> = {};
@@ -67,20 +70,26 @@ export default function vitePluginRsc(
      */
     entries?: Partial<Record<"client" | "ssr" | "rsc", string>>;
     disableServerHandler?: boolean;
+    /**
+     * This is used to configure `optimizeDeps.include` properly when `@hiogwa/vite-rsc` is used as transitive dependency, e.g.
+     *   optimizeDeps.include: ["yourFrameworkPackage > @higoawa/vite-rsc/xxx"]
+     */
+    parentPackage?: string;
   } = {},
 ): Plugin[] {
   return [
     {
       name: "rsc",
       config() {
+        const reactServerDomDep = [
+          rscPluginOptions.parentPackage,
+          `${PKG_NAME}/vendor/react-server-dom`,
+        ]
+          .filter(Boolean)
+          .join(">");
+
         return {
           appType: "custom",
-          resolve: {
-            // this allows transforms to safely inject `import "@hiogawa/vite-rsc/xxx"`
-            // to the files outside of project root.
-            // (e.g. react-router monorepo playground has "use client" in a linked dep.)
-            dedupe: [PKG_NAME],
-          },
           environments: {
             client: {
               build: {
@@ -94,7 +103,7 @@ export default function vitePluginRsc(
               optimizeDeps: {
                 include: [
                   "react-dom/client",
-                  `${PKG_NAME}/vendor/react-server-dom/client.browser`,
+                  `${reactServerDomDep}/client.browser`,
                 ],
                 exclude: [PKG_NAME],
               },
@@ -112,7 +121,7 @@ export default function vitePluginRsc(
                 noExternal: [PKG_NAME],
               },
               optimizeDeps: {
-                include: [`${PKG_NAME}/vendor/react-server-dom/client.edge`],
+                include: [`${reactServerDomDep}/client.edge`],
                 exclude: [PKG_NAME],
               },
             },
@@ -129,12 +138,7 @@ export default function vitePluginRsc(
               // `configEnvironment` below adds more `noExternal`
               resolve: {
                 conditions: ["react-server", ...defaultServerConditions],
-                noExternal: [
-                  "react",
-                  "react-dom",
-                  `${PKG_NAME}/vendor/react-server-dom/server.edge`,
-                  PKG_NAME,
-                ],
+                noExternal: ["react", "react-dom", PKG_NAME],
               },
               optimizeDeps: {
                 include: [
@@ -142,8 +146,8 @@ export default function vitePluginRsc(
                   "react-dom",
                   "react/jsx-runtime",
                   "react/jsx-dev-runtime",
-                  `${PKG_NAME}/vendor/react-server-dom/server.edge`,
-                  `${PKG_NAME}/vendor/react-server-dom/client.edge`,
+                  `${reactServerDomDep}/server.edge`,
+                  `${reactServerDomDep}/client.edge`,
                 ],
                 exclude: [PKG_NAME],
               },
@@ -674,7 +678,8 @@ function vitePluginUseClient(): Plugin[] {
           exportNames,
           renderedExports: [],
         };
-        output.prepend(`import * as $$ReactServer from "${PKG_NAME}/rsc";\n`);
+        const importSource = require.resolve(`${PKG_NAME}/react/rsc`);
+        output.prepend(`import * as $$ReactServer from "${importSource}";\n`);
         return { code: output.toString(), map: { mappings: "" } };
       },
     },
@@ -783,7 +788,8 @@ function vitePluginUseServer(): Plugin[] {
           });
           if (!output.hasChanged()) return;
           serverReferences[normalizedId] = id;
-          output.prepend(`import * as $$ReactServer from "${PKG_NAME}/rsc";\n`);
+          const importSource = require.resolve(`${PKG_NAME}/rsc`);
+          output.prepend(`import * as $$ReactServer from "${importSource}";\n`);
           return {
             code: output.toString(),
             map: output.generateMap({ hires: "boundary" }),
@@ -809,9 +815,8 @@ function vitePluginUseServer(): Plugin[] {
           if (!output?.hasChanged()) return;
           serverReferences[normalizedId] = id;
           const name = this.environment.name === "client" ? "browser" : "ssr";
-          output.prepend(
-            `import * as $$ReactClient from "${PKG_NAME}/react/${name}";\n`,
-          );
+          const importSource = require.resolve(`${PKG_NAME}/react/${name}`);
+          output.prepend(`import * as $$ReactClient from "${importSource}";\n`);
           return {
             code: output.toString(),
             map: output.generateMap({ hires: "boundary" }),

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -55,6 +55,7 @@ const clientReferenceMetaMap: Record</* id */ string, ClientReferenceMeta> = {};
 const serverResourcesMetaMap: Record<string, { key: string }> = {};
 
 const PKG_NAME = "@hiogawa/vite-rsc";
+const REACT_SERVER_DOM_NAME = `${PKG_NAME}/vendor/react-server-dom`;
 
 // dev-only wrapper virtual module of rollupOptions.input.index
 const VIRTUAL_ENTRIES = {
@@ -70,24 +71,12 @@ export default function vitePluginRsc(
      */
     entries?: Partial<Record<"client" | "ssr" | "rsc", string>>;
     disableServerHandler?: boolean;
-    /**
-     * This is used to configure `optimizeDeps.include` properly when `@hiogwa/vite-rsc` is used as transitive dependency, e.g.
-     *   optimizeDeps.include: ["yourFrameworkPackage > @higoawa/vite-rsc/xxx"]
-     */
-    parentPackage?: string;
   } = {},
 ): Plugin[] {
   return [
     {
       name: "rsc",
       config() {
-        const reactServerDomDep = [
-          rscPluginOptions.parentPackage,
-          `${PKG_NAME}/vendor/react-server-dom`,
-        ]
-          .filter(Boolean)
-          .join(">");
-
         return {
           appType: "custom",
           environments: {
@@ -103,7 +92,7 @@ export default function vitePluginRsc(
               optimizeDeps: {
                 include: [
                   "react-dom/client",
-                  `${reactServerDomDep}/client.browser`,
+                  `${REACT_SERVER_DOM_NAME}/client.browser`,
                 ],
                 exclude: [PKG_NAME],
               },
@@ -121,7 +110,7 @@ export default function vitePluginRsc(
                 noExternal: [PKG_NAME],
               },
               optimizeDeps: {
-                include: [`${reactServerDomDep}/client.edge`],
+                include: [`${REACT_SERVER_DOM_NAME}/client.edge`],
                 exclude: [PKG_NAME],
               },
             },
@@ -146,8 +135,8 @@ export default function vitePluginRsc(
                   "react-dom",
                   "react/jsx-runtime",
                   "react/jsx-dev-runtime",
-                  `${reactServerDomDep}/server.edge`,
-                  `${reactServerDomDep}/client.edge`,
+                  `${REACT_SERVER_DOM_NAME}/server.edge`,
+                  `${REACT_SERVER_DOM_NAME}/client.edge`,
                 ],
                 exclude: [PKG_NAME],
               },


### PR DESCRIPTION
Minimal version of https://github.com/hi-ogawa/vite-plugins/pull/973. Let's hold off `parentPackage` option for now.

Frameworks can use either `@hiogawa/vite-rsc` as peer dep or it's also possible to fix up `optimizeDeps.include` via:

```js
      async configEnvironment(name, config, env) {
        if (config.optimizeDeps?.include) {
          config.optimizeDeps.include = config.optimizeDeps.include.map(name => {
            if (name.startsWith("@hiogawa/vite-rsc/")) {
              name = `my-framework-package > ${name}`
            }
            return name;
          })
        }

```