### PR TITLE
chore: set tailwind base path to avoid unneeded hmr

### DIFF
--- a/packages/rsc/examples/basic/src/styles.css
+++ b/packages/rsc/examples/basic/src/styles.css
@@ -1,6 +1,4 @@
-/* css imported by rsc environment */
-
-@import "tailwindcss";
+@import "tailwindcss" source("./");
 
 button {
   @apply bg-gray-100 mx-1 px-2 border hover:bg-gray-200 active:bg-gray-300;


### PR DESCRIPTION
- Closes https://github.com/hi-ogawa/vite-plugins/issues/1075

I wonder whether we should detect this case and just try to ignore by default.