### PR TITLE
ci: add failure notification to trigger-nightly workflow

### DIFF
--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -8,10 +8,14 @@ on:
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
+  # test temporary
+  push:
 
 jobs:
   trigger-nightly:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -8,8 +8,6 @@ on:
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
-  # test temporary
-  push:
 
 jobs:
   trigger-nightly:
@@ -25,7 +23,6 @@ jobs:
           fetch-depth: 0
       - name: git
         run: |
-          false
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -44,8 +44,6 @@ jobs:
             github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: 'Nightly trigger workflow failed',
-              body: `The nightly trigger workflow failed.
-              
-              **Github Actions URL:** ${context.payload.repository.html_url}/actions/runs/${context.runId}
+              title: `Nightly trigger workflow failed - ${context.runId}`,
+              body: `**Github Actions URL:** ${context.payload.repository.html_url}/actions/runs/${context.runId}`
             })

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -21,6 +21,7 @@ jobs:
           fetch-depth: 0
       - name: git
         run: |
+          false
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
@@ -31,3 +32,20 @@ jobs:
           NIGHTLY_VERSION=$(npm view react dist-tags.canary --json | jq -r 'split("-") | .[-2:] | join("-")')
           git commit --allow-empty -m "chore: nightly ${NIGHTLY_VERSION}"
           git push
+      - name: Create issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'Nightly trigger workflow failed',
+              body: `The nightly trigger workflow failed.
+              
+              **Run ID:** ${context.runId}
+              **Workflow:** ${context.workflow}
+              **Run URL:** ${context.payload.repository.html_url}/actions/runs/${context.runId}
+              
+              This is likely due to PAT expiration or other authentication issues.`
+            })

--- a/.github/workflows/trigger-nightly.yml
+++ b/.github/workflows/trigger-nightly.yml
@@ -47,9 +47,5 @@ jobs:
               title: 'Nightly trigger workflow failed',
               body: `The nightly trigger workflow failed.
               
-              **Run ID:** ${context.runId}
-              **Workflow:** ${context.workflow}
-              **Run URL:** ${context.payload.repository.html_url}/actions/runs/${context.runId}
-              
-              This is likely due to PAT expiration or other authentication issues.`
+              **Github Actions URL:** ${context.payload.repository.html_url}/actions/runs/${context.runId}
             })


### PR DESCRIPTION
## Summary
- Add GitHub issue creation when the nightly trigger workflow fails
- Helps notify about PAT expiration or other authentication issues
- Includes run ID, workflow name, and direct link to failed run

## Test plan
- [ ] Test by temporarily adding `false` command at start of git step
- [ ] Verify issue is created with proper details when workflow fails
- [ ] Remove test failure command after verification

🤖 Generated with [Claude Code](https://claude.ai/code)