### PR TITLE
chore: deprecate `@hiogawa/vite-rsc` in favor of `@vitejs/plugin-rsc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Random collection of vite plugins
 ### [`@hiogawa/vite-rsc`](./packages/rsc)
 
 > [!important]
-> `@hiogawa/vite-rsc` is now maintained as Vite's official package [`@vitejs/plugin-rsc`](https://github.com/hi-ogawa/vite-plugin-react/blob/main/packages/plugin-rsc/README.md).
+> `@hiogawa/vite-rsc` is now maintained as Vite's official package [`@vitejs/plugin-rsc`](https://github.com/hi-ogawa/vite-plugin-react/blob/main/packages/plugin-rsc).
 
 Framework-less Vite RSC plugin
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Random collection of vite plugins
 
 ### [`@hiogawa/vite-rsc`](./packages/rsc)
 
+> [!important]
+> `@hiogawa/vite-rsc` is now maintained as Vite's official package [`@vitejs/plugin-rsc`](https://github.com/hi-ogawa/vite-plugin-react/blob/main/packages/plugin-rsc/README.md).
+
 Framework-less Vite RSC plugin
 
 ### [`@hiogawa/react-server`](./packages/react-server)

--- a/packages/rsc/README.md
+++ b/packages/rsc/README.md
@@ -1,3 +1,6 @@
+> [!important]
+> `@hiogawa/vite-rsc` is now maintained as Vite's official package [`@vitejs/plugin-rsc`](https://github.com/hi-ogawa/vite-plugin-react/blob/main/packages/plugin-rsc/README.md).
+
 # @hiogawa/vite-rsc
 
 This package provides [React Server Components](https://react.dev/reference/rsc/server-components) (RSC) support for Vite.

--- a/packages/rsc/README.md
+++ b/packages/rsc/README.md
@@ -1,5 +1,5 @@
 > [!important]
-> `@hiogawa/vite-rsc` is now maintained as Vite's official package [`@vitejs/plugin-rsc`](https://github.com/hi-ogawa/vite-plugin-react/blob/main/packages/plugin-rsc/README.md).
+> `@hiogawa/vite-rsc` is now maintained as Vite's official package [`@vitejs/plugin-rsc`](https://github.com/hi-ogawa/vite-plugin-react/blob/main/packages/plugin-rsc).
 
 # @hiogawa/vite-rsc
 


### PR DESCRIPTION
## todo

- [x] wait for `@vitejs/plugin-rsc` v4.0.10
- [x] run `npm deprecate @hiogawa/vite-rsc "Use @vitejs/plugin-rsc instead"`