### PR TITLE
feat: add `ignoredClientInServerPackageWarning` option

### DIFF
--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -782,6 +782,7 @@ function vitePluginUseClient(
           // expectation on dependency optimizer on browser. Directly copying over
           // "?v=<hash>" from client optimizer in client reference can make a hashed
           // module stale, so we use another virtual module wrapper to delay such process.
+          // TODO: suggest `optimizeDeps.exclude` and skip warning if that's already the case.
           const ignored =
             useClientPluginOptions.ignoredClientInServerPackageWarning?.some(
               (pkg) => id.includes(`/node_modules/${pkg}/`),


### PR DESCRIPTION
We want to silence this on Waku automatically

```
1:38:25 PM [vite] (rsc) warning: [vite-rsc] detected an internal client boundary created by a package imported on rsc environment
  Plugin: rsc:use-client
  File: /home/hiroshi/code/tmp/waku-vite-rsc-test/node_modules/.pnpm/waku@file+..+..+others+waku+packages+waku+waku-0.23.2.tgz_@types+node@24.0.3_@types+rea_0495fbf4a72786d318601067b0743b9e/node_modules/waku/dist/router/client.js?v=9bb5d99e
1:38:25 PM [vite] (rsc) warning: [vite-rsc] detected an internal client boundary created by a package imported on rsc environment
  Plugin: rsc:use-client
  File: /home/hiroshi/code/tmp/waku-vite-rsc-test/node_modules/.pnpm/waku@file+..+..+others+waku+packages+waku+waku-0.23.2.tgz_@types+node@24.0.3_@types+rea_0495fbf4a72786d318601067b0743b9e/node_modules/waku/dist/minimal/client.js?v=9bb5d99e
```

---

Confirmed on Waku example.