### PR TITLE
feat(rsc, transforms): support preserving client reference original value

### DIFF
--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -846,7 +846,7 @@ function vitePluginUseClient(
             let proxyValue =
               `() => { throw new Error("Unexpectedly client reference export '" + ` +
               JSON.stringify(name) +
-              `"' is called on server") }`;
+              ` + "' is called on server") }`;
             if (
               meta?.value &&
               useClientPluginOptions.keepUseCientProxy?.(meta.value)

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -101,7 +101,7 @@ type RscPluginOptions = {
   defineEncryptionKey?: string;
 
   /** Escape hatch for Waku's `allowServer` */
-  keepUseCientProxy?: (value: string) => boolean;
+  keepUseCientProxy?: boolean;
 };
 
 export default function vitePluginRsc(
@@ -848,10 +848,7 @@ function vitePluginUseClient(
               `() => { throw new Error("Unexpectedly client reference export '" + ` +
               JSON.stringify(name) +
               ` + "' is called on server") }`;
-            if (
-              meta?.value &&
-              useClientPluginOptions.keepUseCientProxy?.(meta.value)
-            ) {
+            if (meta?.value) {
               proxyValue = `(${meta.value})`;
             }
             return (

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -841,6 +841,7 @@ function vitePluginUseClient(
         );
         const result = transformDirectiveProxyExport_(ast, {
           directive: "use client",
+          code,
           keep: !!useClientPluginOptions.keepUseCientProxy,
           runtime: (name, meta) => {
             let proxyValue =

--- a/packages/rsc/src/utils/dce.ts
+++ b/packages/rsc/src/utils/dce.ts
@@ -1,0 +1,1 @@
+// DCE logic to support Waku's `allowServer`

--- a/packages/rsc/src/utils/dce.ts
+++ b/packages/rsc/src/utils/dce.ts
@@ -1,1 +1,0 @@
-// DCE logic to support Waku's `allowServer`

--- a/packages/transforms/src/proxy-export.test.ts
+++ b/packages/transforms/src/proxy-export.test.ts
@@ -229,9 +229,9 @@ export const MyClientComp = () => { throw new Error('...') }
       import { atom } from 'jotai/vanilla';
 
       const local1 = 1;
-      export const countAtom = /* #__PURE__ */ $$proxy((atom(local1)), "<id>", "countAtom");
+      export const countAtom = /* #__PURE__ */ $$proxy(atom(local1), "<id>", "countAtom");
 
-      export const MyClientComp = /* #__PURE__ */ $$proxy((() => { throw new Error('...') }), "<id>", "MyClientComp");
+      export const MyClientComp = /* #__PURE__ */ $$proxy(() => { throw new Error('...') }, "<id>", "MyClientComp");
       ",
       }
     `);

--- a/packages/transforms/src/proxy-export.test.ts
+++ b/packages/transforms/src/proxy-export.test.ts
@@ -224,17 +224,14 @@ export const MyClientComp = () => { throw new Error('...') }
     `);
     expect(await testTransform(input, { keep: true })).toMatchInlineSnapshot(`
       {
-        "exportNames": [
-          "countAtom",
-          "MyClientComp",
-        ],
+        "exportNames": [],
         "output": ""use client"
       import { atom } from 'jotai/vanilla';
 
       const local1 = 1;
-      export const countAtom = /* #__PURE__ */ $$proxy(todo, "<id>", "countAtom");
+      export const countAtom = /* #__PURE__ */ $$proxy((atom(local1)), "<id>", "countAtom");
 
-      export const MyClientComp = /* #__PURE__ */ $$proxy(todo, "<id>", "MyClientComp");
+      export const MyClientComp = /* #__PURE__ */ $$proxy((() => { throw new Error('...') }), "<id>", "MyClientComp");
       ",
       }
     `);

--- a/packages/transforms/src/proxy-export.test.ts
+++ b/packages/transforms/src/proxy-export.test.ts
@@ -8,7 +8,12 @@ async function testTransform(input: string, options?: { keep?: boolean }) {
   const ast = await parseAstAsync(input);
   const result = transformProxyExport(ast, {
     code: input,
-    runtime: (name) => `$$proxy("<id>", ${JSON.stringify(name)})`,
+    runtime: (name, meta) => {
+      if (meta?.value) {
+        return `$$proxy(${meta.value}, "<id>", ${JSON.stringify(name)})`;
+      }
+      return `$$proxy("<id>", ${JSON.stringify(name)})`;
+    },
     ...options,
   });
   if (process.env["DEBUG_SOURCEMAP"]) {
@@ -227,11 +232,9 @@ export const MyClientComp = () => { throw new Error('...') }
       import { atom } from 'jotai/vanilla';
 
       const local1 = 1;
-      export const countAtom = /* #__PURE__ */ $$proxy("<id>", "countAtom");
+      export const countAtom = /* #__PURE__ */ $$proxy(todo, "<id>", "countAtom");
 
-
-      export const MyClientComp = /* #__PURE__ */ $$proxy("<id>", "MyClientComp");
-
+      export const MyClientComp = /* #__PURE__ */ $$proxy(todo, "<id>", "MyClientComp");
       ",
       }
     `);

--- a/packages/transforms/src/proxy-export.ts
+++ b/packages/transforms/src/proxy-export.ts
@@ -5,6 +5,7 @@ import { extract_names } from "periscopic";
 import { hasDirective } from "./utils";
 
 export type TransformProxyExportOptions = {
+  /** Required for source map and `keep` options */
   code?: string;
   runtime: (name: string, meta?: { value: string }) => string;
   ignoreExportAllDeclaration?: boolean;
@@ -40,6 +41,9 @@ export function transformProxyExport(
   exportNames: string[];
   output: MagicString;
 } {
+  if (options.keep && typeof options.code !== "string") {
+    throw new Error("`keep` option requires `code`");
+  }
   const output = new MagicString(options.code ?? " ".repeat(ast.end));
   const exportNames: string[] = [];
 

--- a/packages/transforms/src/proxy-export.ts
+++ b/packages/transforms/src/proxy-export.ts
@@ -96,8 +96,10 @@ export function transformProxyExport(
               const decl = node.declaration.declarations[0]!;
               if (decl.id.type === "Identifier" && decl.init) {
                 const name = decl.id.name;
-                let value = options.code.slice(decl.init.start, decl.init.end);
-                value = `(${value})`;
+                const value = options.code.slice(
+                  decl.init.start,
+                  decl.init.end,
+                );
                 const newCode = `export const ${name} = /* #__PURE__ */ ${options.runtime(name, { value })};`;
                 output.update(node.start, node.end, newCode);
                 continue;

--- a/packages/transforms/src/proxy-export.ts
+++ b/packages/transforms/src/proxy-export.ts
@@ -4,16 +4,19 @@ import MagicString from "magic-string";
 import { extract_names } from "periscopic";
 import { hasDirective } from "./utils";
 
+export type TransformProxyExportOptions = {
+  code?: string;
+  runtime: (name: string, value?: string) => string;
+  ignoreExportAllDeclaration?: boolean;
+  rejectNonAsyncFunction?: boolean;
+  keep?: boolean;
+};
+
 export function transformDirectiveProxyExport(
   ast: Program,
   options: {
     directive: string;
-    code?: string;
-    runtime: (name: string) => string;
-    ignoreExportAllDeclaration?: boolean;
-    rejectNonAsyncFunction?: boolean;
-    keep?: boolean;
-  },
+  } & TransformProxyExportOptions,
 ):
   | {
       exportNames: string[];
@@ -28,13 +31,7 @@ export function transformDirectiveProxyExport(
 
 export function transformProxyExport(
   ast: Program,
-  options: {
-    code?: string;
-    runtime: (name: string, value?: string) => string;
-    ignoreExportAllDeclaration?: boolean;
-    rejectNonAsyncFunction?: boolean;
-    keep?: boolean;
-  },
+  options: TransformProxyExportOptions,
 ): {
   exportNames: string[];
   output: MagicString;

--- a/packages/transforms/src/proxy-export.ts
+++ b/packages/transforms/src/proxy-export.ts
@@ -12,6 +12,7 @@ export function transformDirectiveProxyExport(
     runtime: (name: string) => string;
     ignoreExportAllDeclaration?: boolean;
     rejectNonAsyncFunction?: boolean;
+    keep?: boolean;
   },
 ):
   | {
@@ -29,10 +30,10 @@ export function transformProxyExport(
   ast: Program,
   options: {
     code?: string;
-    runtime: (name: string) => string;
+    runtime: (name: string, value?: string) => string;
     ignoreExportAllDeclaration?: boolean;
     rejectNonAsyncFunction?: boolean;
-    noRemove?: boolean;
+    keep?: boolean;
   },
 ): {
   exportNames: string[];
@@ -136,6 +137,8 @@ export function transformProxyExport(
       createExport(node, ["default"]);
       continue;
     }
+
+    if (options.keep) continue;
 
     // remove all other nodes
     output.remove(node.start, node.end);

--- a/packages/transforms/src/proxy-export.ts
+++ b/packages/transforms/src/proxy-export.ts
@@ -32,6 +32,7 @@ export function transformProxyExport(
     runtime: (name: string) => string;
     ignoreExportAllDeclaration?: boolean;
     rejectNonAsyncFunction?: boolean;
+    noRemove?: boolean;
   },
 ): {
   exportNames: string[];


### PR DESCRIPTION
- required by https://github.com/hi-ogawa/waku/pull/2

The idea is:

```js
"use client"
import { unstable_allowServer as allowServer } from 'waku/client';
import { atom } from 'jotai/vanilla';
import clientDep from "./client-dep" // 🗑️

const local1 = 1;
export const countAtom = allowServer(atom(local1));

const local2 = 2; // 🗑️
export const MyClientComp = () => <div>hey: {local2} {clientDep}</div>  // 🗑️
```

  ⬇️ custom DCE (implement it in Waku)

```js
"use client"
import { atom } from 'jotai/vanilla';

const local1 = 1;
export const countAtom = atom(local1);

export const MyClientComp = () => { throw new Error('... waku error ...') }
```

⬇️ rsc plugin use client transform with `keep: true`

```js
"use client"
import { atom } from 'jotai/vanilla';

const local1 = 1;
export const countAtom = $$register(atom(local1), ...)  // just wrap 🎁

export const MyClientComp = $$register(() => { throw new Error('... waku error ...') }, ...) // 🎁
```

It doesn't feel this is a good generalization, but for now let's go with whatever works.