### PR TITLE
feat: add `serverHandler` option to support pure API server

### DIFF
--- a/packages/rsc/examples/hono/index.html
+++ b/packages/rsc/examples/hono/index.html
@@ -1,0 +1,11 @@
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite + RSC</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./src/client.tsx"></script>
+  </body>
+</html>

--- a/packages/rsc/examples/hono/src/client.tsx
+++ b/packages/rsc/examples/hono/src/client.tsx
@@ -1,4 +1,4 @@
-import { fetchRSC } from "@hiogawa/vite-rsc/extra/browser";
+import * as ReactClient from "@hiogawa/vite-rsc/browser";
 import React from "react";
 import ReactDOM from "react-dom/client";
 
@@ -23,7 +23,7 @@ function FetchRsc() {
     <div>
       <button
         onClick={async () => {
-          setRsc(await fetchRSC("/api/rsc"));
+          setRsc(await ReactClient.createFromFetch(fetch("/api/rsc")));
         }}
       >
         fetchRsc

--- a/packages/rsc/examples/hono/src/server.tsx
+++ b/packages/rsc/examples/hono/src/server.tsx
@@ -1,34 +1,17 @@
-import { renderRequest } from "@hiogawa/vite-rsc/extra/rsc";
+import * as ReactServer from "@hiogawa/vite-rsc/rsc";
 import { Hono } from "hono";
 
 const app = new Hono();
 
-app.get("/api/rsc", (c) => {
+app.get("/api/rsc", () => {
   const el = (
     <div>
       <div>Hono!</div>
       <div>random: ${Math.random().toString(36).slice(2)}</div>
     </div>
   );
-  // TODO: request is irrelevant
-  return renderRequest(c.req.raw, el);
+  const stream = ReactServer.renderToReadableStream(el);
+  return new Response(stream);
 });
-
-app.all("/", (c) => {
-  return renderRequest(c.req.raw, <Document />);
-});
-
-function Document() {
-  return (
-    <html>
-      <head>
-        <title>vite-rsc</title>
-      </head>
-      <body>
-        <div id="root"></div>
-      </body>
-    </html>
-  );
-}
 
 export default app.fetch;

--- a/packages/rsc/examples/hono/vite.config.ts
+++ b/packages/rsc/examples/hono/vite.config.ts
@@ -3,6 +3,7 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 export default defineConfig({
+  appType: "spa",
   clearScreen: false,
   plugins: [
     react(),
@@ -10,8 +11,8 @@ export default defineConfig({
       entries: {
         client: "./src/client.tsx",
         rsc: "./src/server.tsx",
-        ssr: "@hiogawa/vite-rsc/extra/ssr",
       },
+      serverHandler: (url) => url.startsWith("/api/"),
     }),
   ],
   build: {

--- a/packages/rsc/examples/react-router/cf/vite.config.ts
+++ b/packages/rsc/examples/react-router/cf/vite.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
       entries: {
         client: "./react-router-vite/entry.browser.tsx",
       },
-      disableServerHandler: true,
+      serverHandler: false,
     }),
     inspect(),
     cloudflare({

--- a/packages/rsc/examples/starter/vite.config.ts
+++ b/packages/rsc/examples/starter/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
       //
       // by default, the plugin setup request handler based on `default export` of `rsc` environment `rollupOptions.input.index`.
       // This can be disabled when setting up own server handler e.g. `@cloudflare/vite-plugin`.
-      // > disableServerHandler: true
+      // > serverHandler: false
     }),
 
     // use any of react plugins https://github.com/vitejs/vite-plugin-react

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -74,7 +74,11 @@ export default function vitePluginRsc(
      * shorthand for configuring `environments.(name).build.rollupOptions.input.index`
      */
     entries?: Partial<Record<"client" | "ssr" | "rsc", string>>;
-    disableServerHandler?: boolean;
+    serverHandler?:
+      | false
+      | {
+          match?: (url: URL) => boolean;
+        };
   } = {},
 ): Plugin[] {
   return [
@@ -201,7 +205,7 @@ export default function vitePluginRsc(
         (globalThis as any).__viteSsrRunner = viteSsrRunner;
         (globalThis as any).__viteRscRunner = viteRscRunner;
 
-        if (rscPluginOptions.disableServerHandler) return;
+        if (rscPluginOptions.serverHandler) return;
 
         return () => {
           server.middlewares.use(async (req, res, next) => {
@@ -215,7 +219,7 @@ export default function vitePluginRsc(
         };
       },
       async configurePreviewServer(server) {
-        if (rscPluginOptions.disableServerHandler) return;
+        if (rscPluginOptions.serverHandler) return;
 
         const entry = pathToFileURL(path.resolve(`dist/rsc/index.js`)).href;
         const mod = await import(/* @vite-ignore */ entry);


### PR DESCRIPTION
- Closes https://github.com/hi-ogawa/vite-plugins/issues/965

This allows only enabling server handler under e.g. `/api`, which might make it easier to do SPA + API server https://github.com/hi-ogawa/vite-plugins/issues/965.

---

It actually needs a bit more
- `appType: "spa"`
- moving server handler to "pre"
- disable `ssr` build and use `rsc -> client -> rsc -> client` to discover references