### PR TITLE
feat: re-export `transformHoistInlineDirective`

### DIFF
--- a/packages/rsc/e2e/fixture.ts
+++ b/packages/rsc/e2e/fixture.ts
@@ -161,6 +161,7 @@ export async function setupIsolatedFixture(options: {
   // setup package.json overrides
   const packagesDir = path.join(import.meta.dirname, "..", "..");
   const overrides = {
+    "@hiogawa/transforms": `file:${path.join(packagesDir, "transforms")}`,
     "@hiogawa/vite-rsc": `file:${path.join(packagesDir, "rsc")}`,
   };
   editFileJson(path.join(options.dest, "package.json"), (pkg: any) => {

--- a/packages/rsc/e2e/fixture.ts
+++ b/packages/rsc/e2e/fixture.ts
@@ -161,7 +161,6 @@ export async function setupIsolatedFixture(options: {
   // setup package.json overrides
   const packagesDir = path.join(import.meta.dirname, "..", "..");
   const overrides = {
-    "@hiogawa/transforms": `file:${path.join(packagesDir, "transforms")}`,
     "@hiogawa/vite-rsc": `file:${path.join(packagesDir, "rsc")}`,
   };
   editFileJson(path.join(options.dest, "package.json"), (pkg: any) => {

--- a/packages/rsc/examples/basic/package.json
+++ b/packages/rsc/examples/basic/package.json
@@ -17,7 +17,6 @@
     "react-dom": "latest"
   },
   "devDependencies": {
-    "@hiogawa/transforms": "latest",
     "@tailwindcss/vite": "^4.1.4",
     "@types/react": "latest",
     "@types/react-dom": "latest",

--- a/packages/rsc/examples/basic/vite.config.ts
+++ b/packages/rsc/examples/basic/vite.config.ts
@@ -1,6 +1,5 @@
 import assert from "node:assert";
-import { transformHoistInlineDirective } from "@hiogawa/transforms";
-import rsc from "@hiogawa/vite-rsc/plugin";
+import rsc, { transformHoistInlineDirective } from "@hiogawa/vite-rsc/plugin";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { type Plugin, defineConfig, parseAstAsync } from "vite";

--- a/packages/rsc/package.json
+++ b/packages/rsc/package.json
@@ -10,6 +10,7 @@
   "license": "MIT",
   "type": "module",
   "exports": {
+    "./package.json": "./package.json",
     "./types": "./types/index.d.ts",
     "./*": "./dist/*.js"
   },

--- a/packages/rsc/src/plugin.ts
+++ b/packages/rsc/src/plugin.ts
@@ -33,6 +33,9 @@ import { generateEncryptionKey, toBase64 } from "./utils/encryption-utils";
 import { createRpcServer } from "./utils/rpc";
 import { normalizeViteImportAnalysisUrl } from "./vite-utils";
 
+// utility exported for "use cache" demo in examples/basic
+export { transformHoistInlineDirective } from "@hiogawa/transforms";
+
 // state for build orchestration
 let serverReferences: Record<string, string> = {};
 let server: ViteDevServer;

--- a/packages/rsc/tsdown.config.ts
+++ b/packages/rsc/tsdown.config.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs";
 import { defineConfig } from "tsdown";
-import pkg from "./package.json" with { type: "json" };
 
 export default defineConfig({
   entry: [
@@ -24,7 +23,7 @@ export default defineConfig({
     "src/utils/rpc.ts",
   ],
   format: ["esm"],
-  external: [/^virtual:/, new RegExp(`^${pkg.name}/`)],
+  external: [/^virtual:/, /^@hiogawa\/vite-rsc\//],
   dts: {
     sourcemap: process.argv.slice(2).includes("--sourcemap"),
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -578,9 +578,6 @@ importers:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
     devDependencies:
-      '@hiogawa/transforms':
-        specifier: latest
-        version: link:../../../transforms
       '@tailwindcss/vite':
         specifier: ^4.1.4
         version: 4.1.4(vite@7.0.0(@types/node@22.16.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))


### PR DESCRIPTION
Likely we merge these two together soon. For starter, this needs to be re-exported to align with https://github.com/hi-ogawa/vite-plugins/pull/1121.