### PR TITLE
feat: re-export `encodeReply` and `createTemporaryReferenceSet` from `react-server-dom/client` in `rsc` + feat(transforms): allow `noExport` for  `transformHoistInlineDirective` + chore: add `use cache` example

### DIFF
--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -702,7 +702,7 @@ test("server-in-client package", async ({ page }) => {
   );
 });
 
-test.only("use cache function", async ({ page }) => {
+test("use cache function", async ({ page }) => {
   await page.goto("./");
   await waitForHydration(page);
   const locator = page.getByTestId("test-use-cache-fn");

--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -701,3 +701,34 @@ test("server-in-client package", async ({ page }) => {
     "[server-in-client: 2]",
   );
 });
+
+test("use cache function", async ({ page }) => {
+  await page.goto("./");
+  await waitForHydration(page);
+  const locator = page.getByTestId("test-use-cache-fn");
+  await expect(locator.locator("span")).toHaveText(
+    "(actionCount: 0, cacheFnCount: 0)",
+  );
+  await locator.getByRole("button").click();
+  await expect(locator.locator("span")).toHaveText(
+    "(actionCount: 1, cacheFnCount: 1)",
+  );
+  await locator.getByRole("button").click();
+  await expect(locator.locator("span")).toHaveText(
+    "(actionCount: 2, cacheFnCount: 1)",
+  );
+  await locator.getByRole("textbox").fill("test");
+  await locator.getByRole("button").click();
+  await expect(locator.locator("span")).toHaveText(
+    "(actionCount: 3, cacheFnCount: 2)",
+  );
+  await locator.getByRole("button").click();
+  await expect(locator.locator("span")).toHaveText(
+    "(actionCount: 4, cacheFnCount: 2)",
+  );
+});
+
+test("use cache component", async ({ page }) => {
+  await page.goto("./");
+  await waitForHydration(page);
+});

--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -702,7 +702,7 @@ test("server-in-client package", async ({ page }) => {
   );
 });
 
-test("use cache function", async ({ page }) => {
+test.only("use cache function", async ({ page }) => {
   await page.goto("./");
   await waitForHydration(page);
   const locator = page.getByTestId("test-use-cache-fn");
@@ -726,6 +726,18 @@ test("use cache function", async ({ page }) => {
   await locator.getByRole("button").click();
   await expect(locator.locator("span")).toHaveText(
     "(actionCount: 4, cacheFnCount: 2)",
+  );
+
+  // revalidate cache
+  await locator.getByRole("textbox").fill("revalidate");
+  await locator.getByRole("button").click();
+  await expect(locator.locator("span")).toHaveText(
+    "(actionCount: 5, cacheFnCount: 3)",
+  );
+  await locator.getByRole("textbox").fill("test");
+  await locator.getByRole("button").click();
+  await expect(locator.locator("span")).toHaveText(
+    "(actionCount: 6, cacheFnCount: 4)",
   );
 });
 

--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -722,6 +722,7 @@ test("use cache function", async ({ page }) => {
   await expect(locator.locator("span")).toHaveText(
     "(actionCount: 3, cacheFnCount: 2)",
   );
+  await locator.getByRole("textbox").fill("test");
   await locator.getByRole("button").click();
   await expect(locator.locator("span")).toHaveText(
     "(actionCount: 4, cacheFnCount: 2)",
@@ -749,4 +750,53 @@ test("use cache component", async ({ page }) => {
     static2: expect.stringMatching(static1!),
     dynamic2: expect.not.stringMatching(dynamic1!),
   });
+});
+
+test("use cache closure", async ({ page }) => {
+  await page.goto("./");
+  await waitForHydration(page);
+  const locator = page.getByTestId("test-use-cache-closure");
+  await expect(locator.locator("span")).toHaveText(
+    "(actionCount: 0, innerFnCount: 0)",
+  );
+
+  // (x, y)
+  await locator.getByPlaceholder("outer").fill("x");
+  await locator.getByPlaceholder("inner").fill("y");
+  await locator.getByRole("button").click();
+  await expect(locator.locator("span")).toHaveText(
+    "(actionCount: 1, innerFnCount: 1)",
+  );
+
+  // (x, y)
+  await locator.getByPlaceholder("outer").fill("x");
+  await locator.getByPlaceholder("inner").fill("y");
+  await locator.getByRole("button").click();
+  await expect(locator.locator("span")).toHaveText(
+    "(actionCount: 2, innerFnCount: 1)",
+  );
+
+  // (xx, y)
+  await locator.getByPlaceholder("outer").fill("xx");
+  await locator.getByPlaceholder("inner").fill("y");
+  await locator.getByRole("button").click();
+  await expect(locator.locator("span")).toHaveText(
+    "(actionCount: 3, innerFnCount: 2)",
+  );
+
+  // (xx, y)
+  await locator.getByPlaceholder("outer").fill("xx");
+  await locator.getByPlaceholder("inner").fill("y");
+  await locator.getByRole("button").click();
+  await expect(locator.locator("span")).toHaveText(
+    "(actionCount: 4, innerFnCount: 2)",
+  );
+
+  // (xx, yy)
+  await locator.getByPlaceholder("outer").fill("xx");
+  await locator.getByPlaceholder("inner").fill("yy");
+  await locator.getByRole("button").click();
+  await expect(locator.locator("span")).toHaveText(
+    "(actionCount: 5, innerFnCount: 3)",
+  );
 });

--- a/packages/rsc/examples/basic/e2e/basic.test.ts
+++ b/packages/rsc/examples/basic/e2e/basic.test.ts
@@ -731,4 +731,22 @@ test("use cache function", async ({ page }) => {
 test("use cache component", async ({ page }) => {
   await page.goto("./");
   await waitForHydration(page);
+  const static1 = await page
+    .getByTestId("test-use-cache-component-static")
+    .textContent();
+  const dynamic1 = await page
+    .getByTestId("test-use-cache-component-dynamic")
+    .textContent();
+  await page.waitForTimeout(100);
+  await page.reload();
+  const static2 = await page
+    .getByTestId("test-use-cache-component-static")
+    .textContent();
+  const dynamic2 = await page
+    .getByTestId("test-use-cache-component-dynamic")
+    .textContent();
+  expect({ static2, dynamic2 }).toEqual({
+    static2: expect.stringMatching(static1!),
+    dynamic2: expect.not.stringMatching(dynamic1!),
+  });
 });

--- a/packages/rsc/examples/basic/package.json
+++ b/packages/rsc/examples/basic/package.json
@@ -19,6 +19,7 @@
     "react-dom": "latest"
   },
   "devDependencies": {
+    "@hiogawa/transforms": "latest",
     "@tailwindcss/vite": "^4.1.4",
     "@types/react": "latest",
     "@types/react-dom": "latest",

--- a/packages/rsc/examples/basic/src/routes/root.tsx
+++ b/packages/rsc/examples/basic/src/routes/root.tsx
@@ -31,6 +31,7 @@ import { TestServerInClient } from "./deps/server-in-client/client";
 import { TestServerInServer } from "./deps/server-in-server/server";
 import { TestSerializationServer } from "./serialization/server";
 import styles from "./server.module.css";
+import { TestUseCache } from "./use-cache/server";
 
 export function Root(props: { url: URL }) {
   return (
@@ -89,6 +90,7 @@ export function Root(props: { url: URL }) {
         <TestServerInServer />
         <TestServerInClient />
         <TestActionStateServer />
+        <TestUseCache />
       </body>
     </html>
   );

--- a/packages/rsc/examples/basic/src/routes/use-cache/server.tsx
+++ b/packages/rsc/examples/basic/src/routes/use-cache/server.tsx
@@ -2,14 +2,18 @@ export function TestUseCache() {
   return (
     <div>
       <form
+        data-testid="test-use-cache-fn"
         action={async (formData) => {
           "use server";
+          actionCount++;
           await testFn(formData.get("argument"));
         }}
       >
         <button>[test-use-cache-fn]</button>
         <input className="w-25" name="argument" placeholder="argument" />
-        (testFnCount: {testFnCount})
+        <span>
+          (actionCount: {actionCount}, cacheFnCount: {cacheFnCount})
+        </span>
       </form>
       <TestComponent>
         {/*
@@ -23,17 +27,18 @@ export function TestUseCache() {
   );
 }
 
-let testFnCount = 0;
+let actionCount = 0;
+let cacheFnCount = 0;
 
 async function testFn(..._args: unknown[]) {
   "use cache";
-  testFnCount++;
+  cacheFnCount++;
 }
 
 async function TestComponent(props: { children?: React.ReactNode }) {
   "use cache";
   return (
-    <div>
+    <div data-testid="test-use-cache-component">
       [test-use-cache-component] (static: {new Date().toISOString()}) (dynamic:{" "}
       {props.children})
     </div>

--- a/packages/rsc/examples/basic/src/routes/use-cache/server.tsx
+++ b/packages/rsc/examples/basic/src/routes/use-cache/server.tsx
@@ -1,3 +1,5 @@
+import { revalidateCache } from "../../use-cache-runtime";
+
 export function TestUseCache() {
   return (
     <>
@@ -15,7 +17,11 @@ function TestUseCacheFn() {
       action={async (formData) => {
         "use server";
         actionCount++;
-        await testFn(formData.get("argument"));
+        const argument = formData.get("argument");
+        await testFn(argument);
+        if (argument === "revalidate") {
+          revalidateCache(testFn);
+        }
       }}
     >
       <button>test-use-cache-fn</button>

--- a/packages/rsc/examples/basic/src/routes/use-cache/server.tsx
+++ b/packages/rsc/examples/basic/src/routes/use-cache/server.tsx
@@ -18,7 +18,7 @@ function TestUseCacheFn() {
         await testFn(formData.get("argument"));
       }}
     >
-      <button>[test-use-cache-fn]</button>
+      <button>test-use-cache-fn</button>
       <input className="w-25" name="argument" placeholder="argument" />
       <span>
         (actionCount: {actionCount}, cacheFnCount: {cacheFnCount})
@@ -62,41 +62,35 @@ async function TestComponent(props: { children?: React.ReactNode }) {
 }
 
 async function TestUseCacheClosure() {
-  function outerFn(outer: string) {
-    async function innerFn(inner: string) {
-      "use cache";
-      innerFnCount++;
-      return (
-        <span>
-          (outer: {outer}, inner: {inner})
-        </span>
-      );
-    }
-    return innerFn;
-  }
-
-  const result = await outerFn(outerFnArg)(innerFnArg);
-
   return (
-    <div className="flex gap-1">
+    <div data-testid="test-use-cache-closure" className="flex gap-1">
       <form
         action={async (formData) => {
           "use server";
           actionCount2++;
           outerFnArg = formData.get("outer") as string;
           innerFnArg = formData.get("inner") as string;
+          await outerFn(outerFnArg)(innerFnArg);
         }}
       >
-        <button>[test-use-cache-closure]</button>
+        <button>test-use-cache-closure</button>
         <input className="w-15" name="outer" placeholder="outer" />
         <input className="w-15" name="inner" placeholder="inner" />
       </form>
-      <span>{result}</span>
       <span>
-        (actionCount2: {actionCount2}, innerFnCount: {innerFnCount})
+        (actionCount: {actionCount2}, innerFnCount: {innerFnCount})
       </span>
     </div>
   );
+}
+
+function outerFn(outer: string) {
+  async function innerFn(inner: string) {
+    "use cache";
+    innerFnCount++;
+    console.log({ outer, inner });
+  }
+  return innerFn;
 }
 
 let outerFnArg = "";

--- a/packages/rsc/examples/basic/src/routes/use-cache/server.tsx
+++ b/packages/rsc/examples/basic/src/routes/use-cache/server.tsx
@@ -39,8 +39,13 @@ async function TestComponent(props: { children?: React.ReactNode }) {
   "use cache";
   return (
     <div data-testid="test-use-cache-component">
-      [test-use-cache-component] (static: {new Date().toISOString()}) (dynamic:{" "}
-      {props.children})
+      [test-use-cache-component]{" "}
+      <span data-testid="test-use-cache-component-static">
+        (static: {new Date().toISOString()})
+      </span>{" "}
+      <span data-testid="test-use-cache-component-dynamic">
+        (dynamic: {props.children})
+      </span>
     </div>
   );
 }

--- a/packages/rsc/examples/basic/src/routes/use-cache/server.tsx
+++ b/packages/rsc/examples/basic/src/routes/use-cache/server.tsx
@@ -1,29 +1,29 @@
 export function TestUseCache() {
   return (
-    <div>
-      <form
-        data-testid="test-use-cache-fn"
-        action={async (formData) => {
-          "use server";
-          actionCount++;
-          await testFn(formData.get("argument"));
-        }}
-      >
-        <button>[test-use-cache-fn]</button>
-        <input className="w-25" name="argument" placeholder="argument" />
-        <span>
-          (actionCount: {actionCount}, cacheFnCount: {cacheFnCount})
-        </span>
-      </form>
-      <TestComponent>
-        {/*
-          NOTE: warpping with `span` is crucial because
-          raw string `children` would get included as cache key
-          and thus causes `TestComponent` to be evaluated in each render.
-        */}
-        <span>{new Date().toISOString()}</span>
-      </TestComponent>
-    </div>
+    <>
+      <TestUseCacheFn />
+      <TestUseCacheComponent />
+      <TestUseCacheClosure />
+    </>
+  );
+}
+
+function TestUseCacheFn() {
+  return (
+    <form
+      data-testid="test-use-cache-fn"
+      action={async (formData) => {
+        "use server";
+        actionCount++;
+        await testFn(formData.get("argument"));
+      }}
+    >
+      <button>[test-use-cache-fn]</button>
+      <input className="w-25" name="argument" placeholder="argument" />
+      <span>
+        (actionCount: {actionCount}, cacheFnCount: {cacheFnCount})
+      </span>
+    </form>
   );
 }
 
@@ -33,6 +33,17 @@ let cacheFnCount = 0;
 async function testFn(..._args: unknown[]) {
   "use cache";
   cacheFnCount++;
+}
+
+function TestUseCacheComponent() {
+  // NOTE: warpping with `span` (or any jsx) is crucial because
+  // raw string `children` would get included as cache key
+  // and thus causes `TestComponent` to be evaluated in each render.
+  return (
+    <TestComponent>
+      <span>{new Date().toISOString()}</span>
+    </TestComponent>
+  );
 }
 
 async function TestComponent(props: { children?: React.ReactNode }) {
@@ -49,3 +60,46 @@ async function TestComponent(props: { children?: React.ReactNode }) {
     </div>
   );
 }
+
+async function TestUseCacheClosure() {
+  function outerFn(outer: string) {
+    async function innerFn(inner: string) {
+      "use cache";
+      innerFnCount++;
+      return (
+        <span>
+          (outer: {outer}, inner: {inner})
+        </span>
+      );
+    }
+    return innerFn;
+  }
+
+  const result = await outerFn(outerFnArg)(innerFnArg);
+
+  return (
+    <div className="flex gap-1">
+      <form
+        action={async (formData) => {
+          "use server";
+          actionCount2++;
+          outerFnArg = formData.get("outer") as string;
+          innerFnArg = formData.get("inner") as string;
+        }}
+      >
+        <button>[test-use-cache-closure]</button>
+        <input className="w-15" name="outer" placeholder="outer" />
+        <input className="w-15" name="inner" placeholder="inner" />
+      </form>
+      <span>{result}</span>
+      <span>
+        (actionCount2: {actionCount2}, innerFnCount: {innerFnCount})
+      </span>
+    </div>
+  );
+}
+
+let outerFnArg = "";
+let innerFnArg = "";
+let innerFnCount = 0;
+let actionCount2 = 0;

--- a/packages/rsc/examples/basic/src/routes/use-cache/server.tsx
+++ b/packages/rsc/examples/basic/src/routes/use-cache/server.tsx
@@ -36,7 +36,7 @@ async function testFn(..._args: unknown[]) {
 }
 
 function TestUseCacheComponent() {
-  // NOTE: warpping with `span` (or any jsx) is crucial because
+  // NOTE: wrapping with `span` (or any jsx) is crucial because
   // raw string `children` would get included as cache key
   // and thus causes `TestComponent` to be evaluated in each render.
   return (

--- a/packages/rsc/examples/basic/src/routes/use-cache/server.tsx
+++ b/packages/rsc/examples/basic/src/routes/use-cache/server.tsx
@@ -1,0 +1,25 @@
+export function TestUseCache() {
+  return (
+    <div>
+      <form
+        action={async (formData) => {
+          "use server";
+          // TODO: "use server" and "use cache" together breaks?
+          const arg = formData.get("arg");
+          console.log("[testFn:before]", { arg });
+          const result = await testFn(arg);
+          console.log("[testFn:after]", { result });
+        }}
+      >
+        <button>[test-use-cache]</button>
+        <input className="w-20" name="arg" placeholder="arg" />
+      </form>
+    </div>
+  );
+}
+
+async function testFn(...args: unknown[]) {
+  "use cache";
+  console.log("[testFn]", args);
+  return args;
+}

--- a/packages/rsc/examples/basic/src/routes/use-cache/server.tsx
+++ b/packages/rsc/examples/basic/src/routes/use-cache/server.tsx
@@ -4,22 +4,38 @@ export function TestUseCache() {
       <form
         action={async (formData) => {
           "use server";
-          // TODO: "use server" and "use cache" together breaks?
-          const arg = formData.get("arg");
-          console.log("[testFn:before]", { arg });
-          const result = await testFn(arg);
-          console.log("[testFn:after]", { result });
+          await testFn(formData.get("argument"));
         }}
       >
-        <button>[test-use-cache]</button>
-        <input className="w-20" name="arg" placeholder="arg" />
+        <button>[test-use-cache-fn]</button>
+        <input className="w-25" name="argument" placeholder="argument" />
+        (testFnCount: {testFnCount})
       </form>
+      <TestComponent>
+        {/*
+          NOTE: warpping with `span` is crucial because
+          raw string `children` would get included as cache key
+          and thus causes `TestComponent` to be evaluated in each render.
+        */}
+        <span>{new Date().toISOString()}</span>
+      </TestComponent>
     </div>
   );
 }
 
-async function testFn(...args: unknown[]) {
+let testFnCount = 0;
+
+async function testFn(..._args: unknown[]) {
   "use cache";
-  console.log("[testFn]", args);
-  return args;
+  testFnCount++;
+}
+
+async function TestComponent(props: { children?: React.ReactNode }) {
+  "use cache";
+  return (
+    <div>
+      [test-use-cache-component] (static: {new Date().toISOString()}) (dynamic:{" "}
+      {props.children})
+    </div>
+  );
 }

--- a/packages/rsc/examples/basic/src/use-cache-runtime.tsx
+++ b/packages/rsc/examples/basic/src/use-cache-runtime.tsx
@@ -17,7 +17,7 @@ export default function cacheWrapper(fn: (...args: any[]) => Promise<unknown>) {
     // Serialize arguments to a cache key via `encodeReply` from `react-server-dom/client`.
     // NOTE: using `renderToReadableStream` here for arguments serialization would end up
     // serializing react elements (e.g. children props), which causes
-    // those arguments to be includes as a cache key and it doesn't achive
+    // those arguments to be included as a cache key and it doesn't achieve
     // "use cache static shell + dynamic children props" pattern.
     // cf. https://nextjs.org/docs/app/api-reference/directives/use-cache#non-serializable-arguments
     const clientTemporaryReferences =

--- a/packages/rsc/examples/basic/src/use-cache-runtime.tsx
+++ b/packages/rsc/examples/basic/src/use-cache-runtime.tsx
@@ -28,6 +28,7 @@ export default function cacheWrapper(fn: (...args: any[]) => Promise<unknown>) {
           );
 
     // cache `fn` result as stream
+    // (cache value is promise so that it dedupes concurrent async calls)
     const entryPromise = (cacheEntries[serializedCacheKey] ??= (async () => {
       const temporaryReferences = ReactRsc.createTemporaryReferenceSet();
       const decodedArgs = await ReactRsc.decodeReply(encodedArguments, {

--- a/packages/rsc/examples/basic/src/use-cache-runtime.tsx
+++ b/packages/rsc/examples/basic/src/use-cache-runtime.tsx
@@ -1,11 +1,16 @@
 import * as ReactRsc from "@hiogawa/vite-rsc/rsc";
-import React from "react";
 
 // based on
 // https://github.com/vercel/next.js/pull/70435
 // https://github.com/vercel/next.js/blob/09a2167b0a970757606b7f91ff2d470f77f13f8c/packages/next/src/server/use-cache/use-cache-wrapper.ts
 
+const cachedFnMap = new WeakMap<Function, unknown>();
+
 export default function cacheWrapper(fn: (...args: any[]) => Promise<unknown>) {
+  if (cachedFnMap.has(fn)) {
+    return cachedFnMap.get(fn)!;
+  }
+
   const cacheEntries: Record<string, Promise<StreamCacher>> = {};
 
   async function cachedFn(...args: any[]) {
@@ -57,7 +62,9 @@ export default function cacheWrapper(fn: (...args: any[]) => Promise<unknown>) {
     return result;
   }
 
-  return React.cache(cachedFn);
+  cachedFnMap.set(fn, cachedFn);
+
+  return cachedFn;
 }
 
 class StreamCacher {

--- a/packages/rsc/examples/basic/src/use-cache-runtime.tsx
+++ b/packages/rsc/examples/basic/src/use-cache-runtime.tsx
@@ -1,0 +1,20 @@
+import * as ReactServer from "@hiogawa/vite-rsc/rsc";
+import React from "react";
+
+// based on
+// https://github.com/vercel/next.js/pull/70435
+// https://github.com/vercel/next.js/blob/09a2167b0a970757606b7f91ff2d470f77f13f8c/packages/next/src/server/use-cache/use-cache-wrapper.ts
+
+export default function cacheWrapper(fn: (...args: any[]) => Promise<unknown>) {
+  let store: Record<string, Promise<ReadableStream>> = {};
+
+  async function cachedFn(...args: any[]) {
+    if (1) return fn(...args);
+    args;
+    store;
+    ReactServer.renderToReadableStream;
+    ReactServer.createFromReadableStream;
+  }
+
+  return React.cache(cachedFn);
+}

--- a/packages/rsc/examples/basic/src/use-cache-runtime.tsx
+++ b/packages/rsc/examples/basic/src/use-cache-runtime.tsx
@@ -16,8 +16,8 @@ export default function cacheWrapper(fn: (...args: any[]) => Promise<unknown>) {
   async function cachedFn(...args: any[]) {
     // Serialize arguments to a cache key via `encodeReply` from `react-server-dom/client`.
     // NOTE: using `renderToReadableStream` here for arguments serialization would end up
-    // serializing react elements arguments (e.g. children props), which causes
-    // those arguments to become a cache key and it doesn't achive
+    // serializing react elements (e.g. children props), which causes
+    // those arguments to be includes as a cache key and it doesn't achive
     // "use cache static shell + dynamic children props" pattern.
     // cf. https://nextjs.org/docs/app/api-reference/directives/use-cache#non-serializable-arguments
     const clientTemporaryReferences =

--- a/packages/rsc/examples/basic/src/use-cache-runtime.tsx
+++ b/packages/rsc/examples/basic/src/use-cache-runtime.tsx
@@ -10,9 +10,10 @@ export default function cacheWrapper(fn: (...args: any[]) => Promise<unknown>) {
 
   async function cachedFn(...args: any[]) {
     // Serialize arguments to a cache key via `encodeReply` from `react-server-dom/client`.
-    // NOTE: using `renderToReadableStream` here instead would end up serializing react elements arguments
-    // (e.g. children props), which causes those arguments to become a cache key and
-    // breaks "use cache static shell + dynamic children props" pattern.
+    // NOTE: using `renderToReadableStream` here for arguments serialization would end up
+    // serializing react elements arguments (e.g. children props), which causes
+    // those arguments to become a cache key and it doesn't achive
+    // "use cache static shell + dynamic children props" pattern.
     // cf. https://nextjs.org/docs/app/api-reference/directives/use-cache#non-serializable-arguments
     const clientTemporaryReferences =
       ReactRsc.createClientTemporaryReferenceSet();

--- a/packages/rsc/examples/basic/src/use-cache-runtime.tsx
+++ b/packages/rsc/examples/basic/src/use-cache-runtime.tsx
@@ -1,4 +1,4 @@
-import * as ReactServer from "@hiogawa/vite-rsc/rsc";
+import * as ReactRsc from "@hiogawa/vite-rsc/rsc";
 import React from "react";
 
 // based on
@@ -6,15 +6,76 @@ import React from "react";
 // https://github.com/vercel/next.js/blob/09a2167b0a970757606b7f91ff2d470f77f13f8c/packages/next/src/server/use-cache/use-cache-wrapper.ts
 
 export default function cacheWrapper(fn: (...args: any[]) => Promise<unknown>) {
-  let store: Record<string, Promise<ReadableStream>> = {};
+  const cacheEntries: Record<string, Promise<StreamCacher>> = {};
 
   async function cachedFn(...args: any[]) {
-    if (1) return fn(...args);
-    args;
-    store;
-    ReactServer.renderToReadableStream;
-    ReactServer.createFromReadableStream;
+    // serialize arguments to a cache key via `encodeReply` from `react-server-dom/client`
+    // TODO: why not use `renderToReadableStream` to serialize instead?
+    const clientTemporaryReferences =
+      ReactRsc.createClientTemporaryReferenceSet();
+    const encodedArguments = await ReactRsc.encodeReply(args, {
+      temporaryReferences: clientTemporaryReferences,
+    });
+    const serializedCacheKey =
+      typeof encodedArguments === "string"
+        ? "a:" + encodedArguments
+        : "b:" +
+          arrayBufferToString(
+            await new Response(encodedArguments).arrayBuffer(),
+          );
+
+    // cache `fn` result as stream
+    const entryPromise = (cacheEntries[serializedCacheKey] ??= (async () => {
+      // handle cache miss
+
+      // TODO: why not use `args` directly?
+      const temporaryReferences = ReactRsc.createTemporaryReferenceSet();
+      const decodedArgs = await ReactRsc.decodeReply(encodedArguments, {
+        temporaryReferences,
+      });
+
+      // run the original function
+      const result = await fn(...decodedArgs);
+
+      // serialize result to a ReadableStream
+      const stream = ReactRsc.renderToReadableStream(result, {
+        environmentName: "Cache",
+        temporaryReferences,
+      });
+      return new StreamCacher(stream);
+    })());
+
+    // deserialized cached stream
+    const stream = (await entryPromise).get();
+    const result = ReactRsc.createFromReadableStream(stream, {
+      environmentName: "Cache",
+      replayConsoleLogs: true,
+      temporaryReferences: clientTemporaryReferences,
+    });
+    return result;
   }
 
   return React.cache(cachedFn);
+}
+
+class StreamCacher {
+  constructor(private stream: ReadableStream<Uint8Array>) {}
+  get(): ReadableStream<Uint8Array> {
+    const [returnStream, savedStream] = this.stream.tee();
+    this.stream = savedStream;
+    return returnStream;
+  }
+}
+
+function arrayBufferToString(buffer: ArrayBuffer | Uint8Array): string {
+  const bytes = new Uint8Array(buffer);
+  const len = bytes.byteLength;
+  if (len < 65535) {
+    return String.fromCharCode.apply(null, bytes as unknown as number[]);
+  }
+  let binary = "";
+  for (let i = 0; i < len; i++) {
+    binary += String.fromCharCode(bytes[i]!);
+  }
+  return binary;
 }

--- a/packages/rsc/examples/basic/src/use-cache-runtime.tsx
+++ b/packages/rsc/examples/basic/src/use-cache-runtime.tsx
@@ -67,6 +67,11 @@ export default function cacheWrapper(fn: (...args: any[]) => Promise<unknown>) {
   return cachedFn;
 }
 
+// TODO
+export function revalidate(fn: Function) {
+  fn;
+}
+
 class StreamCacher {
   constructor(private stream: ReadableStream<Uint8Array>) {}
   get(): ReadableStream<Uint8Array> {

--- a/packages/rsc/examples/basic/src/use-cache-runtime.tsx
+++ b/packages/rsc/examples/basic/src/use-cache-runtime.tsx
@@ -26,8 +26,6 @@ export default function cacheWrapper(fn: (...args: any[]) => Promise<unknown>) {
 
     // cache `fn` result as stream
     const entryPromise = (cacheEntries[serializedCacheKey] ??= (async () => {
-      // handle cache miss
-
       // TODO: why not use `args` directly?
       const temporaryReferences = ReactRsc.createTemporaryReferenceSet();
       const decodedArgs = await ReactRsc.decodeReply(encodedArguments, {

--- a/packages/rsc/src/react/browser.ts
+++ b/packages/rsc/src/react/browser.ts
@@ -26,12 +26,10 @@ export function createFromFetch<T>(
   });
 }
 
-export function encodeReply(
+export const encodeReply: (
   v: unknown[],
   options?: unknown,
-): Promise<string | FormData> {
-  return ReactClient.encodeReply(v, options);
-}
+) => Promise<string | FormData> = ReactClient.encodeReply;
 
 export const createServerReference: (...args: any[]) => unknown =
   ReactClient.createServerReference;

--- a/packages/rsc/src/react/rsc.ts
+++ b/packages/rsc/src/react/rsc.ts
@@ -2,6 +2,9 @@
 import * as ReactClient from "@hiogawa/vite-rsc/vendor/react-server-dom/client.edge";
 // @ts-ignore
 import * as ReactServer from "@hiogawa/vite-rsc/vendor/react-server-dom/server.edge";
+// @ts-ignore
+// import * as ReactStatic from "@hiogawa/vite-rsc/vendor/react-server-dom/static.edge";
+
 import type { ReactFormState } from "react-dom/client";
 import {
   createClientManifest,
@@ -75,3 +78,22 @@ export function decodeFormState(
 
 export const createTemporaryReferenceSet: () => unknown =
   ReactServer.createTemporaryReferenceSet;
+
+// this seems necessary for "use cache"
+// https://github.com/vercel/next.js/blob/09a2167b0a970757606b7f91ff2d470f77f13f8c/packages/next/src/server/use-cache/use-cache-wrapper.ts
+export const encodeReply: (
+  v: unknown[],
+  options?: unknown,
+) => Promise<string | FormData> = ReactClient.encodeReply;
+
+export const createClientTemporaryReferenceSet: () => unknown =
+  ReactClient.createTemporaryReferenceSet;
+
+// export function unstable_prerender<T>(
+//   data: T,
+//   options?: object,
+// ): Promise<{
+//   prelude: ReadableStream<Uint8Array>;
+// }> {
+//   return ReactStatic.unstable_prerender(data, createClientManifest(), options);
+// }

--- a/packages/rsc/src/react/rsc.ts
+++ b/packages/rsc/src/react/rsc.ts
@@ -2,8 +2,6 @@
 import * as ReactClient from "@hiogawa/vite-rsc/vendor/react-server-dom/client.edge";
 // @ts-ignore
 import * as ReactServer from "@hiogawa/vite-rsc/vendor/react-server-dom/server.edge";
-// @ts-ignore
-// import * as ReactStatic from "@hiogawa/vite-rsc/vendor/react-server-dom/static.edge";
 
 import type { ReactFormState } from "react-dom/client";
 import {
@@ -88,12 +86,3 @@ export const encodeReply: (
 
 export const createClientTemporaryReferenceSet: () => unknown =
   ReactClient.createTemporaryReferenceSet;
-
-// export function unstable_prerender<T>(
-//   data: T,
-//   options?: object,
-// ): Promise<{
-//   prelude: ReadableStream<Uint8Array>;
-// }> {
-//   return ReactStatic.unstable_prerender(data, createClientManifest(), options);
-// }

--- a/packages/rsc/src/react/rsc.ts
+++ b/packages/rsc/src/react/rsc.ts
@@ -2,7 +2,6 @@
 import * as ReactClient from "@hiogawa/vite-rsc/vendor/react-server-dom/client.edge";
 // @ts-ignore
 import * as ReactServer from "@hiogawa/vite-rsc/vendor/react-server-dom/server.edge";
-
 import type { ReactFormState } from "react-dom/client";
 import {
   createClientManifest,
@@ -77,8 +76,6 @@ export function decodeFormState(
 export const createTemporaryReferenceSet: () => unknown =
   ReactServer.createTemporaryReferenceSet;
 
-// this seems necessary for "use cache"
-// https://github.com/vercel/next.js/blob/09a2167b0a970757606b7f91ff2d470f77f13f8c/packages/next/src/server/use-cache/use-cache-wrapper.ts
 export const encodeReply: (
   v: unknown[],
   options?: unknown,

--- a/packages/transforms/src/hoist.test.ts
+++ b/packages/transforms/src/hoist.test.ts
@@ -346,7 +346,7 @@ describe("use cache", () => {
   async function testTransform(input: string) {
     const ast = await parseAstAsync(input);
     const { output } = transformHoistInlineDirective(input, ast, {
-      runtime: (value) => `$$regsiter(${value})`,
+      runtime: (value) => `__cache_wrapper(${value})`,
       directive: "use cache",
       rejectNonAsyncFunction: true,
       noExport: true,
@@ -354,18 +354,6 @@ describe("use cache", () => {
     if (!output.hasChanged()) {
       return;
     }
-    //     output.prepend(`
-    // const $$regsiter_cache_fn = (fn) => {
-    //   let __cache;
-    //   return async function __wrapper(...args) {
-    //     const __cache_key = await __serialize(args);
-    //     if (__cache_key in __cache) {
-    //       return __cache[__cache_key];
-    //     }
-    //     return __cache[__cache_key] = fn(...args);
-    //   }
-    // }
-    // `);
     return output.toString();
   }
 
@@ -378,7 +366,7 @@ export async function test(x) {
 `;
 
     expect(await testTransform(input)).toMatchInlineSnapshot(`
-      "export const test = /* #__PURE__ */ $$regsiter($$hoist_0_test);
+      "export const test = /* #__PURE__ */ __cache_wrapper($$hoist_0_test);
 
       ;async function $$hoist_0_test(x) {
         "use cache";
@@ -401,7 +389,7 @@ export async function test(x) {
 
     expect(await testTransform(input)).toMatchInlineSnapshot(`
       "export async function test(x) {
-        const inner = /* #__PURE__ */ $$regsiter($$hoist_0_inner).bind(null, x);
+        const inner = /* #__PURE__ */ __cache_wrapper($$hoist_0_inner).bind(null, x);
       }
 
       ;async function $$hoist_0_inner(x, y) {

--- a/packages/transforms/src/hoist.test.ts
+++ b/packages/transforms/src/hoist.test.ts
@@ -68,19 +68,19 @@ export default function w() {
       const w = /* #__PURE__ */ $$register($$hoist_2_w, "<id>", "$$hoist_2_w");
       export default w;
 
-      ;async function $$hoist_0_f() {
+      ;export async function $$hoist_0_f() {
         "use server";
         return x;
       };
       /* #__PURE__ */ Object.defineProperty($$hoist_0_f, "name", { value: "f" });
 
-      ;async function $$hoist_1_h(formData) {
+      ;export async function $$hoist_1_h(formData) {
         "use server";
         return formData.get(x);
       };
       /* #__PURE__ */ Object.defineProperty($$hoist_1_h, "name", { value: "h" });
 
-      ;function $$hoist_2_w() {
+      ;export function $$hoist_2_w() {
         "use server";
       };
       /* #__PURE__ */ Object.defineProperty($$hoist_2_w, "name", { value: "w" });
@@ -120,7 +120,7 @@ function Counter() {
         return "something";
       }
 
-      ;async function $$hoist_0_changeCount(name, formData) {
+      ;export async function $$hoist_0_changeCount(name, formData) {
           "use server";
           count += Number(formData.get(name));
         };
@@ -163,13 +163,13 @@ function Counter() {
         return "something";
       }
 
-      ;async function $$hoist_0_changeCount(name, formData) {
+      ;export async function $$hoist_0_changeCount(name, formData) {
           "use server";
           count += Number(formData.get(name));
         };
       /* #__PURE__ */ Object.defineProperty($$hoist_0_changeCount, "name", { value: "changeCount" });
 
-      ;async function $$hoist_1_changeCount2(name, formData) {
+      ;export async function $$hoist_1_changeCount2(name, formData) {
           "use server";
           count += Number(formData.get(name));
         };
@@ -207,7 +207,7 @@ function Counter() {
         }
       }
 
-      ;function $$hoist_0_anonymous_server_function(name, formData) {
+      ;export function $$hoist_0_anonymous_server_function(name, formData) {
             "use server";
             count += Number(formData.get(name));
           };
@@ -228,7 +228,7 @@ function Counter() {
         }
       }
 
-      ;function $$hoist_0_anonymous_server_function($$hoist_encoded, formData) {
+      ;export function $$hoist_0_anonymous_server_function($$hoist_encoded, formData) {
             const [name] = __dec($$hoist_encoded);
       "use server";
             count += Number(formData.get(name));
@@ -268,13 +268,13 @@ function validator(action) {
         return /* #__PURE__ */ $$register($$hoist_1_anonymous_server_function, "<id>", "$$hoist_1_anonymous_server_function").bind(null, action);
       }
 
-      ;async function $$hoist_0_anonymous_server_function(x, y) {
+      ;export async function $$hoist_0_anonymous_server_function(x, y) {
           "use server";
           return x + y;
         };
       /* #__PURE__ */ Object.defineProperty($$hoist_0_anonymous_server_function, "name", { value: "anonymous_server_function" });
 
-      ;async function $$hoist_1_anonymous_server_function(action, arg) {
+      ;export async function $$hoist_1_anonymous_server_function(action, arg) {
           "use server";
           return action(arg);
         };
@@ -293,14 +293,14 @@ function validator(action) {
         return /* #__PURE__ */ $$register($$hoist_1_anonymous_server_function, "<id>", "$$hoist_1_anonymous_server_function").bind(null, __enc([action]));
       }
 
-      ;async function $$hoist_0_anonymous_server_function($$hoist_encoded, y) {
+      ;export async function $$hoist_0_anonymous_server_function($$hoist_encoded, y) {
           const [x] = __dec($$hoist_encoded);
       "use server";
           return x + y;
         };
       /* #__PURE__ */ Object.defineProperty($$hoist_0_anonymous_server_function, "name", { value: "anonymous_server_function" });
 
-      ;async function $$hoist_1_anonymous_server_function($$hoist_encoded, arg) {
+      ;export async function $$hoist_1_anonymous_server_function($$hoist_encoded, arg) {
           const [action] = __dec($$hoist_encoded);
       "use server";
           return action(arg);
@@ -332,7 +332,7 @@ export default () => {
         const redirectOnServer = /* #__PURE__ */ $$register($$hoist_0_redirectOnServer, "<id>", "$$hoist_0_redirectOnServer");
       }
 
-      ;async function $$hoist_0_redirectOnServer() {
+      ;export async function $$hoist_0_redirectOnServer() {
           "use server";
           throw redirect();
         };
@@ -349,7 +349,7 @@ describe("use cache", () => {
       runtime: (value) => `$$regsiter(${value})`,
       directive: "use cache",
       rejectNonAsyncFunction: true,
-      export: false,
+      noExport: true,
     });
     if (!output.hasChanged()) {
       return;

--- a/packages/transforms/src/hoist.ts
+++ b/packages/transforms/src/hoist.ts
@@ -19,6 +19,7 @@ export function transformHoistInlineDirective(
     rejectNonAsyncFunction?: boolean;
     encode?: (value: string) => string;
     decode?: (value: string) => string;
+    export?: boolean;
   },
 ): {
   output: MagicString;
@@ -100,7 +101,7 @@ export function transformHoistInlineDirective(
         output.update(
           node.start,
           node.body.start,
-          `\n;export ${node.async ? "async " : ""}function ${newName}(${newParams}) `,
+          `\n;${options.export ? "export " : ""}${node.async ? "async " : ""}function ${newName}(${newParams}) `,
         );
         output.appendLeft(
           node.end,

--- a/packages/transforms/src/hoist.ts
+++ b/packages/transforms/src/hoist.ts
@@ -19,7 +19,7 @@ export function transformHoistInlineDirective(
     rejectNonAsyncFunction?: boolean;
     encode?: (value: string) => string;
     decode?: (value: string) => string;
-    export?: boolean;
+    noExport?: boolean;
   },
 ): {
   output: MagicString;
@@ -101,7 +101,7 @@ export function transformHoistInlineDirective(
         output.update(
           node.start,
           node.body.start,
-          `\n;${options.export ? "export " : ""}${node.async ? "async " : ""}function ${newName}(${newParams}) `,
+          `\n;${options.noExport ? "" : "export "}${node.async ? "async " : ""}function ${newName}(${newParams}) `,
         );
         output.appendLeft(
           node.end,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -572,6 +572,9 @@ importers:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
     devDependencies:
+      '@hiogawa/transforms':
+        specifier: latest
+        version: link:../../../transforms
       '@tailwindcss/vite':
         specifier: ^4.1.4
         version: 4.1.4(vite@6.3.5(@types/node@22.14.1)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))


### PR DESCRIPTION
- Closes https://github.com/hi-ogawa/vite-plugins/issues/902

Vite RSC itself won't likely do anything, but need to see if anything missing on runtime side for "use cache" to be possible.

## resources

- https://github.com/jacob-ebey/react-router-rsc-no-framework
- https://github.com/lazarv/react-server
- https://github.com/vercel/next.js/tree/canary/packages/next/src/server/use-cache
  - https://github.com/vercel/next.js/blob/09a2167b0a970757606b7f91ff2d470f77f13f8c/crates/next-custom-transforms/src/transforms/server_actions.rs#L2045
  - https://github.com/vercel/next.js/pull/70435
  - for now copying this basic implementation

## todo

Just confirm the basic usage and actual frameworks can probably try it out further.

- [ ] test
  - [x] basic
  - [x] with server component
    - static shell + dynamic props https://nextjs.org/docs/app/api-reference/directives/use-cache#non-serializable-arguments
  - [x] with closure
  - [x] revalidate
  - [ ] file level directive
  - [ ] server reference as argument
  - [ ] server reference as return value
  - [ ] client reference as argument
  - [ ] client reference as return value
  - [ ] error handling
- [ ] ssg?