### PR TITLE
feat(fullstack): support `?assets` query

### DIFF
--- a/packages/fullstack/examples/react-router/src/framework/entry.server.tsx
+++ b/packages/fullstack/examples/react-router/src/framework/entry.server.tsx
@@ -5,7 +5,7 @@ import {
   createStaticHandler,
   createStaticRouter,
 } from "react-router";
-import { type CustomHandle, routes } from "../routes";
+import { routes } from "../routes";
 
 const { query, dataRoutes } = createStaticHandler(routes);
 
@@ -28,10 +28,16 @@ async function handler(request: Request): Promise<Response> {
   // collect assets from matched routes
   const assets = mergeAssets(
     clientEntry,
-    ...context.matches
-      .map((m) => m.route.handle as CustomHandle)
-      .filter(Boolean)
-      .map((h) => h.assets),
+    ...(await Promise.all(
+      context.matches
+        .map(
+          (m) =>
+            m.route.handle
+              ?.assets?.()
+              .then((v: typeof import("*?assets")) => v.default)!,
+        )
+        .filter(Boolean),
+    )),
   );
 
   function SsrRoot() {

--- a/packages/fullstack/examples/react-router/src/routes.ts
+++ b/packages/fullstack/examples/react-router/src/routes.ts
@@ -1,4 +1,3 @@
-import type { ImportAssetsResult } from "@hiogawa/vite-plugin-fullstack/runtime";
 import type { RouteObject } from "react-router";
 
 // custom framework may employ fs router convention to reduce boilerplace
@@ -8,35 +7,25 @@ export const routes: RouteObject[] = [
     path: "/",
     lazy: () => import("./root"),
     handle: {
-      assets: import.meta.vite.assets({
-        import: "./root",
-      }),
-    } satisfies CustomHandle,
+      assets: () => import("./root?assets"),
+    },
     children: [
       {
         id: "index",
         index: true,
         lazy: () => import("./routes/index"),
         handle: {
-          assets: import.meta.vite.assets({
-            import: "./routes/index",
-          }),
-        } satisfies CustomHandle,
+          assets: () => import("./routes/index?assets"),
+        },
       },
       {
         id: "about",
         path: "about",
         lazy: () => import("./routes/about"),
         handle: {
-          assets: import.meta.vite.assets({
-            import: "./routes/about",
-          }),
-        } satisfies CustomHandle,
+          assets: () => import("./routes/about?assets"),
+        },
       },
     ],
   },
 ];
-
-export type CustomHandle = {
-  assets: ImportAssetsResult;
-};

