### PR TITLE
ci: add workflow to trigger nightly `@vitejs/plugin-rsc` release

### DIFF
--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -1,0 +1,20 @@
+name: trigger-nightly
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+jobs:
+  update-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: gh pr checkout canary
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add .
+          NIGHTLY_VERSION=$(npm view react dist-tags.canary --json | jq -r 'split("-") | .[-2:] | join("-")')
+          git commit --allow-empty -m "chore: nightly ${NIGHTLY_VERSION}"
+          git push

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -1,8 +1,9 @@
 name: trigger-nightly
 on:
-  schedule:
-    - cron: '0 0 * * *'
-  workflow_dispatch:
+  # schedule:
+  #   - cron: '0 0 * * *'
+  # workflow_dispatch:
+  push:
 jobs:
   update-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -18,9 +18,10 @@ jobs:
       - run: gh pr checkout canary
         env:
           GITHUB_TOKEN: ${{ secrets.REACT_NIGHTLY_TRIGGER_TOKEN }}
-      - run: |
-          # git config --local user.email "action@github.com"
-          # git config --local user.name "GitHub Action"
+      - name: push commit
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
           NIGHTLY_VERSION=$(npm view react dist-tags.canary --json | jq -r 'split("-") | .[-2:] | join("-")')
           git commit --allow-empty -m "chore: nightly ${NIGHTLY_VERSION}"
           git push https://x-access-token:${{ secrets.REACT_NIGHTLY_TRIGGER_TOKEN }}@github.com/${{ github.repository }}.git

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -18,12 +18,10 @@ jobs:
         with:
           token: ${{ secrets.REACT_NIGHTLY_TRIGGER_TOKEN }}
       - run: gh pr checkout canary
-        env:
-          GITHUB_TOKEN: ${{ secrets.REACT_NIGHTLY_TRIGGER_TOKEN }}
       - name: push commit
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           NIGHTLY_VERSION=$(npm view react dist-tags.canary --json | jq -r 'split("-") | .[-2:] | join("-")')
           git commit --allow-empty -m "chore: nightly ${NIGHTLY_VERSION}"
-          git push https://oauth2:${{ secrets.REACT_NIGHTLY_TRIGGER_TOKEN }}@github.com/${{ github.repository }}.git
+          git push

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -15,13 +15,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.REACT_NIGHTLY_TRIGGER_TOKEN }}
       - run: gh pr checkout canary
         env:
           GITHUB_TOKEN: ${{ secrets.REACT_NIGHTLY_TRIGGER_TOKEN }}
       - name: push commit
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          # git config --local user.email "action@github.com"
+          # git config --local user.name "GitHub Action"
           NIGHTLY_VERSION=$(npm view react dist-tags.canary --json | jq -r 'split("-") | .[-2:] | join("-")')
           git commit --allow-empty -m "chore: nightly ${NIGHTLY_VERSION}"
           git push https://oauth2:${{ secrets.REACT_NIGHTLY_TRIGGER_TOKEN }}@github.com/${{ github.repository }}.git

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -11,7 +11,7 @@ permissions:
   # repository-projects: write
 
 jobs:
-  update-pr:
+  trigger-nightly:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -23,4 +23,4 @@ jobs:
           git config --local user.name "GitHub Action"
           NIGHTLY_VERSION=$(npm view react dist-tags.canary --json | jq -r 'split("-") | .[-2:] | join("-")')
           git commit --allow-empty -m "chore: nightly ${NIGHTLY_VERSION}"
-          git push
+          git push https://x-access-token:${{ secrets.REACT_NIGHTLY_TRIGGER_TOKEN }}@github.com/${{ github.repository }}.git

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -32,12 +32,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: hi-ogawa/vite-plugin-react
-          ref: feat-rsc
+          ref: chore-rsc-nightly
           token: ${{ secrets.REACT_NIGHTLY_TRIGGER_TOKEN }}
-      # - name: push commit
-      #   run: |
-      #     git config user.name "github-actions[bot]"
-      #     git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-      #     NIGHTLY_VERSION=$(npm view react dist-tags.canary --json | jq -r 'split("-") | .[-2:] | join("-")')
-      #     git commit --allow-empty -m "chore: nightly ${NIGHTLY_VERSION}"
-      #     git push
+      - name: push commit
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          NIGHTLY_VERSION=$(npm view react dist-tags.canary --json | jq -r 'split("-") | .[-2:] | join("-")')
+          git commit --allow-empty -m "chore: nightly ${NIGHTLY_VERSION}"
+          git push

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -22,8 +22,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.REACT_NIGHTLY_TRIGGER_TOKEN }}
       - name: push commit
         run: |
-          # git config --local user.email "action@github.com"
-          # git config --local user.name "GitHub Action"
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
           NIGHTLY_VERSION=$(npm view react dist-tags.canary --json | jq -r 'split("-") | .[-2:] | join("-")')
           git commit --allow-empty -m "chore: nightly ${NIGHTLY_VERSION}"
           git push https://oauth2:${{ secrets.REACT_NIGHTLY_TRIGGER_TOKEN }}@github.com/${{ github.repository }}.git

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -14,7 +14,6 @@ jobs:
       - run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add .
           NIGHTLY_VERSION=$(npm view react dist-tags.canary --json | jq -r 'split("-") | .[-2:] | join("-")')
           git commit --allow-empty -m "chore: nightly ${NIGHTLY_VERSION}"
           git push

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -16,10 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: canary
           token: ${{ secrets.REACT_NIGHTLY_TRIGGER_TOKEN }}
