### PR TITLE
feat: add buildApp hook alternative for Vite 6

### DIFF
--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -92,7 +92,7 @@ type RscPluginOptions = {
 
   /** should use `buildApp` hook on Vite 7. this is a temporary alternative on Vite 6. */
   buildApp?: {
-    order?: "pre" | "post";
+    order: "pre" | "post";
     handler: () => void | Promise<void>;
   };
 };
@@ -215,7 +215,7 @@ export default function vitePluginRsc(
               await builder.build(builder.environments.rsc!);
               await builder.build(builder.environments.client!);
               await builder.build(builder.environments.ssr!);
-              if (buildAppHook && buildAppHook.order !== "post") {
+              if (buildAppHook && buildAppHook.order === "post") {
                 await buildAppHook.handler();
               }
             },


### PR DESCRIPTION
I might want this just now for Waku fs router build support https://github.com/hi-ogawa/waku/pull/2.

Ah, I remembered technically it's already possible by ssr writeBundle hook like

```js
{
  name: 'after-rsc-build-app'
  enforce: 'post',
  writeBundle() {
    if (this.environment.name === 'ssr') {
       // your post build app logic
    }
  }
}
```
