### PR TITLE
fix: fix ssr optimizeDeps

### DIFF
--- a/packages/react-server/src/plugin/index.ts
+++ b/packages/react-server/src/plugin/index.ts
@@ -169,7 +169,7 @@ export function vitePluginReactServer(
           noExternal: ["@hiogawa/react-server"],
           optimizeDeps: {
             include: ["@hiogawa/react-server > @hiogawa/vite-rsc/react/ssr"],
-            exclude: ["@hiogawa/react-server"],
+            exclude: ["@hiogawa/react-server", "react", "react-dom"],
           },
         },
         build: {

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -115,7 +115,14 @@ export default function vitePluginRsc(
               },
               optimizeDeps: {
                 include: [`${REACT_SERVER_DOM_NAME}/client.edge`],
-                exclude: [PKG_NAME],
+                exclude: [
+                  PKG_NAME,
+                  // ensure `react` and `react-dom` are not optimized
+                  // unless `noExternal` environment (e.g. cloudflare)
+                  ...(!config.environments?.ssr?.resolve?.noExternal
+                    ? ["react", "react-dom"]
+                    : []),
+                ],
               },
             },
             rsc: {


### PR DESCRIPTION
https://github.com/hi-ogawa/vite-plugins/pull/927 actually has an issue as it also pre-bundles `react` and `react-dom` inside `react-server-dom`. This technically causes dual modules but it's been somehow working.