### PR TITLE
chore: tweak pkg-pr-new

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -35,9 +35,9 @@ jobs:
 
       # strip prepack to avoid duplicate builds
       - run: |
-          sed -i 's#"prepack"#"x-prepack"#' packages/rsc-stable/package.json
-          sed -i 's#"prepack"#"x-prepack"#' packages/rsc-canary/package.json
-          sed -i 's#"prepack"#"x-prepack"#' packages/rsc-experimental/package.json
+          for pkg in packages/*/package.json; do
+            sed -i 's#"prepack"#"x-prepack"#' "$pkg"
+          done
 
       - run: |
           pnpx pkg-pr-new publish --comment=off \

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -33,6 +33,12 @@ jobs:
           cp -rf packages/rsc packages/rsc-experimental
           sed -i 's#"name": "@hiogawa/vite-rsc"#"name": "@hiogawa/vite-rsc-experimental"#' packages/rsc-experimental/package.json
 
+      # strip prepack to avoid duplicate builds
+      - run: |
+          sed -i 's#"prepack"#"x-prepack"#' packages/rsc-stable/package.json
+          sed -i 's#"prepack"#"x-prepack"#' packages/rsc-canary/package.json
+          sed -i 's#"prepack"#"x-prepack"#' packages/rsc-experimental/package.json
+
       - run: |
           pnpx pkg-pr-new publish --comment=off \
             packages/react-server \

--- a/packages/rsc/package.json
+++ b/packages/rsc/package.json
@@ -17,7 +17,8 @@
   "scripts": {
     "test-package": "bash scripts/test-package.sh",
     "dev": "tsdown --sourcemap --watch src",
-    "build": "tsdown"
+    "build": "tsdown",
+    "prepack": "tsdown --clean"
   },
   "dependencies": {
     "@hiogawa/transforms": "workspace:*",


### PR DESCRIPTION
- Follow up to https://github.com/hi-ogawa/vite-plugins/pull/1052

I still want prepack command, so locally I can just do `pnpm publish packages/rsc`.

---

Verified https://github.com/pawelblaszczyk5/vite-rsc-experiments works.