--- a/packages/fullstack/examples/vue-router/src/framework/entry.server.ts
+++ b/packages/fullstack/examples/vue-router/src/framework/entry.server.ts
@@ -29,10 +29,14 @@ async function handler(request: Request): Promise<Response> {
 
   // collect assets from current route
   const assets = mergeAssets(
-    clientEntry,
-    ...router.currentRoute.value.matched
-      .map((to) => to.meta.assets!)
-      .filter(Boolean),
+    ...(
+      await Promise.all(
+        router.currentRoute.value.matched
+          .flatMap((to) => to.meta.assets)
+          .filter(Boolean)
+          .map((fn) => fn!()),
+      )
+    ).map((v) => v.default),
   );
   const head = [
     ...assets.css.map((attrs) => {

--- a/packages/fullstack/examples/vue-router/src/framework/entry.server.ts
+++ b/packages/fullstack/examples/vue-router/src/framework/entry.server.ts
@@ -29,14 +29,13 @@ async function handler(request: Request): Promise<Response> {
 
   // collect assets from current route
   const assets = mergeAssets(
-    ...(
-      await Promise.all(
-        router.currentRoute.value.matched
-          .flatMap((to) => to.meta.assets)
-          .filter(Boolean)
-          .map((fn) => fn!()),
-      )
-    ).map((v) => v.default),
+    clientEntry,
+    ...(await Promise.all(
+      router.currentRoute.value.matched
+        .map((to) => to.meta.assets)
+        .filter(Boolean)
+        .map((fn) => fn!().then((m) => m.default)),
+    )),
   );
   const head = [
     ...assets.css.map((attrs) => {

--- a/packages/fullstack/examples/vue-router/src/framework/types.d.ts
+++ b/packages/fullstack/examples/vue-router/src/framework/types.d.ts
@@ -5,6 +5,6 @@ export {};
 
 declare module "vue-router" {
   interface RouteMeta {
-    assets?: (() => Promise<typeof import("*?assets")>)[];
+    assets?: () => Promise<typeof import("*?assets")>;
   }
 }

--- a/packages/fullstack/examples/vue-router/src/framework/types.d.ts
+++ b/packages/fullstack/examples/vue-router/src/framework/types.d.ts
@@ -5,6 +5,6 @@ export {};
 
 declare module "vue-router" {
   interface RouteMeta {
-    assets?: import("@hiogawa/vite-plugin-fullstack/runtime").ImportAssetsResult;
+    assets?: (() => Promise<typeof import("*?assets")>)[];
   }
 }

--- a/packages/fullstack/examples/vue-router/src/routes.ts
+++ b/packages/fullstack/examples/vue-router/src/routes.ts
@@ -7,10 +7,7 @@ export const routes: RouteRecordRaw[] = [
     name: "app",
     component: () => import("./app.vue"),
     meta: {
-      assets: [
-        () => import("./app.vue?assets"),
-        () => import("./framework/entry.client.ts?assets=client"),
-      ],
+      assets: () => import("./app.vue?assets"),
     },
     children: [
       {
@@ -18,7 +15,7 @@ export const routes: RouteRecordRaw[] = [
         name: "home",
         component: () => import("./pages/index.vue"),
         meta: {
-          assets: [() => import("./pages/index.vue?assets")],
+          assets: () => import("./pages/index.vue?assets"),
         },
       },
       {
@@ -26,7 +23,7 @@ export const routes: RouteRecordRaw[] = [
         name: "about",
         component: () => import("./pages/about.vue"),
         meta: {
-          assets: [() => import("./pages/about.vue?assets")],
+          assets: () => import("./pages/about.vue?assets"),
         },
       },
       {
@@ -34,7 +31,7 @@ export const routes: RouteRecordRaw[] = [
         name: "not-found",
         component: () => import("./pages/not-found.vue"),
         meta: {
-          assets: [() => import("./pages/not-found.vue?assets")],
+          assets: () => import("./pages/not-found.vue?assets"),
         },
       },
     ],

--- a/packages/fullstack/examples/vue-router/src/routes.ts
+++ b/packages/fullstack/examples/vue-router/src/routes.ts
@@ -7,7 +7,7 @@ export const routes: RouteRecordRaw[] = [
     name: "app",
     component: () => import("./app.vue"),
     meta: {
-      assets: () => import("./app.vue$?assets"),
+      assets: () => import("./app.vue?assets"),
     },
     children: [
       {
@@ -15,7 +15,7 @@ export const routes: RouteRecordRaw[] = [
         name: "home",
         component: () => import("./pages/index.vue"),
         meta: {
-          assets: () => import("./pages/index.vue$?assets"),
+          assets: () => import("./pages/index.vue?assets"),
         },
       },
       {
@@ -23,7 +23,7 @@ export const routes: RouteRecordRaw[] = [
         name: "about",
         component: () => import("./pages/about.vue"),
         meta: {
-          assets: () => import("./pages/about.vue$?assets"),
+          assets: () => import("./pages/about.vue?assets"),
         },
       },
       {
@@ -31,7 +31,7 @@ export const routes: RouteRecordRaw[] = [
         name: "not-found",
         component: () => import("./pages/not-found.vue"),
         meta: {
-          assets: () => import("./pages/not-found.vue$?assets"),
+          assets: () => import("./pages/not-found.vue?assets"),
         },
       },
     ],

--- a/packages/fullstack/examples/vue-router/src/routes.ts
+++ b/packages/fullstack/examples/vue-router/src/routes.ts
@@ -7,7 +7,7 @@ export const routes: RouteRecordRaw[] = [
     name: "app",
     component: () => import("./app.vue"),
     meta: {
-      assets: () => import("./app.vue?assets"),
+      assets: () => import("./app.vue$?assets"),
     },
     children: [
       {
@@ -15,7 +15,7 @@ export const routes: RouteRecordRaw[] = [
         name: "home",
         component: () => import("./pages/index.vue"),
         meta: {
-          assets: () => import("./pages/index.vue?assets"),
+          assets: () => import("./pages/index.vue$?assets"),
         },
       },
       {
@@ -23,7 +23,7 @@ export const routes: RouteRecordRaw[] = [
         name: "about",
         component: () => import("./pages/about.vue"),
         meta: {
-          assets: () => import("./pages/about.vue?assets"),
+          assets: () => import("./pages/about.vue$?assets"),
         },
       },
       {
@@ -31,7 +31,7 @@ export const routes: RouteRecordRaw[] = [
         name: "not-found",
         component: () => import("./pages/not-found.vue"),
         meta: {
-          assets: () => import("./pages/not-found.vue?assets"),
+          assets: () => import("./pages/not-found.vue$?assets"),
         },
       },
     ],

--- a/packages/fullstack/examples/vue-router/src/routes.ts
+++ b/packages/fullstack/examples/vue-router/src/routes.ts
@@ -7,7 +7,10 @@ export const routes: RouteRecordRaw[] = [
     name: "app",
     component: () => import("./app.vue"),
     meta: {
-      assets: import.meta.vite.assets({ import: "./app.vue" }),
+      assets: [
+        () => import("./app.vue?assets"),
+        () => import("./framework/entry.client.ts?assets=client"),
+      ],
     },
     children: [
       {
@@ -15,7 +18,7 @@ export const routes: RouteRecordRaw[] = [
         name: "home",
         component: () => import("./pages/index.vue"),
         meta: {
-          assets: import.meta.vite.assets({ import: "./pages/index.vue" }),
+          assets: [() => import("./pages/index.vue?assets")],
         },
       },
       {
@@ -23,7 +26,7 @@ export const routes: RouteRecordRaw[] = [
         name: "about",
         component: () => import("./pages/about.vue"),
         meta: {
-          assets: import.meta.vite.assets({ import: "./pages/about.vue" }),
+          assets: [() => import("./pages/about.vue?assets")],
         },
       },
       {
@@ -31,7 +34,7 @@ export const routes: RouteRecordRaw[] = [
         name: "not-found",
         component: () => import("./pages/not-found.vue"),
         meta: {
-          assets: import.meta.vite.assets({ import: "./pages/not-found.vue" }),
+          assets: [() => import("./pages/not-found.vue?assets")],
         },
       },
     ],

--- a/packages/fullstack/examples/vue-router/vite.config.ts
+++ b/packages/fullstack/examples/vue-router/vite.config.ts
@@ -12,7 +12,9 @@ export default defineConfig((_env) => ({
   clearScreen: false,
   plugins: [
     // inspect(),
-    vue(),
+    // avoid vue plugin to process "xxx.vue?assets"
+    // TODO: not working for build?
+    vue({ exclude: /\?assets/ }),
     devtoolsJson(),
     fullstack(),
     !!process.env.TEST_SSG &&

--- a/packages/fullstack/examples/vue-router/vite.config.ts
+++ b/packages/fullstack/examples/vue-router/vite.config.ts
@@ -12,9 +12,7 @@ export default defineConfig((_env) => ({
   clearScreen: false,
   plugins: [
     // inspect(),
-    // avoid vue plugin to process "xxx.vue?assets"
-    // TODO: not working for build?
-    vue({ exclude: /\?assets/ }),
+    vue(),
     devtoolsJson(),
     fullstack(),
     !!process.env.TEST_SSG &&

--- a/packages/fullstack/examples/vue-router/vite.config.ts
+++ b/packages/fullstack/examples/vue-router/vite.config.ts
@@ -7,12 +7,13 @@ import fullstack from "@hiogawa/vite-plugin-fullstack";
 import vue from "@vitejs/plugin-vue";
 import { type Plugin, type ResolvedConfig, defineConfig } from "vite";
 import devtoolsJson from "vite-plugin-devtools-json";
+// import { fil} from "@rolldown/pluginutils"
 
 export default defineConfig((_env) => ({
   clearScreen: false,
   plugins: [
     // inspect(),
-    vue(),
+    patchVueExclude(vue(), /\?assets/),
     devtoolsJson(),
     fullstack(),
     !!process.env.TEST_SSG &&
@@ -47,6 +48,16 @@ export default defineConfig((_env) => ({
     },
   },
 }));
+
+// workaround https://github.com/vitejs/vite-plugin-vue/issues/677
+function patchVueExclude(plugin: Plugin, exclude: RegExp) {
+  const original = (plugin.transform as any).handler;
+  (plugin.transform as any).handler = function (this: any, ...args: any[]) {
+    if (exclude.test(args[1])) return;
+    return original.call(this, ...args);
+  };
+  return plugin;
+}
 
 type SsgPluginOptions = {
   paths: string[];

--- a/packages/fullstack/examples/vue-router/vite.config.ts
+++ b/packages/fullstack/examples/vue-router/vite.config.ts
@@ -7,7 +7,6 @@ import fullstack from "@hiogawa/vite-plugin-fullstack";
 import vue from "@vitejs/plugin-vue";
 import { type Plugin, type ResolvedConfig, defineConfig } from "vite";
 import devtoolsJson from "vite-plugin-devtools-json";
-// import { fil} from "@rolldown/pluginutils"
 
 export default defineConfig((_env) => ({
   clearScreen: false,

--- a/packages/fullstack/src/plugin.ts
+++ b/packages/fullstack/src/plugin.ts
@@ -398,16 +398,18 @@ export function assetsPlugin(pluginOpts?: FullstackPluginOptions): Plugin[] {
     },
     {
       name: "fullstack:assets-query",
-      load(id) {
-        const { filename, query } = parseIdQuery(id);
-        // TODO: parse query properly?
-        const value = query["assets"];
-        if (typeof value !== "undefined") {
-          const options: ImportAssetsOptions = {
-            import: filename,
-          };
-          return `export default import.meta.vite.assets(${JSON.stringify(options)})`;
-        }
+      load: {
+        handler(id) {
+          const { filename, query } = parseIdQuery(id);
+          // TODO: parse query properly?
+          const value = query["assets"];
+          if (typeof value !== "undefined") {
+            const options: ImportAssetsOptions = {
+              import: filename,
+            };
+            return `export default import.meta.vite.assets(${JSON.stringify(options)})`;
+          }
+        },
       },
     },
     // ensure at least one client build input to prevent Vite

--- a/packages/fullstack/src/plugin.ts
+++ b/packages/fullstack/src/plugin.ts
@@ -398,27 +398,13 @@ export function assetsPlugin(pluginOpts?: FullstackPluginOptions): Plugin[] {
     },
     {
       name: "fullstack:assets-query",
-      async resolveId(source, importer) {
-        // TODO: vue doesn't seem to support "xxx.vue?assets".
-        // for now, we allow users to workaround by "xxx.vue$?assets"
-        const { filename, query } = parseIdQuery(source);
-        if (filename.endsWith("$") && "assets" in query) {
-          const resolved = await this.resolve(
-            source.replace("$?", "?"),
-            importer,
-          );
-          if (resolved) {
-            return resolved.id.replace("?", "$?");
-          }
-        }
-      },
       load(id) {
         const { filename, query } = parseIdQuery(id);
         // TODO: parse query properly?
         const value = query["assets"];
         if (typeof value !== "undefined") {
           const options: ImportAssetsOptions = {
-            import: filename.replace(/\$$/, ""),
+            import: filename,
           };
           return `export default import.meta.vite.assets(${JSON.stringify(options)})`;
         }

--- a/packages/fullstack/src/plugin.ts
+++ b/packages/fullstack/src/plugin.ts
@@ -401,12 +401,10 @@ export function assetsPlugin(pluginOpts?: FullstackPluginOptions): Plugin[] {
       load(id) {
         const { filename, query } = parseIdQuery(id);
         // TODO: parse query properly?
-        // for now `?assets` and `?assets=client` are supported.
         const value = query["assets"];
         if (typeof value !== "undefined") {
           const options: ImportAssetsOptions = {
             import: filename,
-            environment: value === "client" ? "client" : undefined,
           };
           return `export default import.meta.vite.assets(${JSON.stringify(options)})`;
         }

--- a/packages/fullstack/src/plugin.ts
+++ b/packages/fullstack/src/plugin.ts
@@ -16,7 +16,11 @@ import {
   normalizePath,
 } from "vite";
 import type { ImportAssetsOptions, ImportAssetsResult } from "../types/shared";
-import { parseAssetsVirtual, toAssetsVirtual } from "./plugins/shared";
+import {
+  parseAssetsVirtual,
+  parseIdQuery,
+  toAssetsVirtual,
+} from "./plugins/shared";
 import {
   createVirtualPlugin,
   getEntrySource,
@@ -390,6 +394,22 @@ export function assetsPlugin(pluginOpts?: FullstackPluginOptions): Plugin[] {
             }
           }
         },
+      },
+    },
+    {
+      name: "fullstack:assets-query",
+      load(id) {
+        const { filename, query } = parseIdQuery(id);
+        // TODO: parse query properly?
+        // for now `?assets` and `?assets=client` are supported.
+        const value = query["assets"];
+        if (typeof value !== "undefined") {
+          const options: ImportAssetsOptions = {
+            import: filename,
+            environment: value === "client" ? "client" : undefined,
+          };
+          return `export default import.meta.vite.assets(${JSON.stringify(options)})`;
+        }
       },
     },
     // ensure at least one client build input to prevent Vite

--- a/packages/fullstack/types/index.d.ts
+++ b/packages/fullstack/types/index.d.ts
@@ -1,3 +1,5 @@
+/// <reference path="./query.d.ts" />
+
 import type { ImportAssetsOptions, ImportAssetsResult } from "./shared.ts";
 
 declare global {

--- a/packages/fullstack/types/query.d.ts
+++ b/packages/fullstack/types/query.d.ts
@@ -1,0 +1,9 @@
+declare module "*?assets" {
+  const default_: import("./shared").ImportAssetsResult;
+  export default result;
+}
+
+declare module "*?assets=client" {
+  const default_: import("./shared").ImportAssetsResult;
+  export default result;
+}

--- a/packages/fullstack/types/query.d.ts
+++ b/packages/fullstack/types/query.d.ts
@@ -2,8 +2,3 @@ declare module "*?assets" {
   const default_: import("./shared").ImportAssetsResult;
   export default result;
 }
-
-declare module "*?assets=client" {
-  const default_: import("./shared").ImportAssetsResult;
-  export default result;
-}

--- a/packages/fullstack/types/shared.ts
+++ b/packages/fullstack/types/shared.ts
@@ -15,6 +15,8 @@ export type ImportAssetsOptions = {
   environment?: string; // TODO: can we remove in favor of asEntry and universal?
   asEntry?: boolean;
   // universal?: boolean;
+  // TODO
+  // async?: boolean;
 };
 
 export type ImportAssetsResult = {

--- a/packages/fullstack/types/shared.ts
+++ b/packages/fullstack/types/shared.ts
@@ -15,8 +15,6 @@ export type ImportAssetsOptions = {
   environment?: string; // TODO: can we remove in favor of asEntry and universal?
   asEntry?: boolean;
   // universal?: boolean;
-  // TODO
-  // async?: boolean;
 };
 
 export type ImportAssetsResult = {


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/vite-plugins/issues/1207

TODO
- [ ] examples
  - [x] react router
  - [ ] vue router
    - blocked by https://github.com/vitejs/vite-plugin-vue/issues/677
    - ~workarounded by allowing `.vue$?assets`, but glob import is not possible `import.meta.glob("*.vue", { query: "?assets" })`.~
    - workarounded by `patchVueExclude`
- [ ] docs