### PR TITLE
fix(fullstack): remove client-fallback from output

### DIFF
--- a/packages/fullstack/src/plugin.ts
+++ b/packages/fullstack/src/plugin.ts
@@ -386,6 +386,14 @@ export function assetsPlugin(pluginOpts?: FullstackPluginOptions): Plugin[] {
           }
         },
       },
+      generateBundle(_optoins, bundle) {
+        if (this.environment.name !== "client") return;
+        for (const [k, v] of Object.entries(bundle)) {
+          if (v.type === "chunk" && v.name === "__fallback") {
+            delete bundle[k];
+          }
+        }
+      },
     },
     patchViteClientPlugin(),
     patchVueScopeCssHmr(),


### PR DESCRIPTION
I'm not sure if we should bother with this, but why not.

## after

```
$ pnpm -C packages/fullstack/examples/basic/ build

> @hiogawa/vite-plugin-fullstack-examples-basic@ build /home/hiroshi/code/personal/vite-plugins/packages/fullstack/examples/basic
> vite build

vite v7.1.5 building SSR bundle for production...
✓ 8 modules transformed.
dist/ssr/assets/react-CHdo91hT.svg  4.13 kB
dist/ssr/assets/index-ByRLJgsi.css  1.39 kB
dist/ssr/index.js                   3.15 kB
✓ built in 61ms
vite v7.1.5 building for production...
✓ 30 modules transformed.
Generated an empty chunk: "__fallback". 👈👈👈
dist/client/assets/react-CHdo91hT.svg          4.13 kB │ gzip:  2.05 kB
dist/client/assets/entry-B-Rktl8a.css          0.45 kB │ gzip:  0.30 kB
dist/client/assets/__fallback-l0sNRNKZ.js      0.00 kB │ gzip:  0.02 kB 👈👈👈
dist/client/assets/entry.client-C_ZNM4Ah.js  187.39 kB │ gzip: 58.92 kB
✓ built in 423ms
```

## before

```
]$ pnpm -C packages/fullstack/examples/basic/ build

> @hiogawa/vite-plugin-fullstack-examples-basic@ build /home/hiroshi/code/personal/vite-plugins/packages/fullstack/examples/basic
> vite build

vite v7.1.5 building SSR bundle for production...
✓ 8 modules transformed.
dist/ssr/assets/react-CHdo91hT.svg  4.13 kB
dist/ssr/assets/index-ByRLJgsi.css  1.39 kB
dist/ssr/index.js                   3.15 kB
✓ built in 59ms
vite v7.1.5 building for production...
✓ 30 modules transformed.
Generated an empty chunk: "__fallback". 👈👈👈 this is still there 🙃
dist/client/assets/react-CHdo91hT.svg          4.13 kB │ gzip:  2.05 kB
dist/client/assets/entry-B-Rktl8a.css          0.45 kB │ gzip:  0.30 kB
dist/client/assets/entry.client-C_ZNM4Ah.js  187.39 kB │ gzip: 58.92 kB
✓ built in 427ms
```