### PR TITLE
fix(fullstack): avoid `addWatchFile` for virtual invalidation

### DIFF
--- a/packages/fullstack/e2e/basic.test.ts
+++ b/packages/fullstack/e2e/basic.test.ts
@@ -105,6 +105,10 @@ function defineTest(f: Fixture) {
         page.getByRole("button", { name: "count (edit) is 1" }),
       ).toBeVisible();
 
+      // test SSR is also updated
+      const res = await page.request.get(page.url());
+      expect(await res.text()).toContain("count (edit)");
+
       jsFile.reset();
       await expect(
         page.getByRole("button", { name: "count is 1" }),

--- a/packages/fullstack/e2e/island.test.ts
+++ b/packages/fullstack/e2e/island.test.ts
@@ -62,6 +62,10 @@ function defineTest(f: Fixture) {
         "Count-edit: 3",
       );
 
+      // test SSR is also updated
+      const res = await page.request.get(page.url());
+      expect(await res.text()).toContain("Count-edit:");
+
       jsFile.reset();
       await expect(page.locator(".counter-card")).toContainText("Count: 3");
 

--- a/packages/fullstack/e2e/react-router.test.ts
+++ b/packages/fullstack/e2e/react-router.test.ts
@@ -63,6 +63,10 @@ function defineTest(f: Fixture) {
         "Count-edit: 1",
       );
 
+      // test SSR is also updated
+      const res = await page.request.get(page.url());
+      expect(await res.text()).toContain("Count-edit");
+
       jsFile.reset();
       await expect(page.locator(".counter-card")).toContainText("Count: 1");
 

--- a/packages/fullstack/e2e/vue-router.test.ts
+++ b/packages/fullstack/e2e/vue-router.test.ts
@@ -73,6 +73,10 @@ function defineTest(f: Fixture) {
         "Count-edit: 1",
       );
 
+      // test SSR is also updated
+      const res = await page.request.get(page.url());
+      expect(await res.text()).toContain("Count-edit:");
+
       jsFile.reset();
       await expect(page.locator(".counter-card")).toContainText("Count: 1");
 

--- a/packages/fullstack/examples/island/src/framework/entry.server.tsx
+++ b/packages/fullstack/examples/island/src/framework/entry.server.tsx
@@ -3,10 +3,7 @@ import { renderToReadableStream } from "preact-render-to-string/stream";
 import Root from "../root";
 import NotFound from "../routes/404";
 import clientAssets from "./entry.client.tsx?assets=client";
-
-// TODO: server hmr broken when importing server entry assets `./entry.server.tsx?assets=ssr`
-import serverAssets from "../root?assets=ssr";
-// import serverAssets from "./entry.server.tsx?assets=ssr";
+import serverAssets from "./entry.server.tsx?assets=ssr";
 
 const routes = {
   "/": {

--- a/packages/fullstack/src/plugin.ts
+++ b/packages/fullstack/src/plugin.ts
@@ -132,11 +132,6 @@ export function assetsPlugin(pluginOpts?: FullstackPluginOptions): Plugin[] {
         const collected = await collectCss(environment, id, {
           eager: pluginOpts?.experimental?.devEagerTransform ?? true,
         });
-        for (const file of [cleanUrl(id), ...collected.visitedFiles]) {
-          if (fs.existsSync(file)) {
-            // ctx.addWatchFile(file);
-          }
-        }
         result.css = collected.hrefs.map((href, i) => ({
           href,
           "data-vite-dev-id": collected.ids[i],
@@ -548,7 +543,6 @@ async function collectCss(
 ) {
   const visited = new Set<string>();
   const cssIds = new Set<string>();
-  const visitedFiles = new Set<string>();
 
   async function recurse(id: string) {
     if (
@@ -561,9 +555,6 @@ async function collectCss(
     visited.add(id);
     const mod = environment.moduleGraph.getModuleById(id);
     if (!mod) return;
-    if (mod?.file) {
-      visitedFiles.add(mod.file);
-    }
     if (options.eager && !mod?.transformResult) {
       try {
         await environment.transformRequest(id);
@@ -592,7 +583,7 @@ async function collectCss(
   const hrefs = [...cssIds].map((id) =>
     normalizeViteImportAnalysisUrl(environment, id),
   );
-  return { ids: [...cssIds], hrefs, visitedFiles: [...visitedFiles] };
+  return { ids: [...cssIds], hrefs };
 }
 
 function invalidteModuleById(environment: DevEnvironment, id: string) {

--- a/packages/fullstack/src/plugin.ts
+++ b/packages/fullstack/src/plugin.ts
@@ -29,7 +29,6 @@ import {
   normalizeRelativePath,
 } from "./plugins/utils";
 import {
-  cleanUrl,
   evalValue,
   normalizeViteImportAnalysisUrl,
 } from "./plugins/vite-utils";


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/vite-plugins/issues/1233
- closes https://github.com/hi-ogawa/vite-plugins/issues/1237

~Not sure yet. It looks like there are other things going wrong with self importing `?assets=ssr`.~ (EDIT: Other thing is fixed by https://github.com/hi-ogawa/vite-plugins/pull/1240)