### PR TITLE
perf: strip code during scan build

### DIFF
--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -746,8 +746,6 @@ function scanBuildStripPlugin(): Plugin {
     transform(code, _id, _options) {
       if (!isScanBuild) return;
       // During server scan, we strip all code but imports to only discover client/server references.
-      //   import "x"
-      //   import "y"
       const [imports] = esModuleLexer.parse(code);
       const output = imports
         .map((e) => e.n && `import ${JSON.stringify(e.n)};\n`)


### PR DESCRIPTION
This seems to help quite a lot

## after

```
$ time pnpm -C packages/rsc/examples/react-router build

> @hiogawa/vite-rsc-examples-react-router@ build /home/hiroshi/code/personal/vite-plugins/packages/rsc/examples/react-router
> vite build --app

vite v6.3.5 building SSR bundle for production...
✓ 66 modules transformed.
✓ built in 335ms
vite v6.3.5 building SSR bundle for production...
✓ 61 modules transformed.
✓ built in 243ms

... (3 more builds same)...
```

## before

```
$ time pnpm -C packages/rsc/examples/react-router build

> @hiogawa/vite-rsc-examples-react-router@ build /home/hiroshi/code/personal/vite-plugins/packages/rsc/examples/react-router
> vite build --app

vite v6.3.5 building SSR bundle for production...
✓ 66 modules transformed.
✓ built in 673ms
vite v6.3.5 building SSR bundle for production...
✓ 61 modules transformed.
✓ built in 865ms

...(3 more builds same)
```