### PR TITLE
fix: ensure server-only and client-only not externalized

### DIFF
--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -114,6 +114,8 @@ export default function vitePluginRsc(
         const noExternal = [
           "react",
           "react-dom",
+          "server-only",
+          "client-only",
           PKG_NAME,
           ...result.ssr.noExternal.sort(),
         ];


### PR DESCRIPTION
I think we should do this by default (but don't make it build error yet). Found while testing https://github.com/hi-ogawa/waku/pull/2/