### PR TITLE
fix: don't copy vite manifest from rsc to client

### DIFF
--- a/packages/rsc/examples/basic/vite.config.ts
+++ b/packages/rsc/examples/basic/vite.config.ts
@@ -83,6 +83,18 @@ export default defineConfig({
         } else {
           assert(!Object.keys(bundle).includes("__server_secret.txt"));
         }
+
+        const viteManifest = bundle[".vite/manifest.json"];
+        assert(viteManifest.type === "asset");
+        assert(typeof viteManifest.source === "string");
+        if (this.environment.name === "rsc") {
+          assert(viteManifest.source.includes("src/server.tsx"));
+          assert(!viteManifest.source.includes("src/client.tsx"));
+        }
+        if (this.environment.name === "client") {
+          assert(!viteManifest.source.includes("src/server.tsx"));
+          assert(viteManifest.source.includes("src/client.tsx"));
+        }
       },
     },
     {

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -566,7 +566,13 @@ export default function vitePluginRsc(
         if (this.environment.name === "client") {
           const filterAssets =
             rscPluginOptions.copyServerAssetsToClient ?? (() => true);
+          const rscBuildOptions = config.environments.rsc!.build;
+          const rscViteManifest =
+            typeof rscBuildOptions.manifest === "string"
+              ? rscBuildOptions.manifest
+              : rscBuildOptions.manifest && ".vite/manifest.json";
           for (const asset of Object.values(rscBundle)) {
+            if (asset.fileName === rscViteManifest) continue;
             if (asset.type === "asset" && filterAssets(asset.fileName)) {
               this.emitFile({
                 type: "asset",


### PR DESCRIPTION
Just noticed `dist/client/.vite/manifest.json` is overwritten by `dist/rsc/.vite/manifest.json` when debugging https://github.com/hi-ogawa/vite-plugins/pull/940.