### PR TITLE
chore: release v0.4.9

### DIFF
--- a/packages/rsc/CHANGELOG.md
+++ b/packages/rsc/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.4.9 (2025-07-03)
+
+- feat: re-export plugin from base exports entry ([#1125](https://github.com/hi-ogawa/vite-plugins/pull/1125))
+- feat: re-export `transformHoistInlineDirective` ([#1122](https://github.com/hi-ogawa/vite-plugins/pull/1122))
+- fix: don't copy vite manifest from rsc to client ([#1118](https://github.com/hi-ogawa/vite-plugins/pull/1118))
+
 ## v0.4.8 (2025-07-01)
 
 - fix: copy all server assets to client by default and output `__vite_rsc_encryption_key` to fs directly ([#1102](https://github.com/hi-ogawa/vite-plugins/pull/1102))

--- a/packages/rsc/package.json
+++ b/packages/rsc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/vite-rsc",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "homepage": "https://github.com/hi-ogawa/vite-plugins/tree/main/packages/rsc",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is supposed to be the last release as `@hiogawa/vite-rsc`. A new package with a same content is expected to be published as `@vitejs/plugin-rsc` soon.