### PR TITLE
fix(fullstack): fix vite peerDependencies range

### DIFF
--- a/packages/fullstack/package.json
+++ b/packages/fullstack/package.json
@@ -28,6 +28,6 @@
     "strip-literal": "^3.1.0"
   },
   "peerDependencies": {
-    "vite": "^6.0.0 || ^7.0.0"
+    "vite": "^7.0.0"
   }
 }


### PR DESCRIPTION
`buildApp` plugin hook is only available since Vite 7.