### PR TITLE
refactor: add `import.meta.viteRsc.loadBootstrapScriptContent`

### DIFF
--- a/packages/rsc-react-router/src/entry.ssr.tsx
+++ b/packages/rsc-react-router/src/entry.ssr.tsx
@@ -1,4 +1,3 @@
-import bootstrapScriptContent from "virtual:vite-rsc/bootstrap-script-content";
 import { createFromReadableStream } from "@hiogawa/vite-rsc/ssr";
 // @ts-ignore
 import * as ReactDomServer from "react-dom/server.edge";
@@ -11,11 +10,13 @@ export default async function handler(
   request: Request,
   callServer: (request: Request) => Promise<Response>,
 ): Promise<Response> {
+  const bootstrapScriptContent =
+    await import.meta.viteRsc.loadBootstrapScriptContent("index");
   return routeRSCServerRequest({
     request,
     callServer,
     decode: (body) => createFromReadableStream(body),
-    renderHTML(getPayload) {
+    async renderHTML(getPayload) {
       return ReactDomServer.renderToReadableStream(
         <RSCStaticRouter getPayload={getPayload} />,
         {

--- a/packages/rsc-react-router/src/entry.ssr.tsx
+++ b/packages/rsc-react-router/src/entry.ssr.tsx
@@ -16,7 +16,7 @@ export default async function handler(
     request,
     callServer,
     decode: (body) => createFromReadableStream(body),
-    async renderHTML(getPayload) {
+    renderHTML(getPayload) {
       return ReactDomServer.renderToReadableStream(
         <RSCStaticRouter getPayload={getPayload} />,
         {

--- a/packages/rsc/README.md
+++ b/packages/rsc/README.md
@@ -165,12 +165,13 @@ export default async function handler(request: Request): Promise<Response> {
 ```tsx
 import * as ReactClient from "@hiogawa/vite-rsc/ssr"; // re-export of react-server-dom/client.edge
 import * as ReactDOMServer from "react-dom/server.edge";
-// helper API to allow referencing browser entry content from SSR environment
-import bootstrapScriptContent from "virtual:vite-rsc/bootstrap-script-content";
 
 export async function handleSsr(rscStream: ReadableStream) {
   // deserialize RSC stream back to React VDOM
   const root = await ReactClient.createFromReadableStream(rscStream);
+
+  // helper API to allow referencing browser entry content from SSR environment
+  const bootstrapScriptContent = await import.meta.viteRsc.loadBootstrapScriptContent("index");
 
   // render html (traditional SSR)
   const htmlStream = ReactDOMServer.renderToReadableStream(root, {
@@ -332,7 +333,7 @@ import { transformRscCssExport } from "@hiogawa/vite-rsc/plugin";
 
 ### available on `ssr` environment
 
-#### `virtual:vite-rsc/bootstrap-script-content`
+#### `import.meta.viteRsc.loadBootstrapScriptContent("index")`
 
 This provides a raw js code to execute a browser entry file specified by `environments.client.build.rollupOptions.input.index`. This is intended to be used with React DOM SSR API, such as [`renderToReadableStream`](https://react.dev/reference/react-dom/server/renderToReadableStream)
 
@@ -340,7 +341,8 @@ This provides a raw js code to execute a browser entry file specified by `enviro
 import bootstrapScriptContent from "virtual:vite-rsc/bootstrap-script-content"
 import { renderToReadableStream } from "react-dom/server.edge";
 
-renderToReadableStream(reactNode, { bootstrapScriptContent });
+const bootstrapScriptContent = await import.meta.viteRsc.loadBootstrapScriptContent("index")
+const htmlStream = await renderToReadableStream(reactNode, { bootstrapScriptContent });
 ```
 
 ### available on `client` environment

--- a/packages/rsc/README.md
+++ b/packages/rsc/README.md
@@ -77,7 +77,6 @@ export default defineConfig() {
   ],
 
   // specify entry point for each environment.
-  // (currently the plugin assumes `rollupOptions.input.index` for some features.)
   environments: {
     // `rsc` environment loads modules with `react-server` condition.
     // this environment is responsible for:

--- a/packages/rsc/examples/react-router/react-router-vite/entry.ssr.tsx
+++ b/packages/rsc/examples/react-router/react-router-vite/entry.ssr.tsx
@@ -1,4 +1,3 @@
-import bootstrapScriptContent from "virtual:vite-rsc/bootstrap-script-content";
 import { createFromReadableStream } from "@hiogawa/vite-rsc/ssr";
 import * as ReactDomServer from "react-dom/server.edge";
 import {
@@ -10,6 +9,8 @@ export default async function handler(
   request: Request,
   callServer: (request: Request) => Promise<Response>,
 ) {
+  const bootstrapScriptContent =
+    await import.meta.viteRsc.loadBootstrapScriptContent("index");
   return routeRSCServerRequest({
     request,
     callServer,

--- a/packages/rsc/examples/starter-cf-single/src/framework/entry.ssr.tsx
+++ b/packages/rsc/examples/starter-cf-single/src/framework/entry.ssr.tsx
@@ -1,4 +1,3 @@
-import bootstrapScriptContent from "virtual:vite-rsc/bootstrap-script-content";
 import { injectRscStreamToHtml } from "@hiogawa/vite-rsc/rsc-html-stream/ssr"; // helper API
 import * as ReactClient from "@hiogawa/vite-rsc/ssr"; // RSC API
 import React from "react";
@@ -31,6 +30,8 @@ export async function renderHTML(
   }
 
   // render html (traditional SSR)
+  const bootstrapScriptContent =
+    await import.meta.viteRsc.loadBootstrapScriptContent("index");
   const htmlStream = await ReactDOMServer.renderToReadableStream(<SsrRoot />, {
     bootstrapScriptContent: options?.debugNojs
       ? undefined

--- a/packages/rsc/examples/starter/README.md
+++ b/packages/rsc/examples/starter/README.md
@@ -21,16 +21,14 @@ See [`@hiogawa/vite-rsc`](https://github.com/hi-ogawa/vite-plugins/tree/main/pac
   - `@higoawa/vite-rsc/plugin`
 - [`./src/framework/entry.rsc.tsx`](./src/framework/entry.rsc.tsx)
   - `@hiogawa/vite-rsc/rsc`
+  - `import.meta.viteRsc.loadModule`
 - [`./src/framework/entry.ssr.tsx`](./src/framework/entry.ssr.tsx)
   - `@hiogawa/vite-rsc/ssr`
   - `@hiogawa/vite-rsc/rsc-html-stream/ssr`
-  - `virtual:vite-rsc/bootstrap-script-content`
+  - `import.meta.viteRsc.loadBootstrapScriptContent`
 - [`./src/framework/entry.browser.tsx`](./src/framework/entry.browser.tsx)
   - `@hiogawa/vite-rsc/browser`
-  - `@hiogawa/vite-rsc/rsc-html-stream/ssr`
   - `@hiogawa/vite-rsc/rsc-html-stream/browser`
-- [./src/root.tsx](./src/root.tsx)
-  - `import.meta.viteRsc.loadCss`
 
 ## Notes
 

--- a/packages/rsc/examples/starter/src/framework/entry.ssr.tsx
+++ b/packages/rsc/examples/starter/src/framework/entry.ssr.tsx
@@ -1,4 +1,3 @@
-import bootstrapScriptContent from "virtual:vite-rsc/bootstrap-script-content";
 import { injectRscStreamToHtml } from "@hiogawa/vite-rsc/rsc-html-stream/ssr"; // helper API
 import * as ReactClient from "@hiogawa/vite-rsc/ssr"; // RSC API
 import React from "react";
@@ -29,6 +28,8 @@ export async function renderHTML(
   }
 
   // render html (traditional SSR)
+  const bootstrapScriptContent =
+    await import.meta.viteRsc.loadBootstrapScriptContent("index");
   const htmlStream = await ReactDOMServer.renderToReadableStream(<SsrRoot />, {
     bootstrapScriptContent: options?.debugNojs
       ? undefined

--- a/packages/rsc/src/extra/ssr.tsx
+++ b/packages/rsc/src/extra/ssr.tsx
@@ -1,4 +1,3 @@
-import bootstrapScriptContent from "virtual:vite-rsc/bootstrap-script-content";
 import React from "react";
 import type { ReactFormState } from "react-dom/client";
 import ReactDomServer from "react-dom/server.edge";
@@ -27,6 +26,8 @@ export async function renderHtml(
     return root;
   }
 
+  const bootstrapScriptContent =
+    await import.meta.viteRsc.loadBootstrapScriptContent("index");
   const htmlStream = await ReactDomServer.renderToReadableStream(<SsrRoot />, {
     bootstrapScriptContent: options?.debugNoJs
       ? undefined

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -611,14 +611,20 @@ export default function vitePluginRsc(
     {
       name: "rsc:bootstrap-script-content",
       async transform(code) {
-        if (!code.includes("import.meta.viteRsc.loadBootstrapScriptContent"))
+        if (
+          !code.includes("loadBootstrapScriptContent") ||
+          !/import\s*\.\s*meta\s*\.\s*viteRsc\s*\.\s*loadBootstrapScriptContent/.test(
+            code,
+          )
+        ) {
           return;
+        }
 
         assert(this.environment.name !== "client");
         const output = new MagicString(code);
 
         for (const match of code.matchAll(
-          /import\.meta\.viteRsc\.loadBootstrapScriptContent\(([\s\S]*?)\)/dg,
+          /import\s*\.\s*meta\s*\.\s*viteRsc\s*\.\s*loadBootstrapScriptContent\(([\s\S]*?)\)/dg,
         )) {
           const argCode = match[1]!.trim();
           const entryName = JSON.parse(argCode);

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -632,11 +632,16 @@ export default function vitePluginRsc(
             entryName,
             `[vite-rsc] expected 'loadBootstrapScriptContent("index")' but got ${argCode}`,
           );
-          let replacement: string = `(import("virtual:vite-rsc/assets-manifest").then(__m => __m.default.bootstrapScriptContent))`;
+          let replacement: string = `Promise.resolve(__vite_rsc_assets_manifest.bootstrapScriptContent)`;
           const [start, end] = match.indices![0]!;
           output.overwrite(start, end, replacement);
         }
         if (output.hasChanged()) {
+          if (!code.includes("__vite_rsc_assets_manifest")) {
+            output.prepend(
+              `import __vite_rsc_assets_manifest from "virtual:vite-rsc/assets-manifest";`,
+            );
+          }
           return {
             code: output.toString(),
             map: output.generateMap({ hires: "boundary" }),

--- a/packages/rsc/types/index.d.ts
+++ b/packages/rsc/types/index.d.ts
@@ -7,6 +7,7 @@ declare global {
       /** @deprecated use `loadModule("ssr", entry)` instead */
       loadSsrModule: <T>(entry: string) => Promise<T>;
       loadModule: <T>(environmentName: string, entryName: string) => Promise<T>;
+      loadBootstrapScriptContent: (entryName: string) => Promise<string>;
     };
   }
 }

--- a/packages/rsc/types/virtual.d.ts
+++ b/packages/rsc/types/virtual.d.ts
@@ -1,4 +1,5 @@
 declare module "virtual:vite-rsc/bootstrap-script-content" {
+  /** @deprecated use `import.meta.viteRsc.loadBootstrapScriptContent("index")` instead */
   const bootstrapScriptContent: string;
   export default bootstrapScriptContent;
 }


### PR DESCRIPTION
Just only this one being virtual is odd, so let's make it `import.meta.viteRsc` API.

## todo

- [x] docs