### PR TITLE
chore: remove vite-plugin-inspect from starter

### DIFF
--- a/packages/rsc/examples/starter/README.md
+++ b/packages/rsc/examples/starter/README.md
@@ -35,4 +35,4 @@ See [`@hiogawa/vite-rsc`](https://github.com/hi-ogawa/vite-plugins/tree/main/pac
 ## Notes
 
 - [`./src/framework/entry.{browser,rsc,ssr}.tsx`](./src/framework) (with inline comments) provides an overview of how low level RSC (React flight) API can be used to build RSC framework.
-- You can use [`vite-plugin-inspect`](https://github.com/antfu-collective/vite-plugin-inspect) (available at http://localhost:5173/__inspect/) to see how `"use client"` and `"use server"` directives are internally transformed.
+- You can use [`vite-plugin-inspect`](https://github.com/antfu-collective/vite-plugin-inspect) to understand how `"use client"` and `"use server"` directives are transformed internally.

--- a/packages/rsc/examples/starter/vite.config.ts
+++ b/packages/rsc/examples/starter/vite.config.ts
@@ -1,7 +1,6 @@
 import rsc from "@hiogawa/vite-rsc/plugin";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
-import inspect from "vite-plugin-inspect";
 
 export default defineConfig({
   plugins: [
@@ -17,10 +16,6 @@ export default defineConfig({
     // use any of react plugins https://github.com/vitejs/vite-plugin-react
     // to enable client component HMR
     react(),
-
-    // vite-plugin-inspect is useful for understanding
-    // "use client" / "use server" transforms.
-    inspect({ build: true }),
   ],
 
   // specify entry point for each environment.

--- a/scripts/vite-ecosystem-ci.sh
+++ b/scripts/vite-ecosystem-ci.sh
@@ -2,6 +2,9 @@
 set -eu -o pipefail
 
 # a part of test-rsc-core from ci.yml
+pnpm -C packages/rsc/examples/starter-e2e test-e2e
+pnpm -C packages/rsc/examples/starter build
+pnpm -C packages/rsc/examples/starter-e2e test-e2e-preview
 pnpm -C packages/rsc/examples/basic test-e2e
 pnpm -C packages/rsc/examples/basic build
 pnpm -C packages/rsc/examples/basic test-e2e-preview

--- a/scripts/vite-ecosystem-ci.sh
+++ b/scripts/vite-ecosystem-ci.sh
@@ -2,9 +2,6 @@
 set -eu -o pipefail
 
 # a part of test-rsc-core from ci.yml
-pnpm -C packages/rsc/examples/starter-e2e test-e2e
-pnpm -C packages/rsc/examples/starter build
-pnpm -C packages/rsc/examples/starter-e2e test-e2e-preview
 pnpm -C packages/rsc/examples/basic test-e2e
 pnpm -C packages/rsc/examples/basic build
 pnpm -C packages/rsc/examples/basic test-e2e-preview


### PR DESCRIPTION
Vite 7 incompatible vite-plugin-inspect was breaking ecosystem-ci.