### PR TITLE
chore: browser only dep example

### DIFF
--- a/packages/rsc/examples/basic/src/routes/client-only/client.tsx
+++ b/packages/rsc/examples/basic/src/routes/client-only/client.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import React from "react";
+
+import { Dep } from "./dep" with { "vite-rsc": "browser-only" };
+
+export function TestBrowserOnly() {
+  return (
+    <div>[test-browser-only]: {useHydrated() ? <Dep /> : "loading..."}</div>
+  );
+}
+
+function useHydrated() {
+  const [hydrated, setHydrated] = React.useState(false);
+  React.useEffect(() => {
+    setHydrated(true);
+  }, []);
+  return hydrated;
+}
+
+// export function dynamic() {
+//   const LazyDep = React.lazy(async () => {
+//     if (import.meta.env.SSR) {
+//     }
+//     const mod = await import("./dep");
+//     return { default: mod.Dep };
+//   });
+
+//   function Wrapper() {
+//     if (import.meta.env.SSR) {
+//       return <>fallback</>;
+//     }
+//     return (
+//       <React.Suspense fallback={<>fallback</>}>
+//         <LazyDep />
+//       </React.Suspense>
+//     );
+//   }
+//   return Wrapper;
+// }
+
+// usage:
+// const Dep = BrowserOnly(() => import("./dep"), { fallback: <div>loading...</div> });
+// <Dep />
+
+// outcome:
+// - build
+//    - no ./dep chunk on
+// - ssr
+//   - render fallback
+//   - render modulepreload of browser ./dep chunk
+// - csr
+//   - anyway
+
+// transform entire module?
+
+// - ssr build
+// Dep = () => { fallback}
+// - client build (and hoist dynamic import as static import so client reference )
+// Dep => () => { useHydated() ? ActualDep : fallback }
+
+// on server compoment
+// import { ClientComp } from "./client";
+// // this is already lazy loaded in a sense
+// // we want to make this client reference to be swapped with fallback on ssr and initial hydration

--- a/packages/rsc/examples/basic/src/routes/client-only/dep.tsx
+++ b/packages/rsc/examples/basic/src/routes/client-only/dep.tsx
@@ -1,0 +1,5 @@
+"use client";
+
+export function Dep() {
+  return <span>dep</span>;
+}

--- a/packages/rsc/examples/basic/src/routes/root.tsx
+++ b/packages/rsc/examples/basic/src/routes/root.tsx
@@ -26,6 +26,7 @@ import {
   TestServerActionBindSimple,
 } from "./action-bind/server";
 import { TestActionStateServer } from "./action-state/server";
+import { TestBrowserOnly } from "./client-only/client";
 import { TestClientInServer } from "./deps/client-in-server/server";
 import { TestServerInClient } from "./deps/server-in-client/client";
 import { TestServerInServer } from "./deps/server-in-server/server";
@@ -89,6 +90,7 @@ export function Root(props: { url: URL }) {
         <TestServerInServer />
         <TestServerInClient />
         <TestActionStateServer />
+        <TestBrowserOnly />
       </body>
     </html>
   );

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -1787,3 +1787,19 @@ export function __fix_cloudflare(): Plugin {
     },
   };
 }
+
+export function vitePluginNextDynamic(): Plugin[] {
+  // if (import.meta.env.SSR) { }
+  //
+  // import.meta.viteRsc.dynamic(() => import("./foo"), { loading: () => ... })
+  return [];
+}
+
+// const ClientOnly = dynamic(() => import("./foo").then(m => m.Foo), { ssr: false })
+/*
+const inner = React.lazy(() => ...)
+
+<React.Suspense fallback={...}>
+  <Inner {...props}/>
+</React.Suspense>
+*/

--- a/packages/rsc/types/index.d.ts
+++ b/packages/rsc/types/index.d.ts
@@ -8,12 +8,6 @@ declare global {
       loadSsrModule: <T>(entry: string) => Promise<T>;
       loadModule: <T>(environmentName: string, entryName: string) => Promise<T>;
       loadBootstrapScriptContent: (entryName: string) => Promise<string>;
-
-      /**
-       * https://github.com/vercel/next.js/blob/09a2167b0a970757606b7f91ff2d470f77f13f8c/packages/next/src/shared/lib/dynamic.tsx#L79
-       * https://nextjs.org/docs/pages/guides/lazy-loading#nextdynamic
-       */
-      dynamic: <T>(loadFn: () => Promise<import("react").ReactNode>) => import("react").ReactNode;
     };
   }
 

--- a/packages/rsc/types/index.d.ts
+++ b/packages/rsc/types/index.d.ts
@@ -8,6 +8,12 @@ declare global {
       loadSsrModule: <T>(entry: string) => Promise<T>;
       loadModule: <T>(environmentName: string, entryName: string) => Promise<T>;
       loadBootstrapScriptContent: (entryName: string) => Promise<string>;
+
+      /**
+       * https://github.com/vercel/next.js/blob/09a2167b0a970757606b7f91ff2d470f77f13f8c/packages/next/src/shared/lib/dynamic.tsx#L79
+       * https://nextjs.org/docs/pages/guides/lazy-loading#nextdynamic
+       */
+      dynamic: <T>(loadFn: () => Promise<import("react").ReactNode>) => import("react").ReactNode;
     };
   }
 


### PR DESCRIPTION
- tree shake on ssr build
- but still modulepreload on ssr?

---

Since client component already provides an essence of lazy loading, what we want to do is more like this style of directive:

```js
import { ClientComp } from "./client" with { noSSR: true }

<ClientComp />
// this renders "fallback" on ssr and hydration.
```

So, this feels like a module level ("callee" side) transform concept than "caller" side transform. The crucial point is that, we want to use "static import" convention to benefit from modulepreload semantics of client reference for free.

So, at its core, we only need to provide emptifying exports on ssr build. Then users can build up on that to do anything e.g.

```js
import * as lib from "browser-lib" with { browserOnly: true }

function Comp() {
  
  // it can be just a utility only called on client
  <button onClick={() => lib.xxx}>...</button>

  // it can be a component 
  useHydrated() ? <lib.Comp ... /> : fallback;
}

function useHydrated() {
  ...
}
```
