### PR TITLE
feat(fullstack): add `clientBuildFallback` option

### DIFF
--- a/packages/fullstack/src/plugin.ts
+++ b/packages/fullstack/src/plugin.ts
@@ -55,6 +55,10 @@ type FullstackPluginOptions = {
      * @default true
      */
     devEagerTransform?: boolean;
+    /**
+     * @default true
+     */
+    clientBuildFallback?: boolean;
   };
 };
 
@@ -543,7 +547,9 @@ export default __assets_runtime.mergeAssets(${codes.join(", ")});
         order: "post",
         handler(name, config, _env) {
           if (name === "client") {
-            if (!config.build?.rollupOptions?.input) {
+            const clientBuildFallback =
+              pluginOpts?.experimental?.clientBuildFallback ?? true;
+            if (clientBuildFallback && !config.build?.rollupOptions?.input) {
               return {
                 build: {
                   rollupOptions: {


### PR DESCRIPTION
This is nice for dynamic client entry, but this can be disabled for Nitro for now to avoid a slightly annoying log when the app is server only https://github.com/nitrojs/nitro/pull/3662

```
◐ Building [Client]                                                                                  nitro 12:51:18 AM
vite v7.1.10 building for production...
✓ 1 modules transformed.
Generated an empty chunk: "__fallback".
✓ built in 23ms
```