-      - run: gh pr checkout canary
-        env:
-          GITHUB_TOKEN: ${{ secrets.REACT_NIGHTLY_TRIGGER_TOKEN }}
       - name: push commit
         run: |
           git config user.name "github-actions[bot]"
@@ -27,3 +25,19 @@ jobs:
           NIGHTLY_VERSION=$(npm view react dist-tags.canary --json | jq -r 'split("-") | .[-2:] | join("-")')
           git commit --allow-empty -m "chore: nightly ${NIGHTLY_VERSION}"
           git push
+
+  trigger-nightly-plugin-rsc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: hi-ogawa/vite-plugin-react
+          ref: feat-rsc
+          token: ${{ secrets.REACT_NIGHTLY_TRIGGER_TOKEN }}
+      # - name: push commit
+      #   run: |
+      #     git config user.name "github-actions[bot]"
+      #     git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      #     NIGHTLY_VERSION=$(npm view react dist-tags.canary --json | jq -r 'split("-") | .[-2:] | join("-")')
+      #     git commit --allow-empty -m "chore: nightly ${NIGHTLY_VERSION}"
+      #     git push

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -24,4 +24,4 @@ jobs:
           git config --local user.name "GitHub Action"
           NIGHTLY_VERSION=$(npm view react dist-tags.canary --json | jq -r 'split("-") | .[-2:] | join("-")')
           git commit --allow-empty -m "chore: nightly ${NIGHTLY_VERSION}"
-          git push https://x-access-token:${{ secrets.REACT_NIGHTLY_TRIGGER_TOKEN }}@github.com/${{ github.repository }}.git
+          git push https://oauth2:${{ secrets.REACT_NIGHTLY_TRIGGER_TOKEN }}@github.com/${{ github.repository }}.git

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -17,10 +17,10 @@ jobs:
       - uses: actions/checkout@v4
       - run: gh pr checkout canary
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REACT_NIGHTLY_TRIGGER_TOKEN }}
       - run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          # git config --local user.email "action@github.com"
+          # git config --local user.name "GitHub Action"
           NIGHTLY_VERSION=$(npm view react dist-tags.canary --json | jq -r 'split("-") | .[-2:] | join("-")')
           git commit --allow-empty -m "chore: nightly ${NIGHTLY_VERSION}"
           git push https://x-access-token:${{ secrets.REACT_NIGHTLY_TRIGGER_TOKEN }}@github.com/${{ github.repository }}.git

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -4,6 +4,12 @@ on:
   #   - cron: '0 0 * * *'
   # workflow_dispatch:
   push:
+
+permissions:
+  contents: write
+  # pull-requests: write
+  # repository-projects: write
+
 jobs:
   update-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -18,6 +18,8 @@ jobs:
         with:
           token: ${{ secrets.REACT_NIGHTLY_TRIGGER_TOKEN }}
       - run: gh pr checkout canary
+        env:
+          GITHUB_TOKEN: ${{ secrets.REACT_NIGHTLY_TRIGGER_TOKEN }}
       - name: push commit
         run: |
           git config --local user.email "action@github.com"

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -5,10 +5,10 @@ on:
   # workflow_dispatch:
   push:
 
-permissions:
-  contents: write
-  # pull-requests: write
-  # repository-projects: write
+# permissions:
+#   contents: write
+#   pull-requests: write
+#   repository-projects: write
 
 jobs:
   trigger-nightly:

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -1,32 +1,16 @@
+# workflow to push an empty commit and trigger pkg.pr.new on @vitejs/plugin-rsc PR
+# https://github.com/vitejs/vite-plugin-react/pull/524
+# cf. React nightly workflow
+# https://github.com/facebook/react/blob/5d87cd224452c68d09bef99656b6261e9772a210/.github/workflows/runtime_prereleases_nightly.yml#L12
+
 name: trigger-nightly
 on:
-  # schedule:
-  #   - cron: '0 0 * * *'
-  # workflow_dispatch:
-  push:
-
-# permissions:
-#   contents: write
-#   pull-requests: write
-#   repository-projects: write
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
 
 jobs:
   trigger-nightly:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: canary
-          token: ${{ secrets.REACT_NIGHTLY_TRIGGER_TOKEN }}
-      - name: push commit
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          NIGHTLY_VERSION=$(npm view react dist-tags.canary --json | jq -r 'split("-") | .[-2:] | join("-")')
-          git commit --allow-empty -m "chore: nightly ${NIGHTLY_VERSION}"
-          git push
-
-  trigger-nightly-plugin-rsc:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -22,8 +22,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.REACT_NIGHTLY_TRIGGER_TOKEN }}
       - name: push commit
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           NIGHTLY_VERSION=$(npm view react dist-tags.canary --json | jq -r 'split("-") | .[-2:] | join("-")')
           git commit --allow-empty -m "chore: nightly ${NIGHTLY_VERSION}"
           git push


### PR DESCRIPTION
This workflow uses my own [fine-grained personal access tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) with a write access to my folk of react plugin repo https://github.com/hi-ogawa/vite-plugin-react/ to push a commit to a PR https://github.com/vitejs/vite-plugin-react/pull/524, which then triggers pkg.pr.new to release `@vitejs/plugin-rsc` for React canary/experimental channel.