### PR TITLE
chore: canary build

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -11,28 +11,27 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
         with:
-          build: false
           playwright: false
 
-      # # stable
-      # - run: |
-      #     cp -rf packages/rsc packages/rsc-stable
+      # stable
+      - run: |
+          cp -rf packages/rsc packages/rsc-stable
 
       # canary
       - run: |
           pnpm i -w react@canary react-dom@canary react-server-dom-webpack@canary
           pnpm i --no-frozen-lockfile
-          pnpm -r --filter '@hiogawa/vite-rsc...' build
-        # cp -rf packages/rsc packages/rsc-canary
-        # sed -i 's#"name": "@hiogawa/vite-rsc"#"name": "@hiogawa/vite-rsc-canary"#' packages/rsc-canary/package.json
+          pnpm -C packages/rsc build
+          cp -rf packages/rsc packages/rsc-canary
+          sed -i 's#"name": "@hiogawa/vite-rsc"#"name": "@hiogawa/vite-rsc-canary"#' packages/rsc-canary/package.json
 
       # experimental
-      # - run: |
-      #     pnpm i -w react@experimental react-dom@experimental react-server-dom-webpack@experimental
-      #     pnpm i --no-frozen-lockfile
-      #     pnpm -C packages/rsc build
-      #     cp -rf packages/rsc packages/rsc-experimental
-      #     sed -i 's#"name": "@hiogawa/vite-rsc"#"name": "@hiogawa/vite-rsc-experimental"#' packages/rsc-experimental/package.json
+      - run: |
+          pnpm i -w react@experimental react-dom@experimental react-server-dom-webpack@experimental
+          pnpm i --no-frozen-lockfile
+          pnpm -C packages/rsc build
+          cp -rf packages/rsc packages/rsc-experimental
+          sed -i 's#"name": "@hiogawa/vite-rsc"#"name": "@hiogawa/vite-rsc-experimental"#' packages/rsc-experimental/package.json
 
       # strip prepack to avoid duplicate builds
       - run: |
@@ -42,5 +41,14 @@ jobs:
 
       - run: |
           pnpx pkg-pr-new publish --comment=off \
-            packages/rsc \
+            packages/react-server \
+            packages/react-server-next \
+            packages/rsc-stable \
+            packages/rsc-canary \
+            packages/rsc-experimental \
+            packages/rsc-react-router \
             packages/transforms \
+            packages/vite-plugin-ssr-middleware \
+            packages/pre-bundle-new-url \
+            packages/server-asset \
+            packages/ssr-css

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -11,27 +11,28 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
         with:
+          build: false
           playwright: false
 
-      # stable
-      - run: |
-          cp -rf packages/rsc packages/rsc-stable
+      # # stable
+      # - run: |
+      #     cp -rf packages/rsc packages/rsc-stable
 
       # canary
       - run: |
           pnpm i -w react@canary react-dom@canary react-server-dom-webpack@canary
           pnpm i --no-frozen-lockfile
-          pnpm -C packages/rsc build
-          cp -rf packages/rsc packages/rsc-canary
-          sed -i 's#"name": "@hiogawa/vite-rsc"#"name": "@hiogawa/vite-rsc-canary"#' packages/rsc-canary/package.json
+          pnpm -r --filter '@hiogawa/vite-rsc...' build
+        # cp -rf packages/rsc packages/rsc-canary
+        # sed -i 's#"name": "@hiogawa/vite-rsc"#"name": "@hiogawa/vite-rsc-canary"#' packages/rsc-canary/package.json
 
       # experimental
-      - run: |
-          pnpm i -w react@experimental react-dom@experimental react-server-dom-webpack@experimental
-          pnpm i --no-frozen-lockfile
-          pnpm -C packages/rsc build
-          cp -rf packages/rsc packages/rsc-experimental
-          sed -i 's#"name": "@hiogawa/vite-rsc"#"name": "@hiogawa/vite-rsc-experimental"#' packages/rsc-experimental/package.json
+      # - run: |
+      #     pnpm i -w react@experimental react-dom@experimental react-server-dom-webpack@experimental
+      #     pnpm i --no-frozen-lockfile
+      #     pnpm -C packages/rsc build
+      #     cp -rf packages/rsc packages/rsc-experimental
+      #     sed -i 's#"name": "@hiogawa/vite-rsc"#"name": "@hiogawa/vite-rsc-experimental"#' packages/rsc-experimental/package.json
 
       # strip prepack to avoid duplicate builds
       - run: |
@@ -41,14 +42,5 @@ jobs:
 
       - run: |
           pnpx pkg-pr-new publish --comment=off \
-            packages/react-server \
-            packages/react-server-next \
-            packages/rsc-stable \
-            packages/rsc-canary \
-            packages/rsc-experimental \
-            packages/rsc-react-router \
+            packages/rsc \
             packages/transforms \
-            packages/vite-plugin-ssr-middleware \
-            packages/pre-bundle-new-url \
-            packages/server-asset \
-            packages/ssr-css

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -41,14 +41,6 @@ jobs:
 
       - run: |
           pnpx pkg-pr-new publish --comment=off \
-            packages/react-server \
-            packages/react-server-next \
             packages/rsc-stable \
             packages/rsc-canary \
             packages/rsc-experimental \
-            packages/rsc-react-router \
-            packages/transforms \
-            packages/vite-plugin-ssr-middleware \
-            packages/pre-bundle-new-url \
-            packages/server-asset \
-            packages/ssr-css


### PR DESCRIPTION
Trying to find a way to (ab)use pkg.pr.new for canary/experimental channel labeling. 

- https://pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/vite-rsc@canary
- https://pkg.pr.new/hi-ogawa/vite-plugins/@hiogawa/vite-rsc@experimental

Eventually, we want this approach for `react-server-dom-vite` fork.

## todo

- [ ] setup schedule trigger new
  - does pkg.pr.new require new commit? (if not, we need auto-commit bot?)
  - `on.schedule.cron` needs to be setup on main.
- [ ] verify `@(branch)` label is not cached on pkg.pr.new side