### PR TITLE
feat(rsc,transforms): rsc css transform for default export identifier

### DIFF
--- a/packages/rsc/examples/react-router/app/routes/home.tsx
+++ b/packages/rsc/examples/react-router/app/routes/home.tsx
@@ -13,7 +13,7 @@ export function loader({ request }: Route.LoaderArgs) {
   return { name: name || "Unknown" };
 }
 
-export function Component({ loaderData }: Route.ComponentProps) {
+const Component = ({ loaderData }: Route.ComponentProps) => {
   return (
     <main className="container my-8 px-8 mx-auto">
       <article className="paper prose max-w-none">
@@ -47,4 +47,6 @@ export function Component({ loaderData }: Route.ComponentProps) {
       </article>
     </main>
   );
-}
+};
+
+export default Component;

--- a/packages/transforms/src/wrap-export.test.ts
+++ b/packages/transforms/src/wrap-export.test.ts
@@ -251,4 +251,24 @@ export default () => {}
       "
     `);
   });
+
+  test("filter defaultExportIdentifierName", async () => {
+    const input = `
+const Page = () => {}
+export default Page;
+`;
+    expect(
+      await testTransform(input, {
+        filter: (_name, meta) => meta.defaultExportIdentifierName === "Page",
+      }),
+    ).toMatchInlineSnapshot(`
+      "
+      const Page = () => {}
+      const $$default = Page;
+      ;
+      const $$wrap_$$default = /* #__PURE__ */ $$wrap($$default, "<id>", "default");
+      export { $$wrap_$$default as default };
+      "
+    `);
+  });
 });

--- a/packages/transforms/src/wrap-export.ts
+++ b/packages/transforms/src/wrap-export.ts
@@ -6,7 +6,7 @@ import { extract_names } from "periscopic";
 type ExportMeta = {
   declName?: string;
   isFunction?: boolean;
-  defaultExportIdentifier?: string;
+  defaultExportIdentifierName?: string;
 };
 
 export type TransformWrapExportFilter = (
@@ -202,6 +202,7 @@ export function transformWrapExport(
       let localName: string;
       let isFunction = false;
       let declName: string | undefined;
+      let defaultExportIdentifierName: string | undefined;
       if (
         (node.declaration.type === "FunctionDeclaration" ||
           node.declaration.type === "ClassDeclaration") &&
@@ -216,8 +217,15 @@ export function transformWrapExport(
         // otherwise we can introduce new variable
         localName = "$$default";
         output.update(node.start, node.declaration.start, "const $$default = ");
+        if (node.declaration.type === "Identifier") {
+          defaultExportIdentifierName = node.declaration.name;
+        }
       }
-      wrapExport(localName, "default", { isFunction, declName });
+      wrapExport(localName, "default", {
+        isFunction,
+        declName,
+        defaultExportIdentifierName,
+      });
     }
   }
 

--- a/packages/transforms/src/wrap-export.ts
+++ b/packages/transforms/src/wrap-export.ts
@@ -18,7 +18,7 @@ export function transformWrapExport(
   input: string,
   ast: Program,
   options: {
-    runtime: (value: string, name: string) => string;
+    runtime: (value: string, name: string, meta: ExportMeta) => string;
     ignoreExportAllDeclaration?: boolean;
     rejectNonAsyncFunction?: boolean;
     filter?: TransformWrapExportFilter;
@@ -49,7 +49,7 @@ export function transformWrapExport(
     const newCode = exports
       .map((e) => [
         filter(e.name, e.meta) &&
-          `${e.name} = /* #__PURE__ */ ${options.runtime(e.name, e.name)};\n`,
+          `${e.name} = /* #__PURE__ */ ${options.runtime(e.name, e.name, e.meta)};\n`,
         `export { ${e.name} };\n`,
       ])
       .flat()
@@ -66,7 +66,7 @@ export function transformWrapExport(
     }
 
     toAppend.push(
-      `const $$wrap_${name} = /* #__PURE__ */ ${options.runtime(name, exportName)}`,
+      `const $$wrap_${name} = /* #__PURE__ */ ${options.runtime(name, exportName, meta)}`,
       `export { $$wrap_${name} as ${exportName} }`,
     );
   }

--- a/packages/transforms/src/wrap-export.ts
+++ b/packages/transforms/src/wrap-export.ts
@@ -3,7 +3,11 @@ import type { Node, Program } from "estree";
 import MagicString from "magic-string";
 import { extract_names } from "periscopic";
 
-type ExportMeta = { declName?: string; isFunction?: boolean };
+type ExportMeta = {
+  declName?: string;
+  isFunction?: boolean;
+  defaultExportIdentifier?: string;
+};
 
 export type TransformWrapExportFilter = (
   name: string,


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/vite-plugins/issues/1044

It's not really sound, but let's just see how far we can get with this:

```js
// input
export default Layout;

// output
export default __vite_rsc_wrap_css__(Layout) // check `typeof Layout === 'function'` internally
```