### PR TITLE
fix: copy all server assets to client by default and output `__vite_rsc_encryption_key` to fs directly

### DIFF
--- a/packages/rsc/examples/basic/vite.config.ts
+++ b/packages/rsc/examples/basic/vite.config.ts
@@ -33,6 +33,8 @@ export default defineConfig({
       // disable auto css injection to manually test `loadCss` feature.
       rscCssTransform: false,
       ignoredPackageWarnings: [/@vitejs\/test-dep-/],
+      copyServerAssetsToClient: (fileName) =>
+        fileName !== "__server_secret.txt",
     }),
     // avoid ecosystem CI fail due to vite-plugin-inspect compatibility
     !process.env.ECOSYSTEM_CI && inspect(),
@@ -65,7 +67,7 @@ export default defineConfig({
       },
     },
     {
-      name: "test-server-emitFile-security",
+      name: "test-server-assets-security",
       buildStart() {
         if (this.environment.name === "rsc") {
           this.emitFile({

--- a/packages/rsc/examples/starter-e2e/e2e/basic.test.ts
+++ b/packages/rsc/examples/starter-e2e/e2e/basic.test.ts
@@ -58,3 +58,16 @@ test("client hmr @dev", async ({ page }) => {
   editor.reset();
   await page.getByRole("button", { name: "Client Counter: 0" }).click();
 });
+
+test("image assets", async ({ page }) => {
+  await page.goto("./");
+  await waitForHydration(page);
+  await expect(page.getByAltText("Vite logo")).not.toHaveJSProperty(
+    "naturalWidth",
+    0,
+  );
+  await expect(page.getByAltText("React logo")).not.toHaveJSProperty(
+    "naturalWidth",
+    0,
+  );
+});

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -1051,13 +1051,15 @@ function vitePluginDefineEncryptionKey(
           return { code };
         }
       },
-      generateBundle() {
+      writeBundle() {
         if (this.environment.name === "rsc" && emitEncryptionKey) {
-          this.emitFile({
-            type: "asset",
-            fileName: "__vite_rsc_encryption_key.js",
-            source: `export default ${defineEncryptionKey};`,
-          });
+          fs.writeFileSync(
+            path.join(
+              this.environment.config.build.outDir,
+              "__vite_rsc_encryption_key.js",
+            ),
+            `export default ${defineEncryptionKey};\n`,
+          );
         }
       },
     },

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -95,7 +95,8 @@ type RscPluginOptions = {
 
   /**
    * This option allows customizing how client build copies assets from server build.
-   * By default, it copies only ".css" files for security reasons.
+   * By default, all assets are copied, but frameworks might want to establish some convention
+   * to tighten security based on this option.
    */
   copyServerAssetsToClient?: (fileName: string) => boolean;
 
@@ -564,8 +565,7 @@ export default function vitePluginRsc(
 
         if (this.environment.name === "client") {
           const filterAssets =
-            rscPluginOptions.copyServerAssetsToClient ??
-            ((id) => id.endsWith(".css"));
+            rscPluginOptions.copyServerAssetsToClient ?? (() => true);
           for (const asset of Object.values(rscBundle)) {
             if (asset.type === "asset" && filterAssets(asset.fileName)) {
               this.emitFile({


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/vite-plugins/issues/1101
