### PR TITLE
fix: transform `__webpack_require__` global

### DIFF
--- a/packages/rsc/src/core/plugin.ts
+++ b/packages/rsc/src/core/plugin.ts
@@ -4,11 +4,21 @@ export default function vitePluginRscCore(): Plugin[] {
   return [
     {
       name: "rsc:patch-react-server-dom-webpack",
-      transform(code, _id, _options) {
+      transform(originalCode, _id, _options) {
+        let code = originalCode;
         if (code.includes("__webpack_require__.u")) {
           // avoid accessing `__webpack_require__` on import side effect
           // https://github.com/facebook/react/blob/a9bbe34622885ef5667d33236d580fe7321c0d8b/packages/react-server-dom-webpack/src/client/ReactFlightClientConfigBundlerWebpackBrowser.js#L16-L17
           code = code.replaceAll("__webpack_require__.u", "({}).u");
+        }
+
+        // the existance of `__webpack_require__` global can break some packages
+        // https://github.com/TooTallNate/node-bindings/blob/c8033dcfc04c34397384e23f7399a30e6c13830d/bindings.js#L90-L94
+        if (code.includes("__webpack_require__")) {
+          code = code.replaceAll("__webpack_require__", "__vite_rsc_require__");
+        }
+
+        if (code !== originalCode) {
           return { code, map: null };
         }
       },

--- a/packages/rsc/src/core/shared.ts
+++ b/packages/rsc/src/core/shared.ts
@@ -15,7 +15,7 @@ export function removeReferenceCacheTag(id: string): string {
 
 export function setInternalRequire(): void {
   // branch client and server require to support the case when ssr and rsc share the same global
-  (globalThis as any).__webpack_require__ = (id: string) => {
+  (globalThis as any).__vite_rsc_require__ = (id: string) => {
     if (id.startsWith(SERVER_REFERENCE_PREFIX)) {
       id = id.slice(SERVER_REFERENCE_PREFIX.length);
       return (globalThis as any).__vite_rsc_server_require__(id);


### PR DESCRIPTION
This is possible after https://github.com/hi-ogawa/vite-plugins/pull/927.

Some package tries to access `__non_webpack_require__` when `__webpack_require__` is defined, so we should avoid surfacing `__webpack_require__` anywhere.

This would help https://github.com/hi-ogawa/rsc-movies/pull/7

---

Sadly, this is breaking `@hiogawa/react-server`. I think https://github.com/hi-ogawa/vite-plugins/pull/927 technically has an issue with dual modules.

We might just want to do the same pre-bundling react deps on ssr just like rsc.

---

This can be technically done when modifying file when vendoring, but it's essentially